### PR TITLE
Add provider dogfood dialect eval script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage/
 
 # OMX runtime state
 .omx/
+
+# Dialect eval generated artifacts
+audits/dialect-eval-*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-618%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-619%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 618 tests passing
+pnpm test        # 619 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 618 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 227 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 228 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 618 tests across 7 packages**
+**Total: 619 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        618 tests passing · BSL 1.1 · GitHub Pages
+        619 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">618</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">619</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/plans/2026-04-21-provider-dogfood-eval.md
+++ b/docs/plans/2026-04-21-provider-dogfood-eval.md
@@ -1,0 +1,15 @@
+# Provider Dogfood Dialect Eval Implementation Plan
+
+**Goal:** Run dialect-eval fixtures through provider-like translation outputs and produce audit artifacts that score forbidden terms, context propagation, and provider output readiness.
+
+**Architecture:** Add a dependency-free `scripts/dialect-eval.mjs` harness. It loads existing fixture JSON, builds deterministic mock-provider outputs by default for CI/offline use, validates forbidden output terms, records semantic context presence, and writes timestamped artifacts under `audits/dialect-eval-*`. Real providers can be added later without changing fixture format.
+
+**Tech Stack:** Node ESM script, JSON fixtures, Vitest smoke test via CLI script execution.
+
+---
+
+## Tasks
+1. Add script and npm command.
+2. Add script-level tests/smoke via a fixture output artifact command.
+3. Ensure artifacts are deterministic enough for CI but ignored unless explicitly committed.
+4. Run build, typecheck, tests, audit, pack checks.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 618 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 619 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-618 tests. 7 packages. pnpm monorepo. TypeScript.
+619 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 618 tests
+**Tech:** TypeScript, pnpm monorepo, 619 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 618 tests passing.
+Source available, BSL 1.1 licensed, 619 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 618 tests
+**Tech stack:** TypeScript, pnpm monorepo, 619 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "dialectos",
   "version": "0.1.0",
   "private": true,
-  "description": "DialectOS — Spanish dialect translation server (MCP + CLI)",
+  "description": "DialectOS \u2014 Spanish dialect translation server (MCP + CLI)",
   "type": "module",
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
-    "clean": "pnpm -r clean"
+    "clean": "pnpm -r clean",
+    "dialect:eval": "node scripts/dialect-eval.mjs"
   },
   "keywords": [
     "spanish",

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("dialect eval script", () => {
+  it("scores fixture outputs and writes an audit artifact", () => {
+    const outDir = join(tmpdir(), `dialect-eval-script-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    execFileSync("node", [
+      "scripts/dialect-eval.mjs",
+      `--out=${outDir}`,
+      "--dialects=es-PA,es-PR,es-MX,es-AR,es-ES",
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
+
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      total: number;
+      passed: number;
+      failed: number;
+      results: Array<{ fixture: string; passes: boolean; output: string }>;
+    };
+
+    expect(results.total).toBeGreaterThanOrEqual(7);
+    expect(results.failed).toBe(0);
+    expect(results.passed).toBe(results.total);
+    expect(results.results.some((result) => result.fixture === "pa-transit-neutral")).toBe(true);
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+});

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const args = new Map();
+for (const arg of process.argv.slice(2)) {
+  const [key, value = ""] = arg.replace(/^--/, "").split("=");
+  args.set(key, value || "true");
+}
+
+const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/dialect-eval";
+const outDir = args.get("out") || `audits/dialect-eval-${new Date().toISOString().slice(0, 10)}`;
+const provider = args.get("provider") || "mock-semantic";
+const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
+
+function mockTranslate(source, dialect) {
+  const safe = source
+    .replace(/\bTake\b/i, dialect === "es-PR" ? "Toma" : "Toma")
+    .replace(/\bbus\b/i, dialect === "es-PR" ? "guagua" : "bus")
+    .replace(/\boffice\b/i, "oficina")
+    .replace(/\bpassword\b/i, "contraseña")
+    .replace(/\baccount settings\b/i, "configuración de la cuenta")
+    .replace(/\bContact support\b/i, "Contacta a soporte")
+    .replace(/\bpayment fails\b/i, "pago falla")
+    .replace(/\bPick up\b/i, "Recoge")
+    .replace(/\bfile\b/i, "archivo")
+    .replace(/\bdeployment\b/i, "despliegue")
+    .replace(/\bYou can update\b/i, dialect === "es-AR" ? "Vos podés actualizar" : "Puedes actualizar")
+    .replace(/\byour account now\b/i, "tu cuenta ahora")
+    .replace(/\bYou can all update\b/i, dialect === "es-ES" ? "Vosotros podéis actualizar" : "Ustedes pueden actualizar")
+    .replace(/\byour passwords now\b/i, "vuestras contraseñas ahora");
+  return safe;
+}
+
+function evaluate(sample, dialect) {
+  const output = mockTranslate(sample.source, dialect);
+  const failures = [];
+  const warnings = [];
+
+  for (const term of sample.forbiddenOutputTerms || []) {
+    const re = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\b`, "i");
+    if (re.test(output)) {
+      failures.push(`Forbidden output term present: ${term}`);
+    }
+  }
+
+  if (!sample.requiredContext?.length) {
+    warnings.push("No requiredContext assertions recorded");
+  }
+  if (!sample.notes || sample.notes.length < 10) {
+    warnings.push("Fixture lacks useful notes");
+  }
+
+  return {
+    dialect,
+    fixture: sample.id,
+    provider,
+    source: sample.source,
+    output,
+    passes: failures.length === 0,
+    failures,
+    warnings,
+  };
+}
+
+const results = [];
+for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort()) {
+  const dialect = basename(file, ".json");
+  if (dialectFilter.size > 0 && !dialectFilter.has(dialect)) continue;
+  const samples = JSON.parse(readFileSync(join(fixtureDir, file), "utf-8"));
+  for (const sample of samples) {
+    results.push(evaluate(sample, dialect));
+  }
+}
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  provider,
+  fixtureDir,
+  total: results.length,
+  passed: results.filter((r) => r.passes).length,
+  failed: results.filter((r) => !r.passes).length,
+  results,
+};
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(join(outDir, "results.json"), `${JSON.stringify(summary, null, 2)}\n`);
+console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed }, null, 2));
+
+if (summary.failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `pnpm dialect:eval` script for running dialect eval fixtures through deterministic provider-like outputs
- write JSON audit artifacts with source, output, pass/fail, warnings, and forbidden-term failures
- add CLI smoke test for the script and generated artifact shape
- ignore generated dialect eval audit directories by default
- update docs to 619 verified tests

## Why
We need an executable dogfood path before live provider evaluation. This script makes the fixture format operational and gives future real-provider scoring a stable artifact shape.

## Verification
- `pnpm dialect:eval -- --out=/tmp/dialect-eval-command --dialects=es-PA,es-PR,es-MX,es-AR,es-ES`
- `pnpm --filter=@espanol/cli test -- dialect-eval-script.test.ts`
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check

## Notes
- The default provider is deterministic/mock for CI. Live provider dogfood is the next layer.