### PR TITLE
Add dialect grammar profiles and prompt guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-604%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-608%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -50,7 +50,7 @@ Spanish is not one language — it's **25 regional variants** with different voc
 - Understanding regional differences (es-MX vs es-ES vs es-AR vs es-CO...)
 - Preserving technical document structure during translation
 - Providing glossary enforcement for consistent terminology
-- Adding semantic context and quality gates that catch drift before it reaches users
+- Adding semantic context, dialect grammar profiles, and quality gates that catch drift before it reaches users
 - Running as an MCP server so AI assistants can translate natively
 
 ---
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 604 tests passing
+pnpm test        # 608 tests passing
 ```
 
 ---
@@ -130,7 +130,7 @@ pnpm test        # 604 tests passing
 ### Translation (6 tools)
 | Tool | Description |
 |------|-------------|
-| `translate_text` | Translate with semantic domain/register/dialect context |
+| `translate_text` | Translate with semantic context plus dialect grammar profile guidance |
 | `detect_dialect` | Detect dialect from sample text |
 | `translate_code_comment` | Translate comments, preserve code |
 | `translate_readme` | Full README translation pipeline |
@@ -144,14 +144,14 @@ pnpm test        # 604 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 219 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 220 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
-| [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + canonical glossary data | 44 |
+| [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary and dialect profile data | 47 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 604 tests across 7 packages**
+**Total: 608 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        604 tests passing · BSL 1.1 · GitHub Pages
+        608 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">604</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">608</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/plans/2026-04-21-dialect-grammar-profiles.md
+++ b/docs/plans/2026-04-21-dialect-grammar-profiles.md
@@ -1,0 +1,24 @@
+# Dialect Grammar Profiles Implementation Plan
+
+**Goal:** Add source-backed grammar profiles and dialect-specific semantic prompt instructions for all 25 Spanish dialects so translation guidance is not just generic context or vocabulary replacement.
+
+**Architecture:** Add canonical dialect grammar/profile data to `@espanol/types`, export lookup helpers, and have CLI semantic context include the relevant profile guidance. Keep the system dependency-free and conservative: profile notes describe defaults and regional variation without pretending native-speaker validation has happened.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest, existing @espanol packages.
+
+---
+
+## Scope
+- 25 `DialectGrammarProfile` entries keyed by `SpanishDialect`.
+- Coverage fields: voseo, plural address, leismo/laismo/loismo notes, formality norms, taboo/ambiguity notes, and semantic prompt guidance.
+- Source references from RAE/ASALE and other broad dialect references.
+- Tests proving every dialect has source-backed profiles and key dialects expose correct guidance.
+- CLI semantic context uses the profile guidance.
+
+## Verification
+- Focused tests for dialect profiles and semantic context.
+- `pnpm build`
+- `pnpm -r exec tsc --noEmit`
+- `pnpm test`
+- `pnpm audit --audit-level low`
+- npm pack dry-run package-content check.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 604 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 608 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-604 tests. 7 packages. pnpm monorepo. TypeScript.
+608 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 604 tests
+**Tech:** TypeScript, pnpm monorepo, 608 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 604 tests passing.
+Source available, BSL 1.1 licensed, 608 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 604 tests
+**Tech stack:** TypeScript, pnpm monorepo, 608 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/semantic-context.test.ts
+++ b/packages/cli/src/__tests__/semantic-context.test.ts
@@ -29,4 +29,23 @@ describe("semantic translation context", () => {
     expect(context).toContain("Document kind: api-docs");
     expect(context).toContain("Preserve product names");
   });
+
+  it("includes deep per-dialect grammar guidance", () => {
+    const argentina = buildSemanticTranslationContext({
+      text: "Help users update their account settings.",
+      dialect: "es-AR",
+      formality: "informal",
+      documentKind: "plain",
+    });
+    expect(argentina).toContain("Use pronominal and verbal voseo");
+    expect(argentina).toContain("Use ustedes for plural address");
+
+    const spain = buildSemanticTranslationContext({
+      text: "Configure your password and account settings.",
+      dialect: "es-ES",
+      documentKind: "plain",
+    });
+    expect(spain).toContain("vosotros/vosotras");
+    expect(spain).toContain("coger is neutral in Spain");
+  });
 });

--- a/packages/cli/src/lib/semantic-context.ts
+++ b/packages/cli/src/lib/semantic-context.ts
@@ -1,4 +1,5 @@
 import type { SpanishDialect, FormalityLevel } from "@espanol/types";
+import { getDialectGrammarProfile } from "@espanol/types";
 import { getDialectInfo } from "./dialect-info.js";
 
 export type SemanticDomain =
@@ -93,9 +94,20 @@ export function analyzeSemanticContext(
 export function buildSemanticTranslationContext(options: BuildSemanticContextOptions): string {
   const signals = analyzeSemanticContext(options.text, options.formality || "auto");
   const dialect = getDialectInfo(options.dialect);
+  const grammarProfile = getDialectGrammarProfile(options.dialect);
   const dialectTerms = dialect
     ? [...dialect.formalTerms.slice(0, 4), ...dialect.slangTerms.slice(0, 4)].join(", ")
     : options.dialect;
+  const grammarGuidance = grammarProfile
+    ? [
+        grammarProfile.pluralAddress,
+        ...grammarProfile.voseo.notes.slice(0, 2),
+        ...grammarProfile.leismoLaismoLoismoNotes.slice(0, 1),
+        ...grammarProfile.formalityNorms.slice(0, 2),
+        ...grammarProfile.tabooAndAmbiguityNotes.slice(0, 2),
+        ...grammarProfile.semanticPromptGuidance,
+      ].join(" ")
+    : undefined;
 
   return [
     "Translate by preserving meaning, intent, and reader expectations; do not translate literally word-by-word.",
@@ -104,6 +116,7 @@ export function buildSemanticTranslationContext(options: BuildSemanticContextOpt
     options.documentKind ? `Document kind: ${options.documentKind}.` : undefined,
     options.sectionType ? `Current section type: ${options.sectionType}.` : undefined,
     dialectTerms ? `Use regional vocabulary naturally where appropriate; examples/signals: ${dialectTerms}.` : undefined,
+    grammarGuidance ? `Dialect grammar and style profile: ${grammarGuidance}` : undefined,
     "Preserve product names, code identifiers, URLs, placeholders, markdown structure, and glossary-locked terms.",
     "Prefer idiomatic Spanish for the target audience over one-to-one lexical substitution.",
   ].filter(Boolean).join(" ");

--- a/packages/types/src/__tests__/dialect-profiles.test.ts
+++ b/packages/types/src/__tests__/dialect-profiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { ALL_SPANISH_DIALECTS } from "../index.js";
+import {
+  DIALECT_GRAMMAR_PROFILES,
+  getDialectGrammarProfile,
+} from "../dialect-profiles.js";
+
+describe("dialect grammar profiles", () => {
+  it("covers every supported Spanish dialect with source-backed grammar guidance", () => {
+    expect(DIALECT_GRAMMAR_PROFILES).toHaveLength(ALL_SPANISH_DIALECTS.length);
+    const profileCodes = new Set(DIALECT_GRAMMAR_PROFILES.map((profile) => profile.code));
+
+    for (const code of ALL_SPANISH_DIALECTS) {
+      expect(profileCodes.has(code)).toBe(true);
+      const profile = getDialectGrammarProfile(code)!;
+      expect(profile.voseo).toBeDefined();
+      expect(profile.pluralAddress).toMatch(/ustedes|vosotros/i);
+      expect(profile.formalityNorms.length).toBeGreaterThanOrEqual(2);
+      expect(profile.tabooAndAmbiguityNotes.length).toBeGreaterThanOrEqual(2);
+      expect(profile.semanticPromptGuidance.length).toBeGreaterThanOrEqual(4);
+      expect(profile.sourceRefs.length).toBeGreaterThanOrEqual(2);
+      expect(profile.sourceRefs.every((source) => source.url.startsWith("https://"))).toBe(true);
+    }
+  });
+
+  it("distinguishes core grammar systems for high-risk dialects", () => {
+    expect(getDialectGrammarProfile("es-ES")?.pluralAddress).toContain("vosotros");
+    expect(getDialectGrammarProfile("es-MX")?.voseo.type).toBe("none");
+    expect(getDialectGrammarProfile("es-AR")?.voseo.type).toBe("dominant");
+    expect(getDialectGrammarProfile("es-UY")?.voseo.type).toBe("dominant");
+    expect(getDialectGrammarProfile("es-CL")?.voseo.type).toBe("informal");
+    expect(getDialectGrammarProfile("es-CR")?.formalityNorms.join(" ")).toMatch(/usted/i);
+  });
+
+  it("includes leismo/laismo/loismo and taboo ambiguity notes", () => {
+    expect(getDialectGrammarProfile("es-ES")?.leismoLaismoLoismoNotes.join(" ")).toMatch(/leísmo/i);
+    expect(getDialectGrammarProfile("es-MX")?.tabooAndAmbiguityNotes.join(" ")).toMatch(/coger/i);
+    expect(getDialectGrammarProfile("es-CO")?.tabooAndAmbiguityNotes.join(" ")).toMatch(/marica/i);
+  });
+});

--- a/packages/types/src/dialect-profiles.ts
+++ b/packages/types/src/dialect-profiles.ts
@@ -1,0 +1,268 @@
+import type { SpanishDialect } from "./index.js";
+
+export type VoseoType = "none" | "regional" | "informal" | "common" | "dominant";
+
+export interface DialectSourceRef {
+  label: string;
+  url: string;
+}
+
+export interface DialectGrammarProfile {
+  code: SpanishDialect;
+  pluralAddress: string;
+  voseo: {
+    type: VoseoType;
+    notes: string[];
+  };
+  leismoLaismoLoismoNotes: string[];
+  formalityNorms: string[];
+  tabooAndAmbiguityNotes: string[];
+  semanticPromptGuidance: string[];
+  sourceRefs: DialectSourceRef[];
+}
+
+const RAE_VOSEO = {
+  label: "RAE/ASALE Nueva gramática: variantes del voseo",
+  url: "https://www.rae.es/gram%C3%A1tica/morfolog%C3%ADa/la-conjugaci%C3%B3n-regular-ii-las-variantes-del-voseo",
+};
+const RAE_LEISMO = {
+  label: "RAE/ASALE: leísmo, laísmo y loísmo",
+  url: "https://www.rae.es/buen-uso-espa%C3%B1ol/le%C3%ADsmo-la%C3%ADsmo-y-lo%C3%ADsmo",
+};
+const DPD = {
+  label: "RAE/ASALE Diccionario panhispánico de dudas",
+  url: "https://www.asale.org/obras-academicas/diccionarios/diccionario-panhispanico-de-dudas-0",
+};
+const DLE = {
+  label: "ASALE Diccionario de americanismos",
+  url: "https://www.asale.org/damer/",
+};
+const NGLE = {
+  label: "RAE/ASALE Nueva gramática de la lengua española",
+  url: "https://www.rae.es/gram%C3%A1tica/",
+};
+
+function profile(
+  code: SpanishDialect,
+  partial: Omit<DialectGrammarProfile, "code" | "sourceRefs"> & { sourceRefs?: DialectSourceRef[] }
+): DialectGrammarProfile {
+  return {
+    code,
+    ...partial,
+    sourceRefs: partial.sourceRefs || [DPD, RAE_VOSEO, RAE_LEISMO],
+  };
+}
+
+const AMERICA_PRONOUN_NOTE = "Use ustedes for all second-person plural contexts; do not generate vosotros forms unless quoting Spain-specific content.";
+const DEFAULT_CLITIC_NOTE = "Prefer standard lo/la/le clitic distinctions in neutral formal output; avoid introducing leísmo, laísmo, or loísmo unless the source explicitly requires it.";
+const DEFAULT_FORMALITY = [
+  "Use tú/vos only for clearly informal copy; use usted for formal support, legal, business, or public-service text.",
+  "When register is ambiguous, prefer a respectful neutral tone rather than slang-heavy localization.",
+];
+
+export const DIALECT_GRAMMAR_PROFILES: DialectGrammarProfile[] = [
+  profile("es-ES", {
+    pluralAddress: "Use vosotros/vosotras for informal plural in most Peninsular contexts; use ustedes for formal plural or Canary/Andalusian-influenced contexts.",
+    voseo: { type: "none", notes: ["Do not use American voseo for Spain-oriented output.", "Use tú for singular informal address."] },
+    leismoLaismoLoismoNotes: ["Limited person-masculine leísmo is accepted in parts of central/northern Spain, but avoid laísmo/loísmo in educated neutral output.", "Default to standard lo/la/le unless a regional Peninsular style is explicitly requested."],
+    formalityNorms: ["Use tú/vosotros for informal product copy.", "Use usted/ustedes for formal, legal, medical, or public-administration copy."],
+    tabooAndAmbiguityNotes: ["coger is neutral in Spain; do not over-avoid it for Peninsular output.", "Avoid American slang such as güey, parce, boludo, or chévere unless quoting."],
+    semanticPromptGuidance: ["Preserve Peninsular address contrast between tú/vosotros and usted/ustedes.", "Prefer idiomatic Spain vocabulary such as ordenador, móvil, coche, vale only where natural.", "Keep formal documentation precise and not slangy.", "Do not Latin-Americanize grammar or plural address."],
+  }),
+  profile("es-MX", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["Mainstream Mexican Spanish is tuteante; do not use vos/voseo in standard Mexican output.", "Use tú for informal singular and usted for formal or respectful singular."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Do not introduce Spain-style leísmo as a dialect feature."],
+    formalityNorms: ["Use usted in formal customer support, public service, and business flows.", "Use tú for consumer UI when the brand voice is casual."],
+    tabooAndAmbiguityNotes: ["coger is often sexual/vulgar in Mexico; prefer tomar, agarrar, recoger, or elegir according to meaning.", "madre/padre expressions are highly context-sensitive; avoid slang unless the audience and register are explicit."],
+    semanticPromptGuidance: ["Use Mexican vocabulary naturally, not just literal replacements.", "Avoid vos and vosotros entirely in generated copy.", "Resolve ambiguous coger based on intent rather than translating it literally.", "Keep business/support tone warm but respectful."],
+  }),
+  profile("es-AR", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "dominant", notes: ["Use pronominal and verbal voseo for informal Argentine/Rioplatense copy: vos tenés, vos podés, vos querés.", "Use tú only when source/audience explicitly requires non-Rioplatense neutrality."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Do not import Peninsular leísmo into neutral Argentine output."],
+    formalityNorms: ["Use vos for informal/product copy.", "Use usted for formal institutional, legal, medical, or high-stakes support text."],
+    tabooAndAmbiguityNotes: ["boludo can be friendly or insulting depending on relationship; avoid in formal or unknown-audience output.", "Concha and coger are vulgar/sexual in Argentina; disambiguate intent before rendering."],
+    semanticPromptGuidance: ["For informal Argentine output, preserve voseo morphology naturally.", "Use ustedes for plural address.", "Avoid overusing che/boludo unless clearly casual and safe.", "Favor Rioplatense idiom while preserving source intent."],
+  }),
+  profile("es-CO", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Voseo is regional, especially in areas such as Antioquia/Valle; do not use it as the default for national Colombian copy.", "Tú and usted coexist; usted is frequent beyond strictly formal contexts."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Avoid leísmo/laísmo/loísmo as generated dialect markers."],
+    formalityNorms: ["Use usted for respectful support/business copy unless a youthful casual voice is requested.", "Use tú for broadly neutral consumer copy; reserve vos for explicitly regional/Paisa/Vallecaucano flavor."],
+    tabooAndAmbiguityNotes: ["marica/parce can be friendly or offensive depending on region and relationship; avoid in formal/unknown-audience text.", "coger can be acceptable in some senses but prefer tomar/agarrar/recoger when ambiguity is possible."],
+    semanticPromptGuidance: ["Default to nationally intelligible Colombian Spanish, not heavy slang.", "Respect the tú/usted distinction; do not force voseo unless regional intent is explicit.", "Use Colombian vocabulary like computador/carro/esfero when natural.", "Avoid slang terms that may be insulting without context."],
+  }),
+  profile("es-CU", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["Cuban Spanish is tuteante in ordinary informal singular address.", "Do not generate voseo for Cuban output."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Use standard clitics for formal written output."],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["asere/socio are colloquial and relationship-dependent; avoid in professional output.", "yuma and socio can carry social nuance; do not literalize without context."],
+    semanticPromptGuidance: ["Use Caribbean/Cuban flavor only when the register permits it.", "Keep technical/support copy clear and neutral.", "Use ustedes for plural address.", "Avoid voseo and Peninsular vosotros."],
+  }),
+  profile("es-PE", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Peruvian Spanish is tuteante in most national contexts; voseo appears sporadically in border/northern/southern areas.", "Do not default to voseo for national Peruvian output."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Avoid making clitic deviations a Peruvian style marker."],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["pata/causa are colloquial; avoid in formal copy.", "cholo can be identity, affectionate, or offensive depending on context; avoid unless source clearly intends it."],
+    semanticPromptGuidance: ["Default to neutral Peruvian Spanish with ustedes plural.", "Do not force slang like causa/pata into formal text.", "Use regional vocabulary only where it preserves audience fit.", "Preserve technical meaning over lexical flavor."],
+  }),
+  profile("es-CL", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "informal", notes: ["Chilean voseo is highly informal and often mixed with tú; use only for explicitly casual Chilean voice.", "For neutral/formal output use tú/usted, not heavy voseo."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Do not introduce Peninsular clitic patterns."],
+    formalityNorms: ["Use usted for formal/service contexts.", "Use tú for neutral informal; use voseo/po/cachái only in clearly colloquial copy."],
+    tabooAndAmbiguityNotes: ["weón/wea can be friendly or offensive; avoid outside intentionally colloquial content.", "coger is not the safest general choice; prefer tomar/agarrar/recoger by meaning."],
+    semanticPromptGuidance: ["Keep Chilean output comprehensible; do not overload with slang.", "Use cachái/po/weón only when the requested register is very informal.", "Use ustedes for plural address.", "Preserve formal clarity in support/legal/technical text."],
+  }),
+  profile("es-VE", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Voseo is regional, notably in western/Zulia usage; do not use as national default.", "Default to tú/usted unless a regional western Venezuelan voice is requested."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["arrecho can mean angry, difficult, or impressive depending on context; avoid in formal copy.", "marico/marica can be offensive; avoid unless clearly quoted/colloquial."],
+    semanticPromptGuidance: ["Use Venezuelan vocabulary naturally but keep formal content neutral.", "Do not default to voseo nationally.", "Use ustedes plural.", "Disambiguate emotionally loaded slang before rendering."],
+  }),
+  profile("es-UY", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "dominant", notes: ["Uruguayan/Rioplatense informal address commonly uses vos with voseo morphology.", "Use tú only for pan-regional neutrality or explicit source constraints."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use vos for informal local voice.", "Use usted in formal business, government, legal, or medical copy."],
+    tabooAndAmbiguityNotes: ["bo/ta are colloquial markers; avoid in formal output.", "boludo can be friendly or insulting; avoid unless context is safe."],
+    semanticPromptGuidance: ["Use natural Uruguayan/Rioplatense voseo for informal audience fit.", "Use ustedes for plural address.", "Keep formal text neutral and precise.", "Do not overstuff copy with bo/ta slang."],
+  }),
+  profile("es-PY", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "common", notes: ["Paraguayan Spanish commonly uses vos in informal contexts, alongside influence from Guaraní/Jopara.", "Use usted for formal/respectful contexts."] },
+    leismoLaismoLoismoNotes: ["RAE notes Paraguayan le usage can be influenced by Guaraní; for broad formal output still preserve standard lo/la/le distinctions.", "Do not introduce nonstandard clitics unless representing local speech intentionally."],
+    formalityNorms: ["Use vos for informal local voice; use usted for formal and respectful contexts.", "Avoid Jopara-heavy phrasing unless explicitly requested."],
+    tabooAndAmbiguityNotes: ["al pedo and similar expressions are colloquial/vulgar; avoid in formal copy.", "Guaraní/Jopara insertions require audience certainty."],
+    semanticPromptGuidance: ["Allow vos for informal Paraguayan voice, but keep formal text standard.", "Use ustedes plural.", "Avoid unrequested Guaraní/Jopara mixing.", "Preserve standard clitic usage in formal documentation."],
+  }),
+  profile("es-BO", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Bolivian Spanish has regional voseo, but national neutral output should not assume it.", "Use tú/usted unless a voseante region/register is requested."] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["cholo/cholita can be identity or sensitive; handle respectfully.", "Regional indigenous-language terms should not be inserted without audience context."],
+    semanticPromptGuidance: ["Default to clear Bolivian Spanish with respectful tone.", "Do not force voseo or indigenous-language markers.", "Use ustedes plural.", "Treat identity terms carefully."],
+  }),
+  profile("es-EC", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Ecuadorian Spanish is broadly tuteante/ustedeante; voseo can occur regionally but is not the national default.", "Use tú/usted for general output." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["chucha and related terms can be vulgar; avoid in formal copy.", "longo can be sensitive/offensive; avoid unless source intent is clear."],
+    semanticPromptGuidance: ["Use neutral Ecuadorian vocabulary and respectful tone.", "Avoid regional slang unless register is explicit.", "Use ustedes plural.", "Do not default to voseo."],
+  }),
+  profile("es-GT", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "common", notes: ["Guatemalan Spanish commonly uses vos in informal/familiar contexts, often alongside tú and usted.", "Use usted for formal or respectful address." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use vos only when an informal local voice is intended.", "Use usted for public-facing, formal, or respectful support copy."],
+    tabooAndAmbiguityNotes: ["cerote/culero can be offensive; avoid unless quoted or explicitly requested.", "pisto is colloquial for money; avoid in formal financial copy unless audience fit is explicit."],
+    semanticPromptGuidance: ["Use vos for informal Guatemalan voice when appropriate.", "Use usted for respectful/formal contexts.", "Use ustedes plural.", "Avoid strong slang in broad-audience copy."],
+  }),
+  profile("es-HN", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "common", notes: ["Honduran Spanish commonly permits vos in informal contexts.", "Use usted for formal/respectful contexts." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["maje can be friendly or insulting; avoid in formal or unknown-audience output.", "Regional slang should be used sparingly and intentionally."],
+    semanticPromptGuidance: ["Use vos only for informal Honduran audience fit.", "Use usted for formal support/business copy.", "Use ustedes plural.", "Keep technical text neutral and clear."],
+  }),
+  profile("es-SV", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "dominant", notes: ["Salvadoran Spanish strongly uses vos in informal/familiar contexts.", "Use usted for formal, respectful, and many service contexts." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use vos for informal local voice.", "Use usted for formal/support/legal copy."],
+    tabooAndAmbiguityNotes: ["cerote/maje can be offensive; avoid unless clearly colloquial and safe.", "bicho is regional but can be informal; avoid in formal child/user references."],
+    semanticPromptGuidance: ["Use Salvadoran voseo for informal copy when appropriate.", "Use usted for respectful and formal contexts.", "Use ustedes plural.", "Avoid strong slang in broad public copy."],
+  }),
+  profile("es-NI", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "dominant", notes: ["Nicaraguan Spanish commonly uses vos in informal contexts.", "Use usted for formal or respectful address." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["maje and related slang can be insulting; avoid in formal copy.", "Regional slang requires clear audience fit."],
+    semanticPromptGuidance: ["Use vos for informal Nicaraguan voice when requested.", "Use usted for formal/support text.", "Use ustedes plural.", "Keep technical text neutral and not slang-heavy."],
+  }),
+  profile("es-CR", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "common", notes: ["Costa Rican Spanish uses usted very broadly and vos in many informal contexts; tú is less central.", "Do not over-tutear Costa Rican output." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Usted is common even beyond highly formal contexts; it is safe for support and product UI.", "Vos can signal informal/local familiarity; use only when the requested voice is casual."],
+    tabooAndAmbiguityNotes: ["mae is colloquial; avoid in formal copy.", "pura vida is iconic but can sound forced in serious contexts."],
+    semanticPromptGuidance: ["Prefer usted for respectful Costa Rican UX/support copy.", "Use vos only for explicitly informal/local voice.", "Use ustedes plural.", "Avoid forced pura vida/mae branding unless requested."],
+  }),
+  profile("es-PA", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["Panamanian national output should default to tú/usted, not voseo.", "Use ustedes for plural address." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["cueco/chombo and related terms can be sensitive or offensive; avoid unless source intent is explicit.", "yeyé is social-label slang; avoid in neutral product copy."],
+    semanticPromptGuidance: ["Use neutral Panamanian Spanish with tú/usted as appropriate.", "Do not default to voseo.", "Use ustedes plural.", "Keep Caribbean/Central American slang restrained."],
+  }),
+  profile("es-DO", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["Dominican Spanish is tuteante; do not generate voseo.", "Use usted for formal and respectful contexts." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["tiguere/vaina are informal and context-sensitive; avoid in formal output.", "que lo que is very casual; do not use in broad professional copy."],
+    semanticPromptGuidance: ["Use Dominican flavor only when casual register is explicit.", "Use tú/usted and ustedes; no voseo/vosotros.", "Keep support/legal/technical copy standard and clear.", "Avoid heavy phonetic or slang representation."],
+  }),
+  profile("es-PR", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["Puerto Rican Spanish is tuteante; do not generate voseo.", "Use usted for formal/respectful contexts." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: DEFAULT_FORMALITY,
+    tabooAndAmbiguityNotes: ["cabrón can be friendly or highly offensive; avoid unless audience/context is explicit.", "Spanglish/English borrowings can be natural but should not be overinserted."],
+    semanticPromptGuidance: ["Use Puerto Rican vocabulary naturally without caricature.", "Use tú/usted and ustedes; avoid vos/vosotros.", "Allow common tech/business English terms only where audience-appropriate.", "Avoid strong slang in formal copy."],
+  }),
+  profile("es-GQ", {
+    pluralAddress: "Use neutral standard plural address; preserve vosotros only when a Peninsular-style context explicitly calls for it, otherwise ustedes is broadly intelligible.",
+    voseo: { type: "none", notes: ["Do not use American voseo for Equatoguinean Spanish.", "Use tú/usted according to formality." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE, "Avoid importing central-Spain leísmo/laísmo as a dialect marker."],
+    formalityNorms: ["Use formal neutral Spanish for public/institutional content.", "Use local lexical flavor sparingly and only when context supports it."],
+    tabooAndAmbiguityNotes: ["Do not invent Africanisms or Chavacano-like forms.", "Use Equatoguinean place/culture terms only when sourced by the input."],
+    semanticPromptGuidance: ["Use conservative standard Spanish with Equatoguinean awareness.", "Avoid American voseo and slang.", "Do not over-Peninsularize unless requested.", "Keep formal/institutional tone precise."],
+  }),
+  profile("es-US", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "none", notes: ["U.S. Spanish is heterogeneous but standard public copy should not default to voseo.", "Use tú/usted depending on audience and formality." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use clear, pan-Hispanic U.S. Spanish for public service and support.", "Allow common U.S. institutional terms and English proper nouns; avoid unnecessary Spanglish."],
+    tabooAndAmbiguityNotes: ["Spanglish may be natural for some audiences but can alienate others; use only when requested.", "Avoid regional slang that privileges one heritage community unless targeted."],
+    semanticPromptGuidance: ["Use accessible U.S. Spanish suitable for diverse heritage audiences.", "Preserve English proper nouns, agencies, product names, and legal terms where expected.", "Use ustedes plural; avoid vos/vosotros.", "Prefer clarity over localized slang."],
+  }),
+  profile("es-PH", {
+    pluralAddress: "Use conservative standard Spanish address; use ustedes for plural address unless the source explicitly asks for Chavacano/historical Philippine flavor.",
+    voseo: { type: "none", notes: ["Do not use American voseo for Philippine Spanish.", "Avoid inventing Chavacano forms in ordinary Spanish translation." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use formal neutral Spanish for institutional/historical content.", "Only introduce Chavacano-like signals when explicitly requested and source-supported."],
+    tabooAndAmbiguityNotes: ["Philippine Spanish/Chavacano identity is sensitive; do not fabricate creole forms.", "Spanish is not a general everyday national language; avoid overlocalizing assumptions."],
+    semanticPromptGuidance: ["Use conservative, intelligible Spanish unless Chavacano is explicitly requested.", "Do not default to Latin American slang or voseo.", "Preserve Philippine names and cultural terms.", "Keep technical/support text neutral."],
+  }),
+  profile("es-BZ", {
+    pluralAddress: AMERICA_PRONOUN_NOTE,
+    voseo: { type: "regional", notes: ["Belizean Spanish sits in contact with Central American and Caribbean varieties; do not assume voseo unless audience/register supports it.", "Use tú/usted for general output." ] },
+    leismoLaismoLoismoNotes: [DEFAULT_CLITIC_NOTE],
+    formalityNorms: ["Use clear neutral Spanish for public/service content.", "Do not overmix Kriol/English unless explicitly requested."],
+    tabooAndAmbiguityNotes: ["Kriol/English code-switching may be natural for some audiences but should not be fabricated.", "Ethnonyms and identity terms require respectful context."],
+    semanticPromptGuidance: ["Use Belize-aware neutral Spanish with Central American/Caribbean sensitivity.", "Use ustedes plural.", "Avoid unrequested Kriol/English mixing.", "Use regional vocabulary sparingly and only when meaning is clear."],
+  }),
+  profile("es-AD", {
+    pluralAddress: "Use Peninsular-style tú/vosotros for informal Spanish in Andorran contexts; use usted/ustedes for formal address.",
+    voseo: { type: "none", notes: ["Do not use American voseo for Andorran Spanish.", "Catalan contact may affect local context, but generated Spanish should remain grammatical Spanish." ] },
+    leismoLaismoLoismoNotes: ["Avoid leísmo/laísmo/loísmo unless representing a specific Peninsular speaker style.", "Default to standard lo/la/le in formal copy."],
+    formalityNorms: ["Use tú/vosotros for informal local/Spain-adjacent content.", "Use usted/ustedes for institutional, legal, tourism, and official copy."],
+    tabooAndAmbiguityNotes: ["Do not insert Catalan words unless source/context requires them.", "Avoid Latin American vocabulary defaults for Andorran audience."],
+    semanticPromptGuidance: ["Use Spain-adjacent grammar and plural address for Andorran Spanish.", "Respect Catalan names/institutions without code-mixing unnecessarily.", "Avoid American voseo/slang.", "Keep tourism/institutional copy polished and formal where appropriate."],
+  }),
+];
+
+export function getDialectGrammarProfile(code: SpanishDialect): DialectGrammarProfile | undefined {
+  return DIALECT_GRAMMAR_PROFILES.find((profile) => profile.code === code);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -380,3 +380,5 @@ export const translationRequestSchema = z.object({
 export const batchTargetsSchema = z.array(dialectSchema).min(1, "At least one target dialect is required").max(25, "Cannot exceed 25 target dialects");
 
 export * from "./glossary-data.js";
+
+export * from "./dialect-profiles.js";


### PR DESCRIPTION
## Summary
- add source-backed grammar profiles for all 25 Spanish dialects
- cover voseo, plural address, clitic cautions, formality norms, taboo/ambiguity notes, and semantic prompt guidance
- include dialect profile guidance in semantic provider context
- add regression tests for full dialect coverage and key grammar distinctions
- update docs to reflect dialect grammar profile support and 608 verified tests

## Why
The semantic context layer cannot rely on keyword lists alone. Dialect quality needs grammar, formality, and social-risk guidance so translation providers avoid literal or socially wrong output.

## Verification
- `pnpm --filter=@espanol/types test -- dialect-profiles.test.ts`
- `pnpm --filter=@espanol/cli test -- semantic-context.test.ts`
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check

## Notes
- Profiles are conservative and source-backed. They are not a substitute for native-speaker review or a gold evaluation corpus.