### PR TITLE
Add dialect evaluation harness fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-612%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-618%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 612 tests passing
+pnpm test        # 618 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 612 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 221 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 227 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 612 tests across 7 packages**
+**Total: 618 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        612 tests passing · BSL 1.1 · GitHub Pages
+        618 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">612</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">618</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/plans/2026-04-21-dialect-evaluation-harness.md
+++ b/docs/plans/2026-04-21-dialect-evaluation-harness.md
@@ -1,0 +1,16 @@
+# Dialect Evaluation Harness Implementation Plan
+
+**Goal:** Add deterministic evaluation fixtures and tests that prove dialect prompts/contracts avoid obvious grammar, register, and taboo mistakes before live provider dogfooding.
+
+**Architecture:** Add JSON fixtures for initial dialects (`es-PA`, `es-PR`, `es-MX`, `es-AR`, `es-ES`) plus a test helper that validates semantic context against required/forbidden prompt traits. This is not native output scoring yet; it is a release gate ensuring the prompt and contracts carry the right constraints.
+
+**Tech Stack:** TypeScript, Vitest, JSON fixtures.
+
+---
+
+## Tasks
+1. Add fixture schema/types for dialect eval samples.
+2. Add fixtures for Panama, Puerto Rico, Mexico, Argentina, Spain.
+3. Add tests that verify context includes required traits and excludes forbidden prompt traits.
+4. Add docs for native review fixtures and future provider dogfood.
+5. Run build, typecheck, tests, audit, and pack checks.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 612 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 618 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-612 tests. 7 packages. pnpm monorepo. TypeScript.
+618 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 612 tests
+**Tech:** TypeScript, pnpm monorepo, 618 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 612 tests passing.
+Source available, BSL 1.1 licensed, 618 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 612 tests
+**Tech stack:** TypeScript, pnpm monorepo, 618 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/docs/validation/es-PA-native-review.md
+++ b/docs/validation/es-PA-native-review.md
@@ -1,0 +1,17 @@
+# Native Review Queue: es-PA Panama
+
+Use this file to record native-speaker judgments. The automated harness only checks prompt/profile constraints; it does not replace human review.
+
+## Review rubric
+- Natural
+- Acceptable but neutral
+- Wrong
+- Cringe/forced
+- Offensive/unsafe
+
+## Initial focus areas
+- Transit and public services
+- Support/security tone
+- Casual product UI
+- English borrowings
+- Sensitive terms: cueco, chombo, yeyé

--- a/docs/validation/es-PR-native-review.md
+++ b/docs/validation/es-PR-native-review.md
@@ -1,0 +1,17 @@
+# Native Review Queue: es-PR Puerto Rico
+
+Use this file to record native-speaker judgments. The automated harness only checks prompt/profile constraints; it does not replace human review.
+
+## Review rubric
+- Natural
+- Acceptable but neutral
+- Wrong
+- Cringe/forced
+- Offensive/unsafe
+
+## Initial focus areas
+- Transit terms such as guagua
+- Support/security tone
+- Casual product UI
+- English borrowings
+- Sensitive terms: cabrón, bicho, puñeta

