### PR TITLE
Add semantic dialect translation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-602%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-604%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -50,7 +50,7 @@ Spanish is not one language — it's **25 regional variants** with different voc
 - Understanding regional differences (es-MX vs es-ES vs es-AR vs es-CO...)
 - Preserving technical document structure during translation
 - Providing glossary enforcement for consistent terminology
-- Adding quality gates that catch semantic drift before it reaches users
+- Adding semantic context and quality gates that catch drift before it reaches users
 - Running as an MCP server so AI assistants can translate natively
 
 ---
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 602 tests passing
+pnpm test        # 604 tests passing
 ```
 
 ---
@@ -130,7 +130,7 @@ pnpm test        # 602 tests passing
 ### Translation (6 tools)
 | Tool | Description |
 |------|-------------|
-| `translate_text` | Translate to any Spanish dialect |
+| `translate_text` | Translate with semantic domain/register/dialect context |
 | `detect_dialect` | Detect dialect from sample text |
 | `translate_code_comment` | Translate comments, preserve code |
 | `translate_readme` | Full README translation pipeline |
@@ -144,14 +144,14 @@ pnpm test        # 602 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for translation workflows | 217 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 219 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + canonical glossary data | 44 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 602 tests across 7 packages**
+**Total: 604 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        602 tests passing · BSL 1.1 · GitHub Pages
+        604 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">602</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">604</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/plans/2026-04-21-semantic-dialect-context.md
+++ b/docs/plans/2026-04-21-semantic-dialect-context.md
@@ -1,0 +1,17 @@
+# Semantic Dialect Context Implementation Plan
+
+**Goal:** Stop relying on word-level replacement alone by giving translation providers explicit semantic context: domain, intent, register, and dialect style guidance.
+
+**Architecture:** Add a dependency-free CLI semantic-context module. It classifies text into domain/intent/register signals, retrieves dialect metadata, and builds provider context strings that instruct providers to preserve meaning over literal word substitution. Thread this context through plain text, README, and API-doc translation paths. Add tests for classifier behavior and command propagation.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest, existing provider interfaces.
+
+---
+
+## Tasks
+1. Add failing tests for semantic domain/intent/register context generation.
+2. Add failing tests that `translate` and `translate-readme` pass context to providers.
+3. Implement `packages/cli/src/lib/semantic-context.ts`.
+4. Thread context into `translate`, `translate-readme`, and `translate-api-docs` provider options.
+5. Update docs to describe semantic context guidance honestly.
+6. Run build, typecheck, tests, audit, and pack checks.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 602 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 604 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-602 tests. 7 packages. pnpm monorepo. TypeScript.
+604 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 602 tests
+**Tech:** TypeScript, pnpm monorepo, 604 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 602 tests passing.
+Source available, BSL 1.1 licensed, 604 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 602 tests
+**Tech stack:** TypeScript, pnpm monorepo, 604 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/semantic-context.test.ts
+++ b/packages/cli/src/__tests__/semantic-context.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeSemanticContext,
+  buildSemanticTranslationContext,
+} from "../lib/semantic-context.js";
+
+describe("semantic translation context", () => {
+  it("classifies technical/security intent beyond literal terms", () => {
+    const signals = analyzeSemanticContext(
+      "If the API token is invalid, the endpoint returns a permission denied error."
+    );
+
+    expect(signals.domain).toBe("security");
+    expect(signals.intent).toBe("error-message");
+    expect(signals.matchedSignals.length).toBeGreaterThan(1);
+  });
+
+  it("builds dialect-aware context that rejects word-by-word translation", () => {
+    const context = buildSemanticTranslationContext({
+      text: "Configure the endpoint and review the authentication token before deployment.",
+      dialect: "es-MX",
+      documentKind: "api-docs",
+      sectionType: "paragraph",
+    });
+
+    expect(context).toContain("do not translate literally word-by-word");
+    expect(context).toContain("Mexican Spanish");
+    expect(context).toContain("Document domain: security");
+    expect(context).toContain("Document kind: api-docs");
+    expect(context).toContain("Preserve product names");
+  });
+});

--- a/packages/cli/src/__tests__/translate-api-docs.test.ts
+++ b/packages/cli/src/__tests__/translate-api-docs.test.ts
@@ -285,7 +285,10 @@ describe("translate-api-docs command", () => {
         "Header1 Header2 Cell1 Cell2",
         "auto",
         "es-ES",
-        { dialect: "es-ES" }
+        expect.objectContaining({
+          dialect: "es-ES",
+          context: expect.stringContaining("do not translate literally word-by-word"),
+        })
       );
       expect(mockWriteOutput).toHaveBeenCalled();
     });
@@ -319,7 +322,10 @@ describe("translate-api-docs command", () => {
         "Item 1\nNested item",
         "auto",
         "es-ES",
-        { dialect: "es-ES" }
+        expect.objectContaining({
+          dialect: "es-ES",
+          context: expect.stringContaining("Current section type: list"),
+        })
       );
       expect(mockWriteOutput).toHaveBeenCalled();
     });
@@ -361,7 +367,10 @@ describe("translate-api-docs command", () => {
         "Some text",
         "auto",
         "es-ES",
-        { dialect: "es-ES" }
+        expect.objectContaining({
+          dialect: "es-ES",
+          context: expect.stringContaining("Document kind: api-docs"),
+        })
       );
       expect(mockWriteOutput).toHaveBeenCalled();
     });
@@ -401,7 +410,10 @@ describe("translate-api-docs command", () => {
         "# API",
         "auto",
         "es-ES",
-        { dialect: "es-ES" }
+        expect.objectContaining({
+          dialect: "es-ES",
+          context: expect.stringContaining("Document domain: technical"),
+        })
       );
       expect(mockWriteOutput).toHaveBeenCalled();
     });

--- a/packages/cli/src/__tests__/translate.test.ts
+++ b/packages/cli/src/__tests__/translate.test.ts
@@ -48,10 +48,11 @@ describe("translate command", () => {
     await executeTranslate("Hello world", {}, getProvider);
 
     expect(getProvider).toHaveBeenCalledWith(undefined);
-    expect(provider.translate).toHaveBeenCalledWith("Hello world", "auto", "es", {
+    expect(provider.translate).toHaveBeenCalledWith("Hello world", "auto", "es", expect.objectContaining({
       formality: "auto",
       dialect: "es-ES",
-    });
+      context: expect.stringContaining("do not translate literally word-by-word"),
+    }));
     expect(stdoutSpy).toHaveBeenCalledWith("Hola mundo");
   });
 
@@ -66,10 +67,11 @@ describe("translate command", () => {
     }, getProvider);
 
     expect(getProvider).toHaveBeenCalledWith("libre");
-    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", {
+    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", expect.objectContaining({
       formality: "formal",
       dialect: "es-MX",
-    });
+      context: expect.stringContaining("Mexican Spanish"),
+    }));
     expect(stdoutSpy).toHaveBeenCalledWith("[formal] Hello");
   });
 
@@ -79,10 +81,11 @@ describe("translate command", () => {
 
     await executeTranslate("Hello", { informal: true }, getProvider);
 
-    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", {
+    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", expect.objectContaining({
       formality: "informal",
       dialect: "es-ES",
-    });
+      context: expect.stringContaining("register: informal"),
+    }));
   });
 
   it("should read input from file and write output to file", async () => {

--- a/packages/cli/src/commands/translate-api-docs.ts
+++ b/packages/cli/src/commands/translate-api-docs.ts
@@ -34,6 +34,7 @@ import {
   type AdaptivePacingState,
 } from "../lib/resilient-translation.js";
 import { calculateQualityScore } from "../lib/quality-score.js";
+import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
 import {
   formatSemanticQualityError,
   resolvePolicy,
@@ -168,6 +169,12 @@ async function translateSection(
     const protectedChunk = protectTokensInText(glossaryChunk.text, mergedTokens);
     const options: TranslateOptions = {
       dialect,
+      context: buildSemanticTranslationContext({
+        text: section.content,
+        dialect,
+        documentKind: "api-docs",
+        sectionType: section.type,
+      }),
     };
     const result = await translateWithFallback(
       registry,

--- a/packages/cli/src/commands/translate-readme.ts
+++ b/packages/cli/src/commands/translate-readme.ts
@@ -51,6 +51,7 @@ import {
   type PolicyProfile,
 } from "../lib/translation-policy.js";
 import { TelemetryCollector, globalTelemetry } from "../lib/telemetry.js";
+import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
 
 interface TranslateReadmeOptions {
   dialect: string;
@@ -268,13 +269,20 @@ async function translateReadme(
       const mergedTokens = Array.from(new Set([...protectedTokens, ...runtimeTokens]));
       const protectedChunk = protectTokensInText(glossaryChunk.text, mergedTokens);
       try {
+        const semanticContext = buildSemanticTranslationContext({
+          text: section.content,
+          dialect: options.dialect as SpanishDialect,
+          formality: translateOptions.formality,
+          documentKind: "readme",
+          sectionType: section.type,
+        });
         const result = await translateWithFallback(
           registry,
           options.provider,
           protectedChunk.text,
           "en",
           "es",
-          translateOptions,
+          { ...translateOptions, context: semanticContext },
           pacing
         );
 

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -10,6 +10,7 @@ import type { SpanishDialect, ProviderName, FormalityLevel } from "@espanol/type
 import { DEFAULT_DIALECT, ALL_SPANISH_DIALECTS } from "@espanol/types";
 import { validateFilePath, validateContentLength } from "@espanol/security";
 import { writeOutput, writeError } from "../lib/output.js";
+import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
 
 /**
  * Options for the translate command
@@ -148,10 +149,18 @@ export async function executeTranslate(
     // Get translation provider
     const translationProvider = getProvider(provider);
 
+    const context = buildSemanticTranslationContext({
+      text,
+      dialect,
+      formality,
+      documentKind: "plain",
+    });
+
     // Perform translation
     const result = await translationProvider.translate(text, "auto", "es", {
       formality,
       dialect,
+      context,
     });
 
     // Write output

--- a/packages/cli/src/lib/semantic-context.ts
+++ b/packages/cli/src/lib/semantic-context.ts
@@ -1,0 +1,110 @@
+import type { SpanishDialect, FormalityLevel } from "@espanol/types";
+import { getDialectInfo } from "./dialect-info.js";
+
+export type SemanticDomain =
+  | "technical"
+  | "localization"
+  | "security"
+  | "business"
+  | "support"
+  | "marketing"
+  | "general";
+
+export type SemanticIntent =
+  | "instructional"
+  | "error-message"
+  | "reference"
+  | "promotional"
+  | "support"
+  | "general";
+
+export interface SemanticContextSignals {
+  domain: SemanticDomain;
+  intent: SemanticIntent;
+  register: FormalityLevel;
+  matchedSignals: string[];
+}
+
+export interface BuildSemanticContextOptions {
+  text: string;
+  dialect: SpanishDialect;
+  formality?: FormalityLevel;
+  documentKind?: "plain" | "readme" | "api-docs" | "i18n";
+  sectionType?: string;
+}
+
+const DOMAIN_PATTERNS: Array<{ domain: SemanticDomain; signals: RegExp[] }> = [
+  { domain: "security", signals: [/\bauth(orization|entication)?\b/i, /\btoken\b/i, /\bsecret\b/i, /\bpermission\b/i, /\bssrf\b/i, /\bxss\b/i] },
+  { domain: "localization", signals: [/\blocale\b/i, /\bi18n\b/i, /\btranslation memory\b/i, /\bglossary\b/i, /\bdialect\b/i] },
+  { domain: "technical", signals: [/\bapi\b/i, /\bendpoint\b/i, /\bcli\b/i, /\bjson\b/i, /\bmarkdown\b/i, /\bfunction\b/i, /\bserver\b/i] },
+  { domain: "business", signals: [/\binvoice\b/i, /\bbilling\b/i, /\bcontract\b/i, /\bsubscription\b/i, /\brevenue\b/i] },
+  { domain: "support", signals: [/\bhelp\b/i, /\bsupport\b/i, /\btroubleshoot\b/i, /\bcontact us\b/i, /\bissue\b/i] },
+  { domain: "marketing", signals: [/\blaunch\b/i, /\bsign up\b/i, /\btry it\b/i, /\bfeature\b/i, /\bbenefit\b/i] },
+];
+
+const INTENT_PATTERNS: Array<{ intent: SemanticIntent; signals: RegExp[] }> = [
+  { intent: "error-message", signals: [/\berror\b/i, /\bfailed\b/i, /\binvalid\b/i, /\bnot found\b/i, /\bdenied\b/i] },
+  { intent: "instructional", signals: [/\bclick\b/i, /\bselect\b/i, /\brun\b/i, /\binstall\b/i, /\bconfigure\b/i] },
+  { intent: "reference", signals: [/\bparameter\b/i, /\breturns?\b/i, /\bexample\b/i, /\bendpoint\b/i, /\bfield\b/i] },
+  { intent: "promotional", signals: [/\btry\b/i, /\bnew\b/i, /\bfast\b/i, /\bpowerful\b/i, /\bfree\b/i] },
+  { intent: "support", signals: [/\bcontact\b/i, /\bhelp\b/i, /\btroubleshoot\b/i, /\bfaq\b/i] },
+];
+
+function scorePatterns<T extends string>(
+  text: string,
+  patterns: Array<{ [key: string]: unknown; signals: RegExp[] }>,
+  key: string,
+  fallback: T
+): { value: T; matchedSignals: string[] } {
+  let best = { value: fallback, score: 0, matchedSignals: [] as string[] };
+  for (const item of patterns) {
+    const matched = item.signals.filter((pattern) => pattern.test(text)).map((pattern) => pattern.source);
+    if (matched.length > best.score) {
+      best = { value: item[key] as T, score: matched.length, matchedSignals: matched };
+    }
+  }
+  return { value: best.value as T, matchedSignals: best.matchedSignals };
+}
+
+export function analyzeSemanticContext(
+  text: string,
+  requestedFormality: FormalityLevel = "auto"
+): SemanticContextSignals {
+  const domain = scorePatterns<SemanticDomain>(text, DOMAIN_PATTERNS, "domain", "general");
+  const intent = scorePatterns<SemanticIntent>(text, INTENT_PATTERNS, "intent", "general");
+  const formalMarkers = /\b(please|dear|sincerely|policy|contract|documentation|reference)\b/i.test(text);
+  const informalMarkers = /\b(hey|cool|awesome|y'all|buddy|guys)\b/i.test(text);
+  const register = requestedFormality !== "auto"
+    ? requestedFormality
+    : formalMarkers && !informalMarkers
+      ? "formal"
+      : informalMarkers
+        ? "informal"
+        : "auto";
+
+  return {
+    domain: domain.value,
+    intent: intent.value,
+    register,
+    matchedSignals: [...domain.matchedSignals, ...intent.matchedSignals],
+  };
+}
+
+export function buildSemanticTranslationContext(options: BuildSemanticContextOptions): string {
+  const signals = analyzeSemanticContext(options.text, options.formality || "auto");
+  const dialect = getDialectInfo(options.dialect);
+  const dialectTerms = dialect
+    ? [...dialect.formalTerms.slice(0, 4), ...dialect.slangTerms.slice(0, 4)].join(", ")
+    : options.dialect;
+
+  return [
+    "Translate by preserving meaning, intent, and reader expectations; do not translate literally word-by-word.",
+    `Target dialect: ${dialect?.name || options.dialect} (${options.dialect}).`,
+    `Document domain: ${signals.domain}; intent: ${signals.intent}; register: ${signals.register}.`,
+    options.documentKind ? `Document kind: ${options.documentKind}.` : undefined,
+    options.sectionType ? `Current section type: ${options.sectionType}.` : undefined,
+    dialectTerms ? `Use regional vocabulary naturally where appropriate; examples/signals: ${dialectTerms}.` : undefined,
+    "Preserve product names, code identifiers, URLs, placeholders, markdown structure, and glossary-locked terms.",
+    "Prefer idiomatic Spanish for the target audience over one-to-one lexical substitution.",
+  ].filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- add a semantic context builder for domain, intent, register, and dialect guidance
- thread semantic context into plain text, README, and API-doc translation calls
- lock provider context behavior with CLI regression tests
- update docs to describe semantic translation workflows and verified 604-test suite

## Why
A glossary is still a dictionary. Translation providers need audience/context instructions to avoid literal word-by-word output and preserve meaning for the target dialect.

## Verification
- `pnpm --filter=@espanol/cli test -- semantic-context.test.ts`
- `pnpm --filter=@espanol/cli test -- translate.test.ts`
- `pnpm --filter=@espanol/cli test -- translate-api-docs.test.ts`
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check

## Notes
- This improves semantic provider guidance; live provider output quality with real credentials still needs evaluation.