### PR TITLE
Harden DialectOS product contracts after adversarial audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
 
       - run: pnpm build
 
+      - name: Verify npm package contents
+        run: |
+          for pkg in packages/*; do
+            (cd "$pkg" && npm pack --dry-run) >/tmp/"$(basename "$pkg")"-pack.txt 2>&1
+            if grep -E 'src/__tests__|src/.*\.test\.ts|fixtures/' /tmp/"$(basename "$pkg")"-pack.txt; then
+              echo "Unexpected test/source fixture content in package $pkg"
+              cat /tmp/"$(basename "$pkg")"-pack.txt
+              exit 1
+            fi
+          done
+
       - run: pnpm test
 
   adversarial-ci:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage/
 
 # Translation checkpoints
 *.checkpoint.json
+
+# OMX runtime state
+.omx/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-603%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-604%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 603 tests passing
+pnpm test        # 604 tests passing
 ```
 
 ---
@@ -145,13 +145,13 @@ pnpm test        # 603 tests passing
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 81 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 226 |
-| [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 60 |
+| [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types | 41 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 603 tests across 7 packages**
+**Total: 604 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-595%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-602%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -32,11 +32,11 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 | Spanish dialect awareness | ❌ Generic "Spanish" | ⚠️ Limited variants | ✅ **25 regional variants** |
 | MCP native integration | ❌ | ❌ | ✅ **16 MCP tools** |
 | Markdown structure preservation | ❌ | ❌ | ✅ **Tables, code blocks, links intact** |
-| i18n locale file support | ❌ | ❌ | ✅ **JSON/YAML/PO diff & merge** |
+| i18n locale file support | ❌ | ❌ | ✅ **JSON locale diff & merge** |
 | Gender-neutral language | ❌ | ❌ | ✅ **elles / latine / -x** |
 | Formality checking (tú vs usted) | ❌ | ❌ | ✅ **Cross-dialect consistency** |
 | Adversarial quality gates | ❌ | ❌ | ✅ **Semantic drift + structure validation** |
-| Self-hosted / free tier | ❌ Paid | ⚠️ Limited free | ✅ **LibreTranslate + MyMemory fallback** |
+| Self-hosted / free tier | ❌ Paid | ⚠️ Limited free | ✅ **LibreTranslate + opt-in MyMemory fallback** |
 
 ---
 
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 595 tests passing
+pnpm test        # 602 tests passing
 ```
 
 ---
@@ -134,7 +134,7 @@ pnpm test        # 595 tests passing
 | `detect_dialect` | Detect dialect from sample text |
 | `translate_code_comment` | Translate comments, preserve code |
 | `translate_readme` | Full README translation pipeline |
-| `search_glossary` | Search 500+ term glossary |
+| `search_glossary` | Search built-in technical glossary |
 | `list_dialects` | List all 25 supported dialects |
 
 ---
@@ -143,15 +143,15 @@ pnpm test        # 595 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 80 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 223 |
-| [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 58 |
-| [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 65 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 81 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 225 |
+| [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 60 |
+| [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types | 41 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
-| [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 73 |
+| [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 595 tests across 7 packages**
+**Total: 602 tests across 7 packages**
 
 ---
 
@@ -219,7 +219,7 @@ See [`SECURITY.md`](SECURITY.md) for details.
 ┌──────────────────────▼──────────────────────────────────────┐
 │                @espanol/providers                            │
 │   ┌─────────┐  ┌─────────────────┐  ┌─────────────────┐    │
-│   │  DeepL  │  │ LibreTranslate  │  │   MyMemory      │    │
+│   │  DeepL  │  │ LibreTranslate  │  │ MyMemory opt-in │    │
 │   │ Primary │  │ Self-hosted     │  │ Free fallback   │    │
 │   └─────────┘  └─────────────────┘  └─────────────────┘    │
 │        │                │                    │              │

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-596%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-597%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 596 tests passing
+pnpm test        # 597 tests passing
 ```
 
 ---
@@ -143,7 +143,7 @@ pnpm test        # 596 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 82 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 83 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
@@ -151,7 +151,7 @@ pnpm test        # 596 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 596 tests across 7 packages**
+**Total: 597 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-598%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-599%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 598 tests passing
+pnpm test        # 599 tests passing
 ```
 
 ---
@@ -143,7 +143,7 @@ pnpm test        # 598 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 84 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
@@ -151,7 +151,7 @@ pnpm test        # 598 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 598 tests across 7 packages**
+**Total: 599 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-602%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-603%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 602 tests passing
+pnpm test        # 603 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 602 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 81 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 225 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 226 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 60 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types | 41 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 602 tests across 7 packages**
+**Total: 603 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-597%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-598%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 597 tests passing
+pnpm test        # 598 tests passing
 ```
 
 ---
@@ -143,7 +143,7 @@ pnpm test        # 597 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 83 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 84 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
@@ -151,7 +151,7 @@ pnpm test        # 597 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 597 tests across 7 packages**
+**Total: 598 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-595%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-596%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 595 tests passing
+pnpm test        # 596 tests passing
 ```
 
 ---
@@ -143,7 +143,7 @@ pnpm test        # 595 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 81 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 82 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
@@ -151,7 +151,7 @@ pnpm test        # 595 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 595 tests across 7 packages**
+**Total: 596 tests across 7 packages**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-604%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-595%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 604 tests passing
+pnpm test        # 595 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 604 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 81 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 226 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types | 41 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 604 tests across 7 packages**
+**Total: 595 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        596 tests passing · BSL 1.1 · GitHub Pages
+        597 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">596</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">597</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        602 tests passing · BSL 1.1 · GitHub Pages
+        603 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">602</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">603</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        603 tests passing · BSL 1.1 · GitHub Pages
+        604 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">603</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">604</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        597 tests passing · BSL 1.1 · GitHub Pages
+        598 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">597</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">598</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        604 tests passing · BSL 1.1 · GitHub Pages
+        595 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">604</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">595</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        595 tests passing · BSL 1.1 · GitHub Pages
+        602 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">595</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">602</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        598 tests passing · BSL 1.1 · GitHub Pages
+        599 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">598</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">599</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        595 tests passing · BSL 1.1 · GitHub Pages
+        596 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">595</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">596</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/plans/2026-04-21-product-remediation-hardening.md
+++ b/docs/plans/2026-04-21-product-remediation-hardening.md
@@ -1,0 +1,126 @@
+# Product Remediation Hardening Implementation Plan
+
+**Goal:** Convert the audit findings into a coherent product-hardening slice that removes false-green translation behavior, unifies CLI/MCP contracts, makes partial failures explicit, and makes the package/docs surfaces honest.
+
+**Architecture:** Introduce shared domain helpers for providers, dialects, glossary, adaptations, quality gating, and table reconstruction rather than continuing duplicated CLI/MCP logic. Keep the changes dependency-free and backwards-compatible at the public CLI/MCP boundary while making unsupported provider/dialect combinations explicit. Tests lock each audited failure before production changes.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest, Commander, MCP SDK, existing @espanol/* packages.
+
+---
+
+## Scope and priorities
+
+### P0 correctness gates
+- Canonicalize provider names (`libre` alias to `libretranslate`, remove fake `deepl-free` behavior unless registered).
+- Enforce provider capability validation before provider calls.
+- Normalize dialect target handling: external providers receive language `es`; dialect stays in options/context unless provider declares native dialect support.
+- Make semantic quality thresholds hard gates for strict/balanced policy.
+- Reconstruct markdown table cells with translated content instead of discarding translations.
+
+### P1 MCP parity
+- Reuse shared CLI/domain data for MCP dialect list, detection, glossary, and manage-variants behavior.
+- Add MCP schema validation for dialect/provider inputs.
+- Make per-key translation failures explicit in MCP responses.
+- Wire MCP config into server startup.
+
+### P2 product hygiene
+- Add package `files` allowlists so npm tarballs ship runtime artifacts only.
+- Fix version/documentation claims that currently overstate shipped behavior.
+- Add CI pack checks and focused regression tests.
+
+---
+
+## Task 1: Provider contract tests
+
+**Files:**
+- Modify: `packages/cli/src/__tests__/translate.test.ts`
+- Modify: `packages/cli/src/__tests__/translate-api-docs.test.ts`
+- Modify: `packages/providers/src/__tests__/providers.test.ts`
+
+**Steps:**
+1. Add failing tests proving `--provider libre` resolves to the registered LibreTranslate provider.
+2. Add failing tests proving `deepl-free` is not advertised unless a provider is registered.
+3. Add failing tests proving providers with `dialectHandling: none` receive target language `es`, not `es-MX`.
+4. Run focused tests and verify failures are the expected contract failures.
+
+## Task 2: Provider contract implementation
+
+**Files:**
+- Modify: `packages/providers/src/registry.ts`
+- Modify: `packages/cli/src/lib/resilient-translation.ts`
+- Modify: `packages/cli/src/commands/translate.ts`
+- Modify: `packages/cli/src/commands/translate-readme.ts`
+- Modify: `packages/cli/src/commands/translate-api-docs.ts`
+- Modify: `packages/cli/src/index.ts`
+- Modify: `packages/providers/src/providers/libre-translate.ts`
+
+**Steps:**
+1. Add provider alias canonicalization in registry.
+2. Add `prepareProviderRequest()` helper that validates capabilities and downgrades target language to `es` for non-native dialect providers.
+3. Thread provider-used/fallback metadata out of fallback translation.
+4. Remove or alias stale CLI provider labels.
+
+## Task 3: Markdown table reconstruction tests and implementation
+
+**Files:**
+- Modify: `packages/markdown-parser/src/__tests__/parser.test.ts`
+- Modify: `packages/markdown-parser/src/index.ts`
+
+**Steps:**
+1. Add a failing test that translated table cell text appears in reconstructed markdown while pipes/alignment remain.
+2. Implement cell-aware reconstruction for simple GitHub-flavored markdown tables.
+3. Add edge tests for header/body cell count mismatch falling back safely.
+
+## Task 4: Quality gate tests and implementation
+
+**Files:**
+- Modify: `packages/cli/src/__tests__/translation-policy.test.ts`
+- Modify: `packages/cli/src/__tests__/translate-readme.test.ts`
+- Modify: `packages/cli/src/lib/translation-policy.ts`
+- Modify: `packages/cli/src/commands/translate-readme.ts`
+- Modify: `packages/cli/src/commands/translate-api-docs.ts`
+
+**Steps:**
+1. Add tests proving low semantic similarity fails in strict/balanced policy.
+2. Keep permissive mode warn-only.
+3. Implement semantic threshold enforcement after quality calculation and before output write.
+
+## Task 5: MCP parity and explicit failures
+
+**Files:**
+- Modify: `packages/mcp/src/tools/translator.ts`
+- Modify: `packages/mcp/src/tools/i18n.ts`
+- Modify: `packages/mcp/src/tools/docs.ts`
+- Modify: `packages/mcp/src/index.ts`
+- Modify: MCP tests under `packages/mcp/src/__tests__`.
+
+**Steps:**
+1. Replace duplicated dialect/glossary/adaptation logic with imports from CLI/domain modules where practical.
+2. Validate schemas using shared zod schemas.
+3. Return errors/skipped counts for partial translation failures; set `isError` when no requested work succeeds.
+4. Load config at MCP startup and inject rate limiter.
+
+## Task 6: Packaging/docs/CI hygiene
+
+**Files:**
+- Modify: package manifests in `packages/*/package.json`.
+- Modify: `.github/workflows/ci.yml`.
+- Modify: `README.md`, `ROADMAP.md`, `CHANGELOG.md` as needed.
+
+**Steps:**
+1. Add `files` allowlists to publish only dist/runtime docs.
+2. Add pack dry-run checks to CI.
+3. Correct README claims to match actual glossary/support surfaces, or update code to make claims true.
+
+## Verification
+
+Run in order:
+1. `pnpm -r exec tsc --noEmit`
+2. `pnpm test`
+3. `pnpm audit --audit-level low`
+4. `npm pack --dry-run` for representative packages and confirm tests/source are excluded.
+5. `git status --short`
+
+## Commit strategy
+
+Use one Lore-style commit for the coherent hardening bundle unless the diff becomes too large; then split into `provider-contracts`, `markdown-quality`, `mcp-parity`, and `packaging-docs` commits.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 595 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 596 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-595 tests. 7 packages. pnpm monorepo. TypeScript.
+596 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 595 tests
+**Tech:** TypeScript, pnpm monorepo, 596 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 595 tests passing.
+Source available, BSL 1.1 licensed, 596 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 595 tests
+**Tech stack:** TypeScript, pnpm monorepo, 596 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 597 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 598 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-597 tests. 7 packages. pnpm monorepo. TypeScript.
+598 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 597 tests
+**Tech:** TypeScript, pnpm monorepo, 598 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 597 tests passing.
+Source available, BSL 1.1 licensed, 598 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 597 tests
+**Tech stack:** TypeScript, pnpm monorepo, 598 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 596 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 597 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-596 tests. 7 packages. pnpm monorepo. TypeScript.
+597 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 596 tests
+**Tech:** TypeScript, pnpm monorepo, 597 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 596 tests passing.
+Source available, BSL 1.1 licensed, 597 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 596 tests
+**Tech stack:** TypeScript, pnpm monorepo, 597 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 603 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 604 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-603 tests. 7 packages. pnpm monorepo. TypeScript.
+604 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 603 tests
+**Tech:** TypeScript, pnpm monorepo, 604 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 603 tests passing.
+Source available, BSL 1.1 licensed, 604 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 603 tests
+**Tech stack:** TypeScript, pnpm monorepo, 604 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 604 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 595 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-604 tests. 7 packages. pnpm monorepo. TypeScript.
+595 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 604 tests
+**Tech:** TypeScript, pnpm monorepo, 595 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 604 tests passing.
+Source available, BSL 1.1 licensed, 595 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 604 tests
+**Tech stack:** TypeScript, pnpm monorepo, 595 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 598 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 599 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-598 tests. 7 packages. pnpm monorepo. TypeScript.
+599 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 598 tests
+**Tech:** TypeScript, pnpm monorepo, 599 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 598 tests passing.
+Source available, BSL 1.1 licensed, 599 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 598 tests
+**Tech stack:** TypeScript, pnpm monorepo, 599 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 595 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 603 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-595 tests. 7 packages. pnpm monorepo. TypeScript.
+603 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 595 tests
+**Tech:** TypeScript, pnpm monorepo, 603 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 595 tests passing.
+Source available, BSL 1.1 licensed, 603 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 595 tests
+**Tech stack:** TypeScript, pnpm monorepo, 603 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,10 @@
     "espanol": "dist/index.js"
   },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -31,5 +34,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/cli/src/__tests__/resilient-translation.test.ts
+++ b/packages/cli/src/__tests__/resilient-translation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TranslationProvider } from "@espanol/types";
+import type { ProviderRegistry } from "@espanol/providers";
+import { translateWithFallback } from "../lib/resilient-translation.js";
+
+class TestRegistry implements Partial<ProviderRegistry> {
+  providers: Record<string, TranslationProvider>;
+  failures: string[] = [];
+  successes: string[] = [];
+
+  constructor(providers: Record<string, TranslationProvider>) {
+    this.providers = providers;
+  }
+
+  get(name: string): TranslationProvider {
+    const provider = this.providers[name];
+    if (!provider) throw new Error("Provider not available");
+    return provider;
+  }
+
+  listProviders(): string[] {
+    return Object.keys(this.providers);
+  }
+
+  isAvailable(name: string): boolean {
+    return name in this.providers;
+  }
+
+  recordSuccess(name: string): void {
+    this.successes.push(name);
+  }
+
+  recordFailure(name: string): void {
+    this.failures.push(name);
+  }
+}
+
+describe("translateWithFallback", () => {
+  it("should report the provider used and fallback count", async () => {
+    const failing: TranslationProvider = {
+      name: "primary",
+      translate: vi.fn().mockRejectedValue(new Error("down")),
+    };
+    const succeeding: TranslationProvider = {
+      name: "secondary",
+      translate: vi.fn().mockResolvedValue({ translatedText: "Hola" }),
+    };
+    const registry = new TestRegistry({
+      primary: failing,
+      secondary: succeeding,
+    }) as ProviderRegistry;
+
+    const result = await translateWithFallback(
+      registry,
+      "primary",
+      "Hello",
+      "en",
+      "es",
+      {},
+      { delayMs: 0 }
+    );
+
+    expect(result.translatedText).toBe("Hola");
+    expect(result.providerUsed).toBe("secondary");
+    expect(result.fallbackCount).toBe(1);
+    expect(result.retryCount).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/translate.test.ts
+++ b/packages/cli/src/__tests__/translate.test.ts
@@ -1,133 +1,124 @@
 /**
  * Tests for the translate command
- * TDD: RED → GREEN → REFACTOR
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Readable } from "node:stream";
-import { ProviderRegistry } from "@espanol/providers";
-import type { TranslationProvider } from "@espanol/types";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import type { TranslationProvider, TranslateOptions } from "@espanol/types";
+import { executeTranslate } from "../commands/translate.js";
 
-// Mock the workspace packages
-vi.mock("@espanol/providers", () => ({
-  ProviderRegistry: vi.fn(),
-  DeepLProvider: vi.fn(),
-  LibreTranslateProvider: vi.fn(),
-  MyMemoryProvider: vi.fn(),
-}));
+function makeProvider(
+  translateImpl: (text: string, sourceLang: string, targetLang: string, options?: TranslateOptions) => Promise<string> | string =
+    async () => "Hola mundo"
+): TranslationProvider {
+  return {
+    name: "mymemory",
+    translate: vi.fn(async (text, sourceLang, targetLang, options) => ({
+      translatedText: await translateImpl(text, sourceLang, targetLang, options),
+      detectedLanguage: "en",
+      provider: "mymemory" as const,
+    })),
+  };
+}
 
 describe("translate command", () => {
-  let mockProvider: TranslationProvider;
-  let mockRegistry: ProviderRegistry;
+  const testDir = "/tmp/espanol-translate-test";
+  const inputFile = path.join(testDir, "input.txt");
+  const outputFile = path.join(testDir, "output.txt");
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    // Mock provider
-    mockProvider = {
-      name: "mymemory",
-      translate: vi.fn().mockResolvedValue({
-        translatedText: "Hola mundo",
-        detectedLanguage: "en",
-        provider: "mymemory" as const,
-      }),
-    };
-
-    // Mock registry
-    mockRegistry = {
-      get: vi.fn().mockReturnValue(mockProvider),
-      getAuto: vi.fn().mockReturnValue(mockProvider),
-      listProviders: vi.fn().mockReturnValue(["mymemory"]),
-      register: vi.fn(),
-    } as unknown as ProviderRegistry;
-
-    vi.mocked(ProviderRegistry).mockImplementation(() => mockRegistry);
-
-    // Mock console.log and console.error
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
-    // Mock process.exit
-    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`Process exited with code ${code}`);
-    }) as any);
+  beforeEach(async () => {
+    await fs.mkdir(testDir, { recursive: true });
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  afterEach(async () => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    await fs.rm(testDir, { recursive: true, force: true });
   });
 
-  describe("CLI argument parsing", () => {
-    it("should parse dialect option", async () => {
-      // This test will verify the dialect argument is parsed correctly
-      // Implementation will be in the actual command
-      expect(true).toBe(true); // Placeholder
-    });
+  it("should translate command-line text with default options", async () => {
+    const provider = makeProvider();
+    const getProvider = vi.fn().mockReturnValue(provider);
 
-    it("should parse provider option", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await executeTranslate("Hello world", {}, getProvider);
 
-    it("should parse formality options (formal/informal/auto)", async () => {
-      expect(true).toBe(true); // Placeholder
+    expect(getProvider).toHaveBeenCalledWith(undefined);
+    expect(provider.translate).toHaveBeenCalledWith("Hello world", "auto", "es", {
+      formality: "auto",
+      dialect: "es-ES",
     });
-
-    it("should parse input-file option", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
-
-    it("should parse output option", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    expect(stdoutSpy).toHaveBeenCalledWith("Hola mundo");
   });
 
-  describe("input reading", () => {
-    it("should read text from command line argument", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+  it("should pass provider, dialect, and formal options", async () => {
+    const provider = makeProvider((text) => `[formal] ${text}`);
+    const getProvider = vi.fn().mockReturnValue(provider);
 
-    it("should read text from file when --input-file is specified", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await executeTranslate("Hello", {
+      provider: "libre",
+      dialect: "es-MX",
+      formal: true,
+    }, getProvider);
 
-    it("should read text from stdin when piped", async () => {
-      expect(true).toBe(true); // Placeholder
+    expect(getProvider).toHaveBeenCalledWith("libre");
+    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", {
+      formality: "formal",
+      dialect: "es-MX",
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith("[formal] Hello");
+  });
+
+  it("should prefer informal when informal option is set", async () => {
+    const provider = makeProvider((text) => `[informal] ${text}`);
+    const getProvider = vi.fn().mockReturnValue(provider);
+
+    await executeTranslate("Hello", { informal: true }, getProvider);
+
+    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", {
+      formality: "informal",
+      dialect: "es-ES",
     });
   });
 
-  describe("provider selection", () => {
-    it("should use auto provider when none specified", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+  it("should read input from file and write output to file", async () => {
+    await fs.writeFile(inputFile, "File input");
+    const provider = makeProvider((text) => `translated: ${text}`);
 
-    it("should use specific provider when specified", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await executeTranslate(undefined, { inputFile, output: outputFile }, () => provider);
 
-    it("should throw error for invalid provider", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await expect(fs.readFile(outputFile, "utf-8")).resolves.toBe("translated: File input");
+    expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
-  describe("output handling", () => {
-    it("should output to stdout by default", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+  it("should reject invalid dialect codes", async () => {
+    const provider = makeProvider();
 
-    it("should output to file when --output is specified", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await expect(
+      executeTranslate("Hello", { dialect: "es-XX" as never }, () => provider)
+    ).rejects.toThrow("Invalid dialect");
+    expect(provider.translate).not.toHaveBeenCalled();
   });
 
-  describe("error handling", () => {
-    it("should throw error for invalid dialect", async () => {
-      expect(true).toBe(true); // Placeholder
+  it("should reject unsupported provider names", async () => {
+    const provider = makeProvider();
+
+    await expect(
+      executeTranslate("Hello", { provider: "deepl-free" }, () => provider)
+    ).rejects.toThrow("Invalid provider");
+    expect(provider.translate).not.toHaveBeenCalled();
+  });
+
+  it("should rethrow provider translation errors", async () => {
+    const provider = makeProvider(async () => {
+      throw new Error("provider down");
     });
 
-    it("should throw error when provider not found", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
-
-    it("should handle translation errors gracefully", async () => {
-      expect(true).toBe(true); // Placeholder
-    });
+    await expect(executeTranslate("Hello", {}, () => provider)).rejects.toThrow("provider down");
+    expect(stderrSpy).toHaveBeenCalledWith("Error: provider down\n");
   });
 });

--- a/packages/cli/src/__tests__/translation-policy.test.ts
+++ b/packages/cli/src/__tests__/translation-policy.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from "vitest";
 import {
   resolvePolicy,
+  shouldFailSemanticQuality,
   listPolicyProfiles,
   type PolicyProfile,
 } from "../lib/translation-policy.js";
@@ -82,6 +83,17 @@ describe("translation policy", () => {
       expect(profiles[0].description).toContain("production");
       expect(profiles[1].description).toContain("CI");
       expect(profiles[2].description).toContain("drafts");
+    });
+  });
+
+  describe("semantic quality gates", () => {
+    it("should fail strict and balanced profiles on low semantic similarity", () => {
+      expect(shouldFailSemanticQuality(resolvePolicy("strict"), 0.59)).toBe(true);
+      expect(shouldFailSemanticQuality(resolvePolicy("balanced"), 0.39)).toBe(true);
+    });
+
+    it("should not fail permissive profile on low semantic similarity", () => {
+      expect(shouldFailSemanticQuality(resolvePolicy("permissive"), 0.01)).toBe(false);
     });
   });
 });

--- a/packages/cli/src/commands/translate-api-docs.ts
+++ b/packages/cli/src/commands/translate-api-docs.ts
@@ -34,6 +34,12 @@ import {
   type AdaptivePacingState,
 } from "../lib/resilient-translation.js";
 import { calculateQualityScore } from "../lib/quality-score.js";
+import {
+  formatSemanticQualityError,
+  resolvePolicy,
+  shouldFailSemanticQuality,
+  type PolicyProfile,
+} from "../lib/translation-policy.js";
 
 // ============================================================================
 // extract-translatable Command
@@ -114,6 +120,8 @@ export interface TranslateApiDocsOptions {
   resume?: boolean;
   /** Behavior when one or more sections fail translation */
   failurePolicy?: "strict" | "allow-partial";
+  /** Operator policy profile */
+  policy?: PolicyProfile;
 }
 
 /**
@@ -354,6 +362,18 @@ export async function executeTranslateApiDocs(
       glossary?.mappings || {},
       validation.valid
     );
+    const policy = resolvePolicy(options?.policy || "balanced", {
+      failurePolicy: options?.failurePolicy,
+      validateStructure: options?.validateStructure,
+      structureMode: options?.structureMode,
+      glossaryMode,
+      protectIdentities,
+      resume,
+    });
+    const semanticGateApplies = content.trim().length >= 120 || translated.trim().length >= 120;
+    if (semanticGateApplies && shouldFailSemanticQuality(policy, quality.semanticSimilarity)) {
+      throw new Error(formatSemanticQualityError(policy, quality.semanticSimilarity));
+    }
     console.error(
       `[quality] score=${quality.score} token=${(quality.tokenIntegrity * 100).toFixed(
         0

--- a/packages/cli/src/commands/translate-readme.ts
+++ b/packages/cli/src/commands/translate-readme.ts
@@ -173,9 +173,9 @@ async function translateReadme(
   getRegistry: () => ProviderRegistry
 ): Promise<TranslateReadmeResult> {
   const startTime = Date.now();
+  let providerUsed: string | undefined;
   let fallbackCount = 0;
   let retryCount = 0;
-  let providerUsed: string | undefined;
 
   // 1. Validate input path
   const validatedPath = validateMarkdownPath(input);
@@ -282,6 +282,9 @@ async function translateReadme(
           restoreProtectedTokens(result.translatedText, protectedChunk.replacements),
           glossaryChunk.replacements
         );
+        providerUsed = result.providerUsed;
+        fallbackCount += result.fallbackCount;
+        retryCount += result.retryCount;
 
         // Create translated section
         translatedSections.push({

--- a/packages/cli/src/commands/translate-readme.ts
+++ b/packages/cli/src/commands/translate-readme.ts
@@ -44,7 +44,12 @@ import {
   type AdaptivePacingState,
 } from "../lib/resilient-translation.js";
 import { calculateQualityScore } from "../lib/quality-score.js";
-import { resolvePolicy, type PolicyProfile } from "../lib/translation-policy.js";
+import {
+  formatSemanticQualityError,
+  resolvePolicy,
+  shouldFailSemanticQuality,
+  type PolicyProfile,
+} from "../lib/translation-policy.js";
 import { TelemetryCollector, globalTelemetry } from "../lib/telemetry.js";
 
 interface TranslateReadmeOptions {
@@ -337,6 +342,18 @@ async function translateReadme(
     glossary?.mappings || {},
     validation.valid
   );
+  const policy = resolvePolicy(options.policy || "balanced", {
+    failurePolicy: options.failurePolicy,
+    validateStructure: options.validateStructure,
+    structureMode: options.structureMode,
+    glossaryMode,
+    protectIdentities: options.protectIdentities,
+    resume: options.resume,
+  });
+  const semanticGateApplies = content.trim().length >= 120 || translated.trim().length >= 120;
+  if (semanticGateApplies && shouldFailSemanticQuality(policy, quality.semanticSimilarity)) {
+    throw new Error(formatSemanticQualityError(policy, quality.semanticSimilarity));
+  }
   writeInfo(
     `[quality] score=${quality.score} token=${(quality.tokenIntegrity * 100).toFixed(
       0

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -112,7 +112,7 @@ function validateDialect(dialect: string): SpanishDialect {
 function validateProvider(provider: string | undefined): string | undefined {
   if (!provider) return undefined;
 
-  const validProviders: ProviderName[] = ["deepl", "deepl-free", "libre", "mymemory"];
+  const validProviders: ProviderName[] = ["deepl", "libre", "mymemory"];
   if (provider !== "auto" && !validProviders.includes(provider as ProviderName)) {
     throw new Error(
       `Invalid provider: ${provider}. Valid providers are: auto, ${validProviders.join(", ")}`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -140,6 +140,7 @@ program
         checkpointFile: options.checkpointFile as string | undefined,
         resume: profile.resume,
         failurePolicy: profile.failurePolicy,
+        policy: profile.profile,
       };
 
       await executeTranslateApiDocs(input, mergedOptions.dialect!, mergedOptions, () => registry);

--- a/packages/cli/src/lib/resilient-translation.ts
+++ b/packages/cli/src/lib/resilient-translation.ts
@@ -96,7 +96,7 @@ function buildProviderChain(
   const priority =
     envPriority.length > 0
       ? envPriority
-      : ["libre", "deepl", "deepl-free", "mymemory"];
+      : ["libre", "deepl", "mymemory"];
   const available = registry.listProviders().filter((name) => registry.isAvailable(name));
   const ordered = priority.filter((name) => available.includes(name));
   const remainder = available.filter((name) => !ordered.includes(name));

--- a/packages/cli/src/lib/resilient-translation.ts
+++ b/packages/cli/src/lib/resilient-translation.ts
@@ -42,10 +42,28 @@ export async function translateWithFallback(
     await waitAdaptive(pacing);
     try {
       const provider = registry.get(name);
-      const result = await provider.translate(text, sourceLang, targetLang, options);
+      const maybeRegistry = registry as ProviderRegistry & {
+        prepareRequest?: ProviderRegistry["prepareRequest"];
+      };
+      const prepared = maybeRegistry.prepareRequest?.(
+        name,
+        text,
+        sourceLang,
+        targetLang,
+        options
+      ) ?? { sourceLang, targetLang, options };
+      const result = await provider.translate(
+        text,
+        prepared.sourceLang,
+        prepared.targetLang,
+        prepared.options
+      );
       pacing.delayMs = nextDelay(pacing.delayMs, false);
       registry.recordSuccess(name);
-      return result;
+      return {
+        ...result,
+        provider: result.provider ?? (provider.name as TranslationResult["provider"]),
+      };
     } catch (error) {
       const throttled = isThrottleError(error);
       pacing.delayMs = nextDelay(pacing.delayMs, throttled);

--- a/packages/cli/src/lib/resilient-translation.ts
+++ b/packages/cli/src/lib/resilient-translation.ts
@@ -5,6 +5,12 @@ export interface AdaptivePacingState {
   delayMs: number;
 }
 
+export interface ResilientTranslationResult extends TranslationResult {
+  providerUsed: string;
+  fallbackCount: number;
+  retryCount: number;
+}
+
 const THROTTLE_PATTERN = /(too many requests|rate limit|429)/i;
 
 export function isThrottleError(error: unknown): boolean {
@@ -34,11 +40,11 @@ export async function translateWithFallback(
   targetLang: string,
   options: TranslateOptions,
   pacing: AdaptivePacingState
-): Promise<TranslationResult> {
+): Promise<ResilientTranslationResult> {
   const chain = buildProviderChain(registry, preferredProvider);
   const errors: string[] = [];
 
-  for (const name of chain) {
+  for (const [attemptIndex, name] of chain.entries()) {
     await waitAdaptive(pacing);
     try {
       const provider = registry.get(name);
@@ -63,6 +69,9 @@ export async function translateWithFallback(
       return {
         ...result,
         provider: result.provider ?? (provider.name as TranslationResult["provider"]),
+        providerUsed: provider.name,
+        fallbackCount: attemptIndex,
+        retryCount: 0,
       };
     } catch (error) {
       const throttled = isThrottleError(error);

--- a/packages/cli/src/lib/translation-policy.ts
+++ b/packages/cli/src/lib/translation-policy.ts
@@ -25,6 +25,8 @@ export interface TranslationPolicy {
   protectIdentities: boolean;
   /** Whether to resume from checkpoints */
   resume: boolean;
+  /** Minimum semantic similarity required before output is considered safe */
+  semanticThreshold: number | null;
 }
 
 const POLICY_PRESETS: Record<PolicyProfile, TranslationPolicy> = {
@@ -36,6 +38,7 @@ const POLICY_PRESETS: Record<PolicyProfile, TranslationPolicy> = {
     glossaryMode: "strict",
     protectIdentities: true,
     resume: true,
+    semanticThreshold: 0.6,
   },
   balanced: {
     profile: "balanced",
@@ -45,6 +48,7 @@ const POLICY_PRESETS: Record<PolicyProfile, TranslationPolicy> = {
     glossaryMode: "strict",
     protectIdentities: true,
     resume: true,
+    semanticThreshold: 0.4,
   },
   permissive: {
     profile: "permissive",
@@ -54,6 +58,7 @@ const POLICY_PRESETS: Record<PolicyProfile, TranslationPolicy> = {
     glossaryMode: "off",
     protectIdentities: false,
     resume: false,
+    semanticThreshold: null,
   },
 };
 
@@ -100,4 +105,21 @@ export function listPolicyProfiles(): { name: PolicyProfile; description: string
         "Maximize throughput: skip validation, allow partial failures, disable glossary and identity protection. Suitable for drafts.",
     },
   ];
+}
+
+export function shouldFailSemanticQuality(
+  policy: TranslationPolicy,
+  semanticSimilarity: number
+): boolean {
+  return policy.semanticThreshold !== null && semanticSimilarity < policy.semanticThreshold;
+}
+
+export function formatSemanticQualityError(
+  policy: TranslationPolicy,
+  semanticSimilarity: number
+): string {
+  const threshold = policy.semanticThreshold ?? 0;
+  return `Semantic quality gate failed for ${policy.profile} policy: ${(semanticSimilarity * 100).toFixed(
+    0
+  )}% is below required ${(threshold * 100).toFixed(0)}%`;
 }

--- a/packages/locale-utils/package.json
+++ b/packages/locale-utils/package.json
@@ -6,7 +6,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -24,5 +27,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -29,5 +29,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/markdown-parser/src/__tests__/parser.test.ts
+++ b/packages/markdown-parser/src/__tests__/parser.test.ts
@@ -737,6 +737,33 @@ describe("reconstructMarkdown", () => {
     expect(result).toContain("|");
   });
 
+  it("should reconstruct translated table cells while preserving separators", () => {
+    const sections: MarkdownSection[] = [
+      {
+        type: "table",
+        content: "Name Description Create item Delete item",
+        raw: "| Name | Description |\n| --- | --- |\n| Create | Create item |\n| Delete | Delete item |",
+        translatable: true,
+      },
+    ];
+    const translatedSections: MarkdownSection[] = [
+      {
+        type: "table",
+        content: "Nombre Descripción Crear Crear elemento Eliminar Eliminar elemento",
+        raw: sections[0].raw,
+        translatable: true,
+      },
+    ];
+
+    const result = reconstructMarkdown(sections, translatedSections);
+
+    expect(result).toContain("| Nombre | Descripción |");
+    expect(result).toContain("| Crear | Crear elemento |");
+    expect(result).toContain("| Eliminar | Eliminar elemento |");
+    expect(result).toContain("| --- | --- |");
+    expect(result).not.toContain("| Name | Description |");
+  });
+
   it("should preserve blockquote markers", () => {
     const sections: MarkdownSection[] = [
       {

--- a/packages/markdown-parser/src/index.ts
+++ b/packages/markdown-parser/src/index.ts
@@ -474,10 +474,7 @@ function reconstructSection(
     }
 
     case "table": {
-      // Tables: try to preserve structure
-      // This is a simplified version - a full implementation would
-      // parse the table structure and replace cell content
-      return original.raw; // Preserve original structure for now
+      return reconstructTable(original, translated);
     }
 
     case "list": {
@@ -532,6 +529,89 @@ function reconstructSection(
       return translated.content;
     }
   }
+}
+
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim();
+  const withoutOuter = trimmed.startsWith("|") && trimmed.endsWith("|")
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  return withoutOuter.split("|").map((cell) => cell.trim());
+}
+
+function isAlignmentRow(line: string): boolean {
+  const cells = splitTableRow(line);
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+}
+
+function formatTableRow(cells: string[], hadOuterPipes: boolean): string {
+  const body = cells.map((cell) => ` ${cell.trim()} `).join("|");
+  return hadOuterPipes ? `|${body}|` : body;
+}
+
+function tableContentCells(content: string): string[] | null {
+  const lines = content.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (lines.length > 0 && lines.every((line) => line.includes("|"))) {
+    return lines
+      .filter((line) => !isAlignmentRow(line))
+      .flatMap(splitTableRow)
+      .filter((cell) => cell.length > 0);
+  }
+  return null;
+}
+
+function translatedCellsByOriginalShape(originalCells: string[], translatedContent: string): string[] {
+  const tableCells = tableContentCells(translatedContent);
+  if (tableCells && tableCells.length === originalCells.length) {
+    return tableCells;
+  }
+
+  const translatedWords = translatedContent.split(/\s+/).filter(Boolean);
+  if (translatedWords.length === 0) {
+    return [];
+  }
+
+  const cells: string[] = [];
+  let wordIndex = 0;
+  for (const originalCell of originalCells) {
+    const wordCount = Math.max(originalCell.split(/\s+/).filter(Boolean).length, 1);
+    const next = translatedWords.slice(wordIndex, wordIndex + wordCount);
+    if (next.length < wordCount) {
+      return [];
+    }
+    cells.push(next.join(" "));
+    wordIndex += wordCount;
+  }
+
+  if (wordIndex !== translatedWords.length) {
+    return [];
+  }
+
+  return cells;
+}
+
+function reconstructTable(original: MarkdownSection, translated: MarkdownSection): string {
+  const lines = original.raw.split("\n");
+  const dataRows = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.includes("|") && !isAlignmentRow(line));
+  const originalCells = dataRows.flatMap(({ line }) => splitTableRow(line));
+  const translatedCells = translatedCellsByOriginalShape(originalCells, translated.content);
+
+  if (originalCells.length === 0 || translatedCells.length !== originalCells.length) {
+    return original.raw;
+  }
+
+  let translatedIndex = 0;
+  const rebuilt = [...lines];
+  for (const { line, index } of dataRows) {
+    const cellCount = splitTableRow(line).length;
+    const rowCells = translatedCells.slice(translatedIndex, translatedIndex + cellCount);
+    translatedIndex += cellCount;
+    rebuilt[index] = formatTableRow(rowCells, line.trim().startsWith("|") && line.trim().endsWith("|"));
+  }
+
+  return rebuilt.join("\n");
 }
 
 // ============================================================================

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -42,7 +42,7 @@ Add to your MCP client configuration:
 - `detect_dialect` — Detect dialect from text
 - `translate_code_comment` — Translate comments, preserve code
 - `translate_readme` — Full README translation pipeline
-- `search_glossary` — Search 500+ term glossary
+- `search_glossary` — Search built-in technical glossary
 - `list_dialects` — List all 25 supported dialects
 
 ## Security

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,7 +8,10 @@
     "espanol-mcp": "dist/index.js"
   },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -30,5 +33,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -42,6 +42,14 @@ describe("Configuration System", () => {
     expect(config.rateLimit.windowMs).toBe(30000);
   });
 
+
+  it("should fail fast on invalid numeric env vars", async () => {
+    vi.stubEnv("ESPANOL_RATE_LIMIT", "many,soon");
+    const { loadConfig } = await import("../lib/config.js");
+
+    expect(() => loadConfig()).toThrow(/Invalid MCP config env ESPANOL_RATE_LIMIT/);
+  });
+
   it("should override max file size from env var", async () => {
     vi.stubEnv("ESPANOL_MAX_FILE_SIZE", "1048576");
     const { loadConfig } = await import("../lib/config.js");

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -80,6 +80,14 @@ describe("Configuration System", () => {
     expect(config.security.allowedDirs).toEqual(["/locales", "/data"]);
   });
 
+
+  it("should fail fast on invalid log level env var", async () => {
+    vi.stubEnv("ESPANOL_LOG_LEVEL", "verbose");
+    const { loadConfig } = await import("../lib/config.js");
+
+    expect(() => loadConfig()).toThrow(/Invalid MCP config env ESPANOL_LOG_LEVEL/);
+  });
+
   it("should parse config file", async () => {
     mkdirSync(tempDir, { recursive: true });
     const configPath = join(tempDir, "config.json");

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -74,15 +74,14 @@ describe("Configuration System", () => {
     expect(config.logging.level).toBe("debug");
   });
 
-  it("should ignore invalid config file and use defaults", async () => {
+  it("should fail fast on invalid config file", async () => {
     mkdirSync(tempDir, { recursive: true });
     const configPath = join(tempDir, "bad.json");
     writeFileSync(configPath, "not valid json{{{");
 
     const { loadConfig } = await import("../lib/config.js");
-    const config = loadConfig(configPath);
 
-    expect(config.rateLimit.maxRequests).toBe(60);
+    expect(() => loadConfig(configPath)).toThrow(/Invalid MCP config/);
   });
 
   it("should get config path from CLI args", async () => {

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -43,6 +43,20 @@ describe("Configuration System", () => {
   });
 
 
+
+  it("should not leak env overrides into later default config loads", async () => {
+    const { loadConfig } = await import("../lib/config.js");
+
+    vi.stubEnv("ESPANOL_RATE_LIMIT", "120,30000");
+    expect(loadConfig().rateLimit.maxRequests).toBe(120);
+
+    vi.unstubAllEnvs();
+    delete process.env.ESPANOL_RATE_LIMIT;
+
+    expect(loadConfig().rateLimit.maxRequests).toBe(60);
+    expect(loadConfig().rateLimit.windowMs).toBe(60000);
+  });
+
   it("should fail fast on invalid numeric env vars", async () => {
     vi.stubEnv("ESPANOL_RATE_LIMIT", "many,soon");
     const { loadConfig } = await import("../lib/config.js");

--- a/packages/mcp/src/__tests__/docs.test.ts
+++ b/packages/mcp/src/__tests__/docs.test.ts
@@ -18,7 +18,6 @@ class MockSecurityError extends Error {
 // Mock fs module
 vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
 }));
 
 // Mock the core libraries

--- a/packages/mcp/src/__tests__/docs.test.ts
+++ b/packages/mcp/src/__tests__/docs.test.ts
@@ -25,7 +25,6 @@ vi.mock("node:fs", () => ({
 vi.mock("@espanol/markdown-parser", () => ({
   parseMarkdown: vi.fn(),
   reconstructMarkdown: vi.fn(),
-  extractTranslatableText: vi.fn(),
 }));
 
 vi.mock("@espanol/security", () => {
@@ -73,7 +72,6 @@ vi.mock("@espanol/providers", () => ({
 import {
   parseMarkdown,
   reconstructMarkdown,
-  extractTranslatableText,
 } from "@espanol/markdown-parser";
 import {
   validateMarkdownPath,
@@ -140,12 +138,6 @@ describe("MCP Docs Tools", () => {
     vi.mocked(reconstructMarkdown).mockReturnValue(
       "# Hola Mundo\n\nEste es un párrafo de prueba.\n\n```javascript\nconsole.log('code');\n```"
     );
-
-    // Mock extractTranslatableText
-    vi.mocked(extractTranslatableText).mockReturnValue([
-      "Hello World",
-      "This is a test paragraph.",
-    ]);
 
     // Mock validateMarkdownPath
     vi.mocked(validateMarkdownPath).mockReturnValue("/test/path.md");

--- a/packages/mcp/src/__tests__/i18n.test.ts
+++ b/packages/mcp/src/__tests__/i18n.test.ts
@@ -415,6 +415,35 @@ describe("MCP i18n Tools", () => {
       expect(parsedResult.adapted).toBe(false);
       expect(parsedResult.changes).toEqual([]);
     });
+
+    it("should apply adaptations for newly supported dialects", async () => {
+      vi.mocked(readLocaleFile).mockReturnValue([
+        { key: "computer", value: "El ordenador está en el coche" },
+      ]);
+
+      const { registerI18nTools } = await import("../tools/i18n.js");
+      const mockServer = {
+        tool: vi.fn(),
+      };
+
+      registerI18nTools(mockServer as any, { registry: mockRegistry });
+
+      const dialectCall = vi.mocked(mockServer.tool).mock.calls.find(
+        (call) => call[0] === "manage_dialect_variants"
+      );
+      const handler = dialectCall![3];
+
+      await handler({
+        sourcePath: "/test/es-ES.json",
+        variant: "es-US" as const,
+        outputPath: "/test/es-US.json",
+      } as any);
+
+      const writtenEntries = vi.mocked(writeLocaleFile).mock.calls[0][1];
+      expect(writtenEntries).toEqual([
+        { key: "computer", value: "El computadora está en el carro" },
+      ]);
+    });
   });
 
   describe("check_formality tool", () => {

--- a/packages/mcp/src/__tests__/i18n.test.ts
+++ b/packages/mcp/src/__tests__/i18n.test.ts
@@ -18,8 +18,6 @@ class MockSecurityError extends Error {
 
 // Mock fs module
 vi.mock("node:fs", () => ({
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
   existsSync: vi.fn().mockReturnValue(true),
   statSync: vi.fn().mockReturnValue({ isDirectory: () => true }),
 }));

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mcpState = vi.hoisted(() => ({
+  constructorArgs: [] as unknown[][],
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: vi.fn().mockImplementation((...args: unknown[]) => {
+    mcpState.constructorArgs.push(args);
+    return { tool: vi.fn(), connect: vi.fn() };
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: vi.fn(),
+}));
+
+vi.mock("../tools/docs.js", () => ({
+  registerDocsTools: vi.fn(),
+}));
+
+vi.mock("../tools/i18n.js", () => ({
+  registerI18nTools: vi.fn(),
+}));
+
+vi.mock("../tools/translator.js", () => ({
+  registerTranslatorTools: vi.fn(),
+}));
+
+vi.mock("../lib/provider-factory.js", () => ({
+  createProviderRegistry: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@espanol/security", () => ({
+  RateLimiter: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("MCP server bootstrap", () => {
+  beforeEach(() => {
+    mcpState.constructorArgs = [];
+    vi.resetModules();
+  });
+
+  it("should use the package.json version in MCP server metadata", async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const packageJson = JSON.parse(
+      readFileSync(join(here, "../../package.json"), "utf-8")
+    ) as { version: string };
+
+    const { createServer } = await import("../index.js");
+    createServer();
+
+    expect(mcpState.constructorArgs[0]?.[0]).toMatchObject({
+      name: "@espanol/mcp",
+      version: packageJson.version,
+    });
+  });
+});

--- a/packages/mcp/src/__tests__/security.test.ts
+++ b/packages/mcp/src/__tests__/security.test.ts
@@ -18,7 +18,6 @@ vi.mock("node:fs", () => ({
 vi.mock("@espanol/markdown-parser", () => ({
   parseMarkdown: vi.fn(),
   reconstructMarkdown: vi.fn(),
-  extractTranslatableText: vi.fn(),
 }));
 
 vi.mock("@espanol/locale-utils", () => ({
@@ -80,7 +79,6 @@ vi.mock("@espanol/providers", () => ({
 import {
   parseMarkdown,
   reconstructMarkdown,
-  extractTranslatableText,
 } from "@espanol/markdown-parser";
 import {
   readLocaleFile,
@@ -154,9 +152,6 @@ describe("MCP Security Tests", () => {
 
     // Mock reconstructMarkdown
     vi.mocked(reconstructMarkdown).mockReturnValue("# Hola Mundo");
-
-    // Mock extractTranslatableText
-    vi.mocked(extractTranslatableText).mockReturnValue(["Hello World"]);
 
     // Mock readLocaleFile
     vi.mocked(readLocaleFile).mockReturnValue([

--- a/packages/mcp/src/__tests__/security.test.ts
+++ b/packages/mcp/src/__tests__/security.test.ts
@@ -9,7 +9,6 @@ import { readFileSync } from "node:fs";
 // Mock fs module
 vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
   existsSync: vi.fn().mockReturnValue(true),
   statSync: vi.fn().mockReturnValue({ isDirectory: () => true }),
 }));

--- a/packages/mcp/src/__tests__/translator.test.ts
+++ b/packages/mcp/src/__tests__/translator.test.ts
@@ -524,7 +524,7 @@ describe("MCP Translator Tools", () => {
   });
 
   describe("list_dialects tool", () => {
-    it("should list all 20 Spanish dialects", async () => {
+    it("should list all 25 Spanish dialects", async () => {
       const { registerTranslatorTools } = await import("../tools/translator.js");
       const mockServer = {
         tool: vi.fn(),
@@ -544,8 +544,8 @@ describe("MCP Translator Tools", () => {
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.dialects).toBeDefined();
       expect(Array.isArray(parsedResult.dialects)).toBe(true);
-      expect(parsedResult.dialects.length).toBe(20);
-      expect(parsedResult.count).toBe(20);
+      expect(parsedResult.dialects.length).toBe(25);
+      expect(parsedResult.count).toBe(25);
 
       // Check structure of first dialect
       expect(parsedResult.dialects[0]).toHaveProperty("code");
@@ -574,6 +574,11 @@ describe("MCP Translator Tools", () => {
       expect(dialectCodes).toContain("es-MX");
       expect(dialectCodes).toContain("es-AR");
       expect(dialectCodes).toContain("es-CO");
+      expect(dialectCodes).toContain("es-GQ");
+      expect(dialectCodes).toContain("es-US");
+      expect(dialectCodes).toContain("es-PH");
+      expect(dialectCodes).toContain("es-BZ");
+      expect(dialectCodes).toContain("es-AD");
     });
   });
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -32,7 +32,7 @@ function createServer(config: MCPConfig = loadConfig()): McpServer {
   const server = new McpServer(
     {
       name: "@espanol/mcp",
-      version: "0.1.1",
+      version: "0.1.0",
     },
     {
       capabilities: {},

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -17,6 +17,9 @@ import { registerDocsTools } from "./tools/docs.js";
 import { registerI18nTools } from "./tools/i18n.js";
 import { registerTranslatorTools } from "./tools/translator.js";
 import { setupGlobalHandlers } from "./lib/error-handler.js";
+import { loadConfig, getConfigPath, type MCPConfig } from "./lib/config.js";
+import { createProviderRegistry } from "./lib/provider-factory.js";
+import { RateLimiter } from "@espanol/security";
 
 // ============================================================================
 // MCP Server Setup
@@ -25,7 +28,7 @@ import { setupGlobalHandlers } from "./lib/error-handler.js";
 /**
  * Create and configure the MCP server
  */
-function createServer(): McpServer {
+function createServer(config: MCPConfig = loadConfig()): McpServer {
   const server = new McpServer(
     {
       name: "@espanol/mcp",
@@ -36,10 +39,16 @@ function createServer(): McpServer {
     }
   );
 
+  const registry = createProviderRegistry();
+  const rateLimiter = new RateLimiter(
+    config.rateLimit.maxRequests,
+    config.rateLimit.windowMs
+  );
+
   // Register all tool categories (16 tools total)
-  registerDocsTools(server);
-  registerI18nTools(server);
-  registerTranslatorTools(server);
+  registerDocsTools(server, { registry, rateLimiter });
+  registerI18nTools(server, { registry, rateLimiter });
+  registerTranslatorTools(server, { registry, rateLimiter });
 
   return server;
 }
@@ -53,7 +62,7 @@ function createServer(): McpServer {
  */
 async function main(): Promise<void> {
   setupGlobalHandlers();
-  const server = createServer();
+  const server = createServer(loadConfig(getConfigPath()));
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/mcp/src/lib/config.ts
+++ b/packages/mcp/src/lib/config.ts
@@ -38,8 +38,9 @@ export function loadConfig(configPath?: string): MCPConfig {
       const raw = readFileSync(configPath, "utf-8");
       const fileConfig = configSchema.parse(JSON.parse(raw));
       Object.assign(config, fileConfig);
-    } catch {
-      // Use defaults if config file is invalid
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid MCP config at ${configPath}: ${message}`);
     }
   }
 

--- a/packages/mcp/src/lib/config.ts
+++ b/packages/mcp/src/lib/config.ts
@@ -26,6 +26,17 @@ export type MCPConfig = z.infer<typeof configSchema>;
 
 const DEFAULT_CONFIG: MCPConfig = configSchema.parse({});
 
+function parsePositiveIntEnv(name: string, value: string, min: number): number {
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error(`Invalid MCP config env ${name}: expected integer >= ${min}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < min) {
+    throw new Error(`Invalid MCP config env ${name}: expected integer >= ${min}`);
+  }
+  return parsed;
+}
+
 /**
  * Load configuration with priority: env vars > config file > defaults
  */
@@ -46,17 +57,20 @@ export function loadConfig(configPath?: string): MCPConfig {
 
   // 2. Override from environment variables
   if (process.env.ESPANOL_RATE_LIMIT) {
-    const [max, window] = process.env.ESPANOL_RATE_LIMIT.split(",");
-    config.rateLimit.maxRequests = parseInt(max, 10) || 60;
-    config.rateLimit.windowMs = parseInt(window, 10) || 60000;
+    const parts = process.env.ESPANOL_RATE_LIMIT.split(",");
+    if (parts.length !== 2) {
+      throw new Error("Invalid MCP config env ESPANOL_RATE_LIMIT: expected <maxRequests>,<windowMs>");
+    }
+    config.rateLimit.maxRequests = parsePositiveIntEnv("ESPANOL_RATE_LIMIT", parts[0], 1);
+    config.rateLimit.windowMs = parsePositiveIntEnv("ESPANOL_RATE_LIMIT", parts[1], 1000);
   }
 
   if (process.env.ESPANOL_MAX_FILE_SIZE) {
-    config.security.maxFileSize = parseInt(process.env.ESPANOL_MAX_FILE_SIZE, 10) || 512 * 1024;
+    config.security.maxFileSize = parsePositiveIntEnv("ESPANOL_MAX_FILE_SIZE", process.env.ESPANOL_MAX_FILE_SIZE, 1024);
   }
 
   if (process.env.ESPANOL_MAX_CONTENT_LENGTH) {
-    config.security.maxContentLength = parseInt(process.env.ESPANOL_MAX_CONTENT_LENGTH, 10) || 50000;
+    config.security.maxContentLength = parsePositiveIntEnv("ESPANOL_MAX_CONTENT_LENGTH", process.env.ESPANOL_MAX_CONTENT_LENGTH, 1000);
   }
 
   if (process.env.ALLOWED_LOCALE_DIRS) {

--- a/packages/mcp/src/lib/config.ts
+++ b/packages/mcp/src/lib/config.ts
@@ -78,9 +78,10 @@ export function loadConfig(configPath?: string): MCPConfig {
   if (process.env.ESPANOL_LOG_LEVEL) {
     const validLevels = ["error", "warn", "info", "debug"] as const;
     const level = process.env.ESPANOL_LOG_LEVEL;
-    if (validLevels.includes(level as typeof validLevels[number])) {
-      config.logging.level = level as MCPConfig["logging"]["level"];
+    if (!validLevels.includes(level as typeof validLevels[number])) {
+      throw new Error(`Invalid MCP config env ESPANOL_LOG_LEVEL: expected one of ${validLevels.join(", ")}`);
     }
+    config.logging.level = level as MCPConfig["logging"]["level"];
   }
 
   return config;

--- a/packages/mcp/src/lib/config.ts
+++ b/packages/mcp/src/lib/config.ts
@@ -24,8 +24,6 @@ const configSchema = z.object({
 
 export type MCPConfig = z.infer<typeof configSchema>;
 
-const DEFAULT_CONFIG: MCPConfig = configSchema.parse({});
-
 function parsePositiveIntEnv(name: string, value: string, min: number): number {
   if (!/^\d+$/.test(value.trim())) {
     throw new Error(`Invalid MCP config env ${name}: expected integer >= ${min}`);
@@ -41,7 +39,7 @@ function parsePositiveIntEnv(name: string, value: string, min: number): number {
  * Load configuration with priority: env vars > config file > defaults
  */
 export function loadConfig(configPath?: string): MCPConfig {
-  const config = { ...DEFAULT_CONFIG };
+  const config = configSchema.parse({});
 
   // 1. Load from config file
   if (configPath && existsSync(configPath)) {

--- a/packages/mcp/src/lib/provider-request.ts
+++ b/packages/mcp/src/lib/provider-request.ts
@@ -1,0 +1,33 @@
+import type { ProviderRegistry } from "@espanol/providers";
+import type { TranslateOptions } from "@espanol/types";
+
+export interface PreparedToolProviderRequest {
+  sourceLang: string;
+  targetLang: string;
+  options: TranslateOptions;
+}
+
+export function prepareProviderRequest(
+  registry: ProviderRegistry,
+  providerName: string,
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  options: TranslateOptions
+): PreparedToolProviderRequest {
+  const maybeRegistry = registry as ProviderRegistry & {
+    prepareRequest?: (
+      name: string,
+      text: string,
+      sourceLang: string,
+      targetLang: string,
+      options: TranslateOptions
+    ) => PreparedToolProviderRequest;
+  };
+
+  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
+    sourceLang,
+    targetLang,
+    options,
+  };
+}

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -24,7 +24,6 @@ import {
   validateMarkdownPath,
   validateContentLength,
   RateLimiter,
-  SecurityError,
   createSafeError,
 } from "@espanol/security";
 import type { ProviderRegistry } from "@espanol/providers";

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -15,6 +15,7 @@ import type {
   MarkdownSection,
   SpanishDialect,
   ProviderName,
+  TranslateOptions,
 } from "@espanol/types";
 import {
   parseMarkdown,
@@ -66,6 +67,30 @@ interface CreateBilingualDocParams {
   provider?: ProviderName;
 }
 
+function prepareProviderRequest(
+  registry: ProviderRegistry,
+  providerName: string,
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  options: TranslateOptions
+): { sourceLang: string; targetLang: string; options: TranslateOptions } {
+  const maybeRegistry = registry as ProviderRegistry & {
+    prepareRequest?: (
+      name: string,
+      text: string,
+      sourceLang: string,
+      targetLang: string,
+      options: TranslateOptions
+    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
+  };
+  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
+    sourceLang,
+    targetLang,
+    options,
+  };
+}
+
 // ============================================================================
 // Tool Handlers
 // ============================================================================
@@ -113,11 +138,19 @@ async function handleTranslateMarkdown(
         translatedSections.push(section);
       } else {
         // Translate the content
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           section.content,
           "en",
           params.dialect || "es-ES",
           { formality, dialect: params.dialect }
+        );
+        const result = await provider.translate(
+          section.content,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         translatedSections.push({
@@ -261,7 +294,9 @@ async function handleTranslateApiDocs(
         translatedSections.push(section);
       } else {
         // For API docs, add context about documentation
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           section.content,
           "en",
           params.dialect || "es-ES",
@@ -269,6 +304,12 @@ async function handleTranslateApiDocs(
             context: "API documentation",
             dialect: params.dialect,
           }
+        );
+        const result = await provider.translate(
+          section.content,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         translatedSections.push({
@@ -347,11 +388,19 @@ async function handleCreateBilingualDoc(
         bilingualParts.push(section.raw);
       } else {
         // Translate the content
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           section.content,
           "en",
           params.dialect || "es-ES",
           { dialect: params.dialect }
+        );
+        const result = await provider.translate(
+          section.content,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         // Add side-by-side sections

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -19,7 +19,6 @@ import type {
 import {
   parseMarkdown,
   reconstructMarkdown,
-  extractTranslatableText,
 } from "@espanol/markdown-parser";
 import {
   validateMarkdownPath,
@@ -192,9 +191,6 @@ async function handleExtractTranslatable(
 
     // Parse markdown
     const parsed = parseMarkdown(content);
-
-    // Extract translatable text
-    const translatableTexts = extractTranslatableText(parsed);
 
     // Build sections array
     const sections = parsed.sections

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -15,7 +15,6 @@ import type {
   MarkdownSection,
   SpanishDialect,
   ProviderName,
-  TranslateOptions,
 } from "@espanol/types";
 import {
   parseMarkdown,
@@ -33,6 +32,7 @@ import type { ProviderRegistry } from "@espanol/providers";
 import { ToolResult } from "../lib/types.js";
 import type { BaseToolOptions } from "../lib/types.js";
 import { createProviderRegistry as createProviderRegistryImpl } from "../lib/provider-factory.js";
+import { prepareProviderRequest } from "../lib/provider-request.js";
 
 // Re-export for backward compatibility
 export { createProviderRegistryImpl as createProviderRegistry };
@@ -65,30 +65,6 @@ interface CreateBilingualDocParams {
   filePath: string;
   dialect?: SpanishDialect;
   provider?: ProviderName;
-}
-
-function prepareProviderRequest(
-  registry: ProviderRegistry,
-  providerName: string,
-  text: string,
-  sourceLang: string,
-  targetLang: string,
-  options: TranslateOptions
-): { sourceLang: string; targetLang: string; options: TranslateOptions } {
-  const maybeRegistry = registry as ProviderRegistry & {
-    prepareRequest?: (
-      name: string,
-      text: string,
-      sourceLang: string,
-      targetLang: string,
-      options: TranslateOptions
-    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
-  };
-  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
-    sourceLang,
-    targetLang,
-    options,
-  };
 }
 
 // ============================================================================

--- a/packages/mcp/src/tools/i18n.ts
+++ b/packages/mcp/src/tools/i18n.ts
@@ -22,7 +22,6 @@ import type {
   FormalityIssue,
   GenderNeutralStrategy,
   VariantResult,
-  TranslateOptions,
 } from "@espanol/types";
 import {
   readLocaleFile,
@@ -47,6 +46,7 @@ import {
 } from "@espanol/providers";
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "../lib/provider-factory.js";
+import { prepareProviderRequest } from "../lib/provider-request.js";
 
 // ============================================================================
 // Types
@@ -85,30 +85,6 @@ interface CheckFormalityParams {
 interface ApplyGenderNeutralParams {
   localePath: string;
   strategy?: GenderNeutralStrategy;
-}
-
-function prepareProviderRequest(
-  registry: ProviderRegistry,
-  providerName: string,
-  text: string,
-  sourceLang: string,
-  targetLang: string,
-  options: TranslateOptions
-): { sourceLang: string; targetLang: string; options: TranslateOptions } {
-  const maybeRegistry = registry as ProviderRegistry & {
-    prepareRequest?: (
-      name: string,
-      text: string,
-      sourceLang: string,
-      targetLang: string,
-      options: TranslateOptions
-    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
-  };
-  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
-    sourceLang,
-    targetLang,
-    options,
-  };
 }
 
 // ============================================================================

--- a/packages/mcp/src/tools/i18n.ts
+++ b/packages/mcp/src/tools/i18n.ts
@@ -22,6 +22,7 @@ import type {
   FormalityIssue,
   GenderNeutralStrategy,
   VariantResult,
+  TranslateOptions,
 } from "@espanol/types";
 import {
   readLocaleFile,
@@ -86,6 +87,30 @@ interface ApplyGenderNeutralParams {
   strategy?: GenderNeutralStrategy;
 }
 
+function prepareProviderRequest(
+  registry: ProviderRegistry,
+  providerName: string,
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  options: TranslateOptions
+): { sourceLang: string; targetLang: string; options: TranslateOptions } {
+  const maybeRegistry = registry as ProviderRegistry & {
+    prepareRequest?: (
+      name: string,
+      text: string,
+      sourceLang: string,
+      targetLang: string,
+      options: TranslateOptions
+    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
+  };
+  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
+    sourceLang,
+    targetLang,
+    options,
+  };
+}
+
 // ============================================================================
 // Dialect Adaptation Maps
 // ============================================================================
@@ -135,6 +160,41 @@ const DIALECT_ADAPTATIONS: Record<string, Record<string, string>> = {
     "coger": "tomar",
     "prisas": "prisa",
     "dinero": "dinero",
+  },
+  "es-GQ": {
+    "ordenador": "computadora",
+    "coche": "carro",
+    "móvil": "celular",
+    "patata": "papa",
+    "gafas": "lentes",
+  },
+  "es-US": {
+    "ordenador": "computadora",
+    "coche": "carro",
+    "móvil": "celular",
+    "patata": "papa",
+    "gafas": "lentes",
+  },
+  "es-PH": {
+    "ordenador": "computadora",
+    "coche": "carro",
+    "móvil": "celular",
+    "patata": "papa",
+    "gafas": "lentes",
+  },
+  "es-BZ": {
+    "ordenador": "computadora",
+    "coche": "carro",
+    "móvil": "celular",
+    "patata": "papa",
+    "gafas": "lentes",
+  },
+  "es-AD": {
+    "ordenador": "computadora",
+    "coche": "carro",
+    "móvil": "celular",
+    "patata": "papa",
+    "gafas": "lentes",
   },
 };
 
@@ -341,6 +401,7 @@ async function handleTranslateMissingKeys(
 
     // Translate missing keys
     let translatedCount = 0;
+    const errors: string[] = [];
     const updatedTargetEntries = [...targetEntries];
 
     for (const key of missingKeys) {
@@ -348,11 +409,19 @@ async function handleTranslateMissingKeys(
       if (!baseEntry) continue;
 
       try {
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           baseEntry.value,
           "en",
           params.dialect || "es-ES",
           { dialect: params.dialect }
+        );
+        const result = await provider.translate(
+          baseEntry.value,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         updatedTargetEntries.push({
@@ -361,7 +430,8 @@ async function handleTranslateMissingKeys(
         });
         translatedCount++;
       } catch (error) {
-        // Silently skip failed translations — provider already handles error logging
+        const safe = createSafeError(error);
+        errors.push(`${key}: ${safe.error}`);
       }
     }
 
@@ -375,9 +445,12 @@ async function handleTranslateMissingKeys(
           text: JSON.stringify({
             translatedCount,
             missingKeys,
+            errors,
+            skippedCount: errors.length,
           }),
         },
       ],
+      isError: translatedCount === 0 && missingKeys.length > 0 && errors.length > 0,
     };
   } catch (error) {
     const safeError = createSafeError(error);
@@ -464,11 +537,19 @@ async function handleBatchTranslateLocales(
         // Translate missing keys
         for (const entry of missingEntries) {
           try {
-            const result = await provider.translate(
+            const prepared = prepareProviderRequest(
+              registry,
+              provider.name,
               entry.value,
               "en",
               targetDialect,
               { dialect: targetDialect }
+            );
+            const result = await provider.translate(
+              entry.value,
+              prepared.sourceLang,
+              prepared.targetLang,
+              prepared.options
             );
 
             targetEntries.push({

--- a/packages/mcp/src/tools/i18n.ts
+++ b/packages/mcp/src/tools/i18n.ts
@@ -11,17 +11,15 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { readFileSync, existsSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 import type {
   SpanishDialect,
   ProviderName,
   I18nEntry,
-  LocaleDiff,
   FormalityIssue,
   GenderNeutralStrategy,
-  VariantResult,
 } from "@espanol/types";
 import {
   readLocaleFile,
@@ -40,9 +38,6 @@ import {
 } from "@espanol/security";
 import {
   ProviderRegistry,
-  DeepLProvider,
-  LibreTranslateProvider,
-  MyMemoryProvider,
 } from "@espanol/providers";
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "../lib/provider-factory.js";

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -32,9 +32,6 @@ import {
 } from "@espanol/security";
 import {
   ProviderRegistry,
-  DeepLProvider,
-  LibreTranslateProvider,
-  MyMemoryProvider,
 } from "@espanol/providers";
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "../lib/provider-factory.js";

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -17,7 +17,6 @@ import type {
   SpanishDialect,
   ProviderName,
   GlossaryEntry,
-  TranslateOptions,
 } from "@espanol/types";
 import {
   parseMarkdown,
@@ -39,6 +38,7 @@ import {
 } from "@espanol/providers";
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "../lib/provider-factory.js";
+import { prepareProviderRequest } from "../lib/provider-request.js";
 
 // ============================================================================
 // Types
@@ -75,30 +75,6 @@ interface SearchGlossaryParams {
 }
 
 interface ListDialectsParams {}
-
-function prepareProviderRequest(
-  registry: ProviderRegistry,
-  providerName: string,
-  text: string,
-  sourceLang: string,
-  targetLang: string,
-  options: TranslateOptions
-): { sourceLang: string; targetLang: string; options: TranslateOptions } {
-  const maybeRegistry = registry as ProviderRegistry & {
-    prepareRequest?: (
-      name: string,
-      text: string,
-      sourceLang: string,
-      targetLang: string,
-      options: TranslateOptions
-    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
-  };
-  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
-    sourceLang,
-    targetLang,
-    options,
-  };
-}
 
 // ============================================================================
 // Dialect Metadata

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -17,6 +17,7 @@ import type {
   SpanishDialect,
   ProviderName,
   GlossaryEntry,
+  TranslateOptions,
 } from "@espanol/types";
 import {
   parseMarkdown,
@@ -75,12 +76,36 @@ interface SearchGlossaryParams {
 
 interface ListDialectsParams {}
 
+function prepareProviderRequest(
+  registry: ProviderRegistry,
+  providerName: string,
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  options: TranslateOptions
+): { sourceLang: string; targetLang: string; options: TranslateOptions } {
+  const maybeRegistry = registry as ProviderRegistry & {
+    prepareRequest?: (
+      name: string,
+      text: string,
+      sourceLang: string,
+      targetLang: string,
+      options: TranslateOptions
+    ) => { sourceLang: string; targetLang: string; options: TranslateOptions };
+  };
+  return maybeRegistry.prepareRequest?.(providerName, text, sourceLang, targetLang, options) ?? {
+    sourceLang,
+    targetLang,
+    options,
+  };
+}
+
 // ============================================================================
 // Dialect Metadata
 // ============================================================================
 
 /**
- * Metadata for all 20 Spanish dialects with detection keywords
+ * Metadata for all 25 Spanish dialects with detection keywords
  */
 const DIALECT_METADATA: Array<{
   code: SpanishDialect;
@@ -428,6 +453,36 @@ const DIALECT_METADATA: Array<{
       "broki",
     ],
   },
+  {
+    code: "es-GQ",
+    name: "Equatoguinean Spanish",
+    description: "Spanish spoken in Equatorial Guinea",
+    keywords: ["guineano", "malabo", "bubi", "fang", "annobón", "bioko", "ñame", "fufú"],
+  },
+  {
+    code: "es-US",
+    name: "U.S. Spanish",
+    description: "Spanish spoken in the United States by Chicano and heritage communities",
+    keywords: ["troca", "parquear", "lonche", "wacha", "cholo", "vato", "carnal", "neta"],
+  },
+  {
+    code: "es-PH",
+    name: "Philippine Spanish",
+    description: "Spanish and Chavacano-influenced Spanish from the Philippines",
+    keywords: ["jendeh", "kame", "kita", "quilaya", "tamén", "onde", "conele", "vusos"],
+  },
+  {
+    code: "es-BZ",
+    name: "Belizean Spanish",
+    description: "Spanish spoken in Belize",
+    keywords: ["beliceño", "kriol", "garífuna", "cayos", "mestizo", "criollo", "dangriga", "mopan"],
+  },
+  {
+    code: "es-AD",
+    name: "Andorran Spanish",
+    description: "Catalan-influenced Spanish from Andorra",
+    keywords: ["andorrano", "canillo", "escaldes", "encamp", "ordino", "massana", "pirineo", "andorra"],
+  },
 ];
 
 // ============================================================================
@@ -528,11 +583,19 @@ async function handleTranslateText(
     if (params.informal) formality = "informal";
 
     // Translate
-    const result = await provider.translate(
+    const prepared = prepareProviderRequest(
+      registry,
+      provider.name,
       params.text,
       "en",
       params.dialect || "es-ES",
       { formality, dialect: params.dialect }
+    );
+    const result = await provider.translate(
+      params.text,
+      prepared.sourceLang,
+      prepared.targetLang,
+      prepared.options
     );
 
     return {
@@ -702,15 +765,24 @@ async function handleTranslateCodeComment(
 
     // Translate each comment sequentially
     let commentsTranslated = 0;
+    const errors: string[] = [];
     const replacements: Array<{ original: string; translated: string }> = [];
 
     for (const comment of comments) {
       try {
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           comment.content,
           "en",
           params.dialect || "es-ES",
           { context: "code comment", dialect: params.dialect }
+        );
+        const result = await provider.translate(
+          comment.content,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         const translated = comment.isSingleLine
@@ -719,8 +791,9 @@ async function handleTranslateCodeComment(
 
         replacements.push({ original: comment.full, translated });
         commentsTranslated++;
-      } catch {
-        // Skip failed translations
+      } catch (error) {
+        const safe = createSafeError(error);
+        errors.push(`comment@${comment.index}: ${safe.error}`);
       }
     }
 
@@ -738,9 +811,12 @@ async function handleTranslateCodeComment(
           text: JSON.stringify({
             translatedCode,
             commentsTranslated,
+            errors,
+            skippedCount: errors.length,
           }),
         },
       ],
+      isError: commentsTranslated === 0 && comments.length > 0 && errors.length > 0,
     };
   } catch (error) {
     const safeError = createSafeError(error);
@@ -804,11 +880,19 @@ async function handleTranslateReadme(
           codeBlocksPreserved++;
         }
       } else {
-        const result = await provider.translate(
+        const prepared = prepareProviderRequest(
+          registry,
+          provider.name,
           section.content,
           "en",
           params.dialect || "es-ES",
           { formality, dialect: params.dialect }
+        );
+        const result = await provider.translate(
+          section.content,
+          prepared.sourceLang,
+          prepared.targetLang,
+          prepared.options
         );
 
         translatedSections.push({

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -6,7 +6,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -25,5 +28,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/providers/src/__tests__/providers.test.ts
+++ b/packages/providers/src/__tests__/providers.test.ts
@@ -293,6 +293,18 @@ describe("ProviderRegistry", () => {
     expect(registry.isAvailable("libre")).toBe(true);
   });
 
+  it("should not alias nonexistent DeepL free provider to DeepL", () => {
+    const registry = new ProviderRegistry();
+    const deeplProvider: TranslationProvider = {
+      name: "deepl",
+      translate: async () => ({ translatedText: "test" }),
+    };
+
+    registry.register(deeplProvider);
+
+    expect(() => registry.get("deepl-free")).toThrow("Provider not available");
+  });
+
   it("should throw when getting non-existent provider", () => {
     const registry = new ProviderRegistry();
 

--- a/packages/providers/src/__tests__/providers.test.ts
+++ b/packages/providers/src/__tests__/providers.test.ts
@@ -280,6 +280,19 @@ describe("ProviderRegistry", () => {
     expect(retrieved).toBe(mockProvider);
   });
 
+  it("should resolve canonical provider aliases", () => {
+    const registry = new ProviderRegistry();
+    const libreProvider: TranslationProvider = {
+      name: "libretranslate",
+      translate: async () => ({ translatedText: "test" }),
+    };
+
+    registry.register(libreProvider);
+
+    expect(registry.get("libre")).toBe(libreProvider);
+    expect(registry.isAvailable("libre")).toBe(true);
+  });
+
   it("should throw when getting non-existent provider", () => {
     const registry = new ProviderRegistry();
 
@@ -990,6 +1003,35 @@ describe("Provider capabilities", () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0].reason).toContain("does not support dialect");
+  });
+
+  it("Registry should prepare dialect requests for providers without native dialect support", () => {
+    const registry = new ProviderRegistry();
+    const provider: TranslationProvider = {
+      name: "nodialect",
+      translate: async () => ({ translatedText: "test" }),
+      getCapabilities: () => ({
+        name: "nodialect",
+        displayName: "No Dialect",
+        needsApiKey: false,
+        supportsFormality: false,
+        supportsContext: false,
+        supportsDialect: false,
+        supportedSourceLangs: ["en", "auto"],
+        supportedTargetLangs: ["es"],
+        maxPayloadChars: 10000,
+        dialectHandling: "none",
+      }),
+    };
+
+    registry.register(provider);
+    const prepared = registry.prepareRequest("nodialect", "hello", "en", "es-MX", {
+      dialect: "es-MX",
+    });
+
+    expect(prepared.targetLang).toBe("es");
+    expect(prepared.options).not.toHaveProperty("dialect");
+    expect(prepared.warnings).toContain("Provider nodialect does not support dialect es-MX; using generic Spanish target es");
   });
 
   it("Registry validateRequest should return empty for valid requests", () => {

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -28,7 +28,6 @@ export class ProviderRegistry {
 
   private canonicalName(name: string): string {
     if (name === "libre") return "libretranslate";
-    if (name === "deepl-free") return "deepl";
     return name;
   }
 

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -3,7 +3,7 @@
  * Manages multiple translation providers and selects available ones
  */
 
-import type { TranslationProvider, ProviderCapability } from "./types.js";
+import type { TranslationProvider, ProviderCapability, TranslateOptions } from "./types.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
 
 interface ProviderEntry {
@@ -16,8 +16,21 @@ export interface CapabilityValidationError {
   reason: string;
 }
 
+export interface PreparedProviderRequest {
+  sourceLang: string;
+  targetLang: string;
+  options: TranslateOptions;
+  warnings: string[];
+}
+
 export class ProviderRegistry {
   private providers = new Map<string, ProviderEntry>();
+
+  private canonicalName(name: string): string {
+    if (name === "libre") return "libretranslate";
+    if (name === "deepl-free") return "deepl";
+    return name;
+  }
 
   constructor(
     private readonly failureThreshold: number = 5,
@@ -40,7 +53,7 @@ export class ProviderRegistry {
    * Get a specific provider by name
    */
   get(name: string): TranslationProvider {
-    const entry = this.providers.get(name);
+    const entry = this.providers.get(this.canonicalName(name));
     if (!entry) {
       throw new Error("Provider not available");
     }
@@ -64,7 +77,7 @@ export class ProviderRegistry {
    * Get circuit breaker for a provider
    */
   getBreaker(name: string): CircuitBreaker | undefined {
-    return this.providers.get(name)?.breaker;
+    return this.providers.get(this.canonicalName(name))?.breaker;
   }
 
   /**
@@ -78,7 +91,7 @@ export class ProviderRegistry {
    * Check if a provider is available (circuit not open)
    */
   isAvailable(name: string): boolean {
-    const entry = this.providers.get(name);
+    const entry = this.providers.get(this.canonicalName(name));
     return entry ? entry.breaker.canExecute() : false;
   }
 
@@ -86,7 +99,7 @@ export class ProviderRegistry {
    * Get capabilities for a specific provider
    */
   getCapabilities(name: string): ProviderCapability | null {
-    const entry = this.providers.get(name);
+    const entry = this.providers.get(this.canonicalName(name));
     if (!entry) return null;
     return entry.provider.getCapabilities?.() ?? null;
   }
@@ -162,10 +175,77 @@ export class ProviderRegistry {
   }
 
   /**
+   * Prepare a provider-specific request from a dialect-aware request.
+   *
+   * Providers such as LibreTranslate and MyMemory only accept base language
+   * codes (for example "es") and do not natively handle Spanish dialects.
+   * This method normalizes those requests before validation so callers do not
+   * accidentally send unsupported BCP-47 dialect tags to external APIs.
+   */
+  prepareRequest(
+    name: string,
+    text: string,
+    sourceLang: string,
+    targetLang: string,
+    options: TranslateOptions = {}
+  ): PreparedProviderRequest {
+    const canonical = this.canonicalName(name);
+    const caps = this.getCapabilities(canonical);
+    const preparedOptions: TranslateOptions = { ...options };
+    const warnings: string[] = [];
+    let preparedTargetLang = targetLang;
+
+    const requestedDialect = options.dialect ?? (
+      targetLang.startsWith("es-") ? targetLang as TranslateOptions["dialect"] : undefined
+    );
+
+    if (requestedDialect && caps?.dialectHandling === "none") {
+      preparedTargetLang = requestedDialect.split("-")[0];
+      delete preparedOptions.dialect;
+      warnings.push(
+        `Provider ${canonical} does not support dialect ${requestedDialect}; using generic Spanish target ${preparedTargetLang}`
+      );
+    }
+
+    if (preparedOptions.formality && caps && !caps.supportsFormality) {
+      warnings.push(`Provider ${canonical} does not support formality; dropping formality option`);
+      delete preparedOptions.formality;
+    }
+
+    if (preparedOptions.context && caps && !caps.supportsContext) {
+      warnings.push(`Provider ${canonical} does not support context; dropping context option`);
+      delete preparedOptions.context;
+    }
+
+    const validationErrors = this.validateRequest(
+      canonical,
+      text,
+      sourceLang,
+      preparedTargetLang,
+      {
+        formality: preparedOptions.formality,
+        dialect: preparedOptions.dialect,
+      }
+    );
+    if (validationErrors.length > 0) {
+      throw new Error(
+        validationErrors.map((error) => `${error.provider}: ${error.reason}`).join("; ")
+      );
+    }
+
+    return {
+      sourceLang,
+      targetLang: preparedTargetLang,
+      options: preparedOptions,
+      warnings,
+    };
+  }
+
+  /**
    * Record a successful translation for a provider
    */
   recordSuccess(name: string): void {
-    const entry = this.providers.get(name);
+    const entry = this.providers.get(this.canonicalName(name));
     if (entry) {
       entry.breaker.recordSuccess();
     }
@@ -175,7 +255,7 @@ export class ProviderRegistry {
    * Record a failed translation for a provider
    */
   recordFailure(name: string): void {
-    const entry = this.providers.get(name);
+    const entry = this.providers.get(this.canonicalName(name));
     if (entry) {
       entry.breaker.recordFailure();
     }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -6,7 +6,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -23,5 +26,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/security/src/__tests__/security.test.ts
+++ b/packages/security/src/__tests__/security.test.ts
@@ -461,6 +461,14 @@ describe("createSafeError", () => {
     expect(result).toHaveProperty("error");
     expect(result).toHaveProperty("code");
   });
+
+  it("should not log as a side effect", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    createSafeError(new Error("safe response only"));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("RateLimiter", () => {

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -540,13 +540,6 @@ export function createSafeError(error: unknown): {
   error: string;
   code: ErrorCode;
 } {
-  // Log the real error for debugging
-  if (error instanceof Error) {
-    console.error(`[Security] ${error.name}: ${error.message}`);
-  } else {
-    console.error(`[Security] ${String(error)}`);
-  }
-
   // Extract message
   const message =
     error instanceof Error ? error.message : String(error);

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -22,5 +25,10 @@
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -238,7 +238,6 @@ describe("Zod Validation Schemas", () => {
   describe("providerNameSchema", () => {
     it("should accept valid providers", () => {
       expect(() => providerNameSchema.parse("deepl")).not.toThrow();
-      expect(() => providerNameSchema.parse("deepl-free")).not.toThrow();
       expect(() => providerNameSchema.parse("libre")).not.toThrow();
       expect(() => providerNameSchema.parse("mymemory")).not.toThrow();
     });
@@ -247,6 +246,7 @@ describe("Zod Validation Schemas", () => {
       expect(() => providerNameSchema.parse("google")).toThrow();
       expect(() => providerNameSchema.parse("")).toThrow();
       expect(() => providerNameSchema.parse("deeplx")).toThrow();
+      expect(() => providerNameSchema.parse("deepl-free")).toThrow();
     });
   });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,7 +48,7 @@ export const DEFAULT_DIALECT: SpanishDialect = "es-ES";
 /**
  * Supported translation providers
  */
-export type ProviderName = "deepl" | "deepl-free" | "libre" | "mymemory";
+export type ProviderName = "deepl" | "libre" | "mymemory";
 
 /**
  * Translation options
@@ -344,7 +344,7 @@ export const dialectSchema = z.enum([
 /**
  * Validates translation provider names
  */
-export const providerNameSchema = z.enum(["deepl", "deepl-free", "libre", "mymemory"], {
+export const providerNameSchema = z.enum(["deepl", "libre", "mymemory"], {
   message: "Invalid translation provider",
 });
 


### PR DESCRIPTION
## Summary
- harden provider contracts: remove fake `deepl-free`, canonicalize Libre provider alias, validate/downgrade dialect requests by provider capability
- fix false-green markdown table reconstruction and strengthen semantic policy gates
- align MCP parity/config behavior, fail fast on invalid config/env, and remove stale/dead MCP code/test scaffolding
- restrict package publish contents and keep docs/test counts aligned with verified behavior

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check for all workspace packages

## Notes
- Live external provider calls with production credentials were not run.
- Branch preserves Lore-style atomic remediation commits for future traceability.