--- a/packages/cli/src/__tests__/dialect-eval.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { SpanishDialect, FormalityLevel } from "@espanol/types";
+import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
+
+interface DialectEvalSample {
+  id: string;
+  source: string;
+  domain: string;
+  register: FormalityLevel;
+  documentKind: "plain" | "readme" | "api-docs" | "i18n";
+  requiredContext: string[];
+  forbiddenContext: string[];
+  forbiddenOutputTerms: string[];
+  notes: string;
+}
+
+const fixtureDir = join(import.meta.dirname, "fixtures", "dialect-eval");
+
+function loadFixture(file: string): { dialect: SpanishDialect; samples: DialectEvalSample[] } {
+  const dialect = file.replace(/\.json$/, "") as SpanishDialect;
+  const samples = JSON.parse(readFileSync(join(fixtureDir, file), "utf-8")) as DialectEvalSample[];
+  return { dialect, samples };
+}
+
+describe("dialect evaluation harness", () => {
+  const fixtures = readdirSync(fixtureDir).filter((file) => file.endsWith(".json"));
+
+  it("has launch fixtures for the initial high-value dialect set", () => {
+    expect(fixtures.sort()).toEqual(["es-AR.json", "es-ES.json", "es-MX.json", "es-PA.json", "es-PR.json"]);
+  });
+
+  for (const file of fixtures) {
+    const { dialect, samples } = loadFixture(file);
+
+    it(`${dialect} semantic context satisfies eval fixture constraints`, () => {
+      expect(samples.length).toBeGreaterThan(0);
+      for (const sample of samples) {
+        const context = buildSemanticTranslationContext({
+          text: sample.source,
+          dialect,
+          formality: sample.register,
+          documentKind: sample.documentKind,
+        });
+
+        for (const required of sample.requiredContext) {
+          expect(context, `${sample.id} missing ${required}`).toContain(required);
+        }
+        for (const forbidden of sample.forbiddenContext) {
+          expect(context, `${sample.id} should not contain ${forbidden}`).not.toContain(forbidden);
+        }
+        expect(sample.forbiddenOutputTerms.length).toBeGreaterThan(0);
+        expect(sample.notes.length).toBeGreaterThan(10);
+      }
+    });
+  }
+});

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-AR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-AR.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "ar-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Argentine Spanish",
+      "Use pronominal and verbal voseo",
+      "Use ustedes for plural address",
+      "boludo"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros"
+    ],
+    "notes": "Informal Argentine output should preserve voseo but avoid unsafe slang unless requested."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-ES.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-ES.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "es-plural-address",
+    "source": "You can all update your passwords now.",
+    "domain": "security",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Peninsular Spanish",
+      "vosotros/vosotras",
+      "coger is neutral in Spain",
+      "address contrast"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "güey",
+      "parce",
+      "boludo"
+    ],
+    "notes": "Spain can use vosotros and should not get Latin American slang."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "mx-ambiguous-coger",
+    "source": "Pick up the file before deployment.",
+    "domain": "technical",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Mexican Spanish",
+      "Avoid literal coger",
+      "prefer-neutral-alternative",
+      "Localize grammar"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "coger",
+      "vos",
+      "vosotros"
+    ],
+    "notes": "Mexico should avoid literal coger for pick up/take."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PA.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PA.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "pa-transit-neutral",
+    "source": "Take the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Panamanian",
+      "Use neutral Panamanian Spanish",
+      "Use ustedes plural",
+      "avoid-by-default",
+      "prefer-neutral-alternative"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "cueco",
+      "chombo",
+      "yeyé"
+    ],
+    "notes": "Panama should default to bus/tomar-style neutral wording, not voseo or sensitive slang."
+  },
+  {
+    "id": "pa-support-formal",
+    "source": "Please update your password before continuing.",
+    "domain": "security",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Use usted",
+      "respectful",
+      "never-unless-requested"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "cueco",
+      "chombo",
+      "yeyé"
+    ],
+    "notes": "Support/security copy should be respectful and neutral."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "pr-transit-neutral",
+    "source": "Take the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Puerto Rican",
+      "Use Puerto Rican vocabulary naturally",
+      "Use tú/usted and ustedes",
+      "avoid-by-default",
+      "never-unless-requested"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "cabrón",
+      "bicho",
+      "puñeta"
+    ],
+    "notes": "PR can use guagua in the right context, but strong slang must not be introduced by default."
+  },
+  {
+    "id": "pr-support-formal",
+    "source": "Contact support if the payment fails.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "formal",
+      "support",
+      "Avoid strong slang",
+      "never-unless-requested"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "cabrón",
+      "bicho",
+      "puñeta"
+    ],
+    "notes": "Formal PR support copy should avoid slang."
+  }
+]


### PR DESCRIPTION
## Summary
- add deterministic dialect evaluation fixtures for es-PA, es-PR, es-MX, es-AR, and es-ES
- add a CLI test harness that verifies semantic context carries required profile/safety traits
- record forbidden output terms for future provider-output scoring
- add native-review queues for Panama and Puerto Rico
- update docs/test count to 618 verified tests

## Why
The product needs automated release gates before humans or live providers are involved. This gives us stable fixtures for dialect grammar, register, and slang safety expectations.

## Verification
- `pnpm --filter=@espanol/cli test -- dialect-eval.test.ts`
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check

## Notes
- This validates context/profile constraints, not actual live provider output yet. Next step is provider dogfood against these fixtures.