### PR TITLE
fix: type safety and error handling improvements

### DIFF
--- a/packages/cli/src/commands/i18n/batch-translate.ts
+++ b/packages/cli/src/commands/i18n/batch-translate.ts
@@ -5,7 +5,7 @@
 
 import { readLocaleFile, writeLocaleFile } from "@espanol/locale-utils";
 import { validateFilePath, MAX_ARRAY_LENGTH } from "@espanol/security";
-import type { TranslationProvider, SpanishDialect, ProviderName } from "@espanol/types";
+import type { TranslationProvider, SpanishDialect, ProviderName, I18nEntry } from "@espanol/types";
 import { ALL_SPANISH_DIALECTS } from "@espanol/types";
 import { writeError, writeInfo } from "../../lib/output.js";
 import { join } from "node:path";
@@ -75,7 +75,7 @@ export async function executeBatchTranslate(
         const targetPath = join(validatedDir, `${targetDialect}.json`);
 
         // Check if target file exists
-        let targetEntries: any[] = [];
+        let targetEntries: I18nEntry[] = [];
         try {
           targetEntries = readLocaleFile(targetPath);
         } catch {
@@ -84,7 +84,7 @@ export async function executeBatchTranslate(
         }
 
         // Translate all base keys
-        const translatedEntries: any[] = [];
+        const translatedEntries: I18nEntry[] = [];
 
         for (const baseEntry of baseEntries) {
           try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { executeCheckFormality } from "./commands/i18n/check-formality.js";
 import { executeApplyGenderNeutral } from "./commands/i18n/apply-gender-neutral.js";
 import { getDefaultProviderRegistry } from "./lib/provider-factory.js";
 import { writeError, writeOutput } from "./lib/output.js";
+import { SecurityError, createSafeError } from "@espanol/security";
 import type { SpanishDialect } from "@espanol/types";
 import { parse, format } from "node:path";
 
@@ -362,6 +363,14 @@ i18nCommand
 
 // Parse arguments
 program.parseAsync(process.argv).catch((error) => {
-  writeError(error.message);
+  // Handle SecurityError with proper error classification
+  if (error instanceof SecurityError) {
+    const safeError = createSafeError(error);
+    writeError(`Security Error [${safeError.code}]: ${safeError.error}`);
+  } else {
+    // Handle other errors
+    const safeError = createSafeError(error);
+    writeError(safeError.error);
+  }
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Replace `any[]` with proper `I18nEntry` types in batch-translate.ts
- Improve error handling in CLI index.ts with proper error classification

## Issues
- [HIGH] Type safety violation with `any` types in batch-translate.ts
- [HIGH] Inconsistent error handling in CLI commands

## Test plan
- [x] TypeScript compilation
- [x] Test suite passes (171 tests in cli, 80 tests in mcp)

## Changes Made
- `packages/cli/src/commands/i18n/batch-translate.ts:8` - Import I18nEntry type
- `packages/cli/src/commands/i18n/batch-translate.ts:78,87` - Replace `any[]` with `I18nEntry[]`
- `packages/cli/src/index.ts:22` - Import SecurityError and createSafeError
- `packages/cli/src/index.ts:365-373` - Add error classification with SecurityError handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)