### PR TITLE
Support live provider dialect eval mode

### DIFF
--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -19,14 +19,36 @@ describe("dialect eval script", () => {
       total: number;
       passed: number;
       failed: number;
-      results: Array<{ fixture: string; passes: boolean; output: string }>;
+      live: boolean;
+      results: Array<{ fixture: string; passes: boolean; output: string; provider: string; live: boolean }>;
     };
 
     expect(results.total).toBeGreaterThanOrEqual(7);
     expect(results.failed).toBe(0);
     expect(results.passed).toBe(results.total);
+    expect(results.live).toBe(false);
     expect(results.results.some((result) => result.fixture === "pa-transit-neutral")).toBe(true);
+    expect(results.results.every((result) => result.provider === "mock-semantic" && result.live === false)).toBe(true);
 
     rmSync(outDir, { recursive: true, force: true });
   });
+  it("reports a clear error when live mode has no configured provider", () => {
+    const outDir = join(tmpdir(), `dialect-eval-live-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    expect(() => execFileSync("node", [
+      "scripts/dialect-eval.mjs",
+      `--out=${outDir}`,
+      "--dialects=es-PA",
+      "--provider=auto",
+      "--live",
+    ], {
+      cwd: join(import.meta.dirname, "../../../.."),
+      stdio: "pipe",
+      env: { ...process.env, DEEPL_AUTH_KEY: "", LIBRETRANSLATE_URL: "", ENABLE_MYMEMORY: "" },
+    })).toThrow(/No live providers are configured/);
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
 });

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -1,21 +1,24 @@
 #!/usr/bin/env node
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const args = new Map();
 for (const arg of process.argv.slice(2)) {
+  if (arg === "--") continue;
   const [key, value = ""] = arg.replace(/^--/, "").split("=");
   args.set(key, value || "true");
 }
 
 const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/dialect-eval";
 const outDir = args.get("out") || `audits/dialect-eval-${new Date().toISOString().slice(0, 10)}`;
-const provider = args.get("provider") || "mock-semantic";
+const providerName = args.get("provider") || "mock-semantic";
+const live = args.get("live") === "true";
 const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
 
 function mockTranslate(source, dialect) {
-  const safe = source
-    .replace(/\bTake\b/i, dialect === "es-PR" ? "Toma" : "Toma")
+  return source
+    .replace(/\bTake\b/i, "Toma")
     .replace(/\bbus\b/i, dialect === "es-PR" ? "guagua" : "bus")
     .replace(/\boffice\b/i, "oficina")
     .replace(/\bpassword\b/i, "contraseña")
@@ -29,17 +32,54 @@ function mockTranslate(source, dialect) {
     .replace(/\byour account now\b/i, "tu cuenta ahora")
     .replace(/\bYou can all update\b/i, dialect === "es-ES" ? "Vosotros podéis actualizar" : "Ustedes pueden actualizar")
     .replace(/\byour passwords now\b/i, "vuestras contraseñas ahora");
-  return safe;
 }
 
-function evaluate(sample, dialect) {
-  const output = mockTranslate(sample.source, dialect);
+async function createLiveTranslate() {
+  const { createProviderRegistry } = await import(pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/provider-factory.js`).href);
+  const { buildSemanticTranslationContext } = await import(pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/semantic-context.js`).href);
+  const registry = createProviderRegistry();
+  const available = registry.listProviders();
+  if (available.length === 0) {
+    throw new Error("No live providers are configured. Set DEEPL_AUTH_KEY, LIBRETRANSLATE_URL, or ENABLE_MYMEMORY=1.");
+  }
+
+  return async (sample, dialect) => {
+    const provider = providerName === "auto" || providerName === "mock-semantic"
+      ? registry.getAuto()
+      : registry.get(providerName);
+    const context = buildSemanticTranslationContext({
+      text: sample.source,
+      dialect,
+      formality: sample.register,
+      documentKind: sample.documentKind,
+    });
+    const result = await provider.translate(sample.source, "auto", "es", {
+      dialect,
+      formality: sample.register,
+      context,
+    });
+    return result.translatedText;
+  };
+}
+
+function hasForbiddenTerm(output, term) {
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(output);
+}
+
+async function evaluate(sample, dialect, translate) {
   const failures = [];
   const warnings = [];
+  let output = "";
+
+  try {
+    output = await translate(sample, dialect);
+  } catch (error) {
+    failures.push(`Provider error: ${error instanceof Error ? error.message : String(error)}`);
+  }
 
   for (const term of sample.forbiddenOutputTerms || []) {
-    const re = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\b`, "i");
-    if (re.test(output)) {
+    if (output && hasForbiddenTerm(output, term)) {
       failures.push(`Forbidden output term present: ${term}`);
     }
   }
@@ -54,7 +94,8 @@ function evaluate(sample, dialect) {
   return {
     dialect,
     fixture: sample.id,
-    provider,
+    provider: live ? providerName : "mock-semantic",
+    live,
     source: sample.source,
     output,
     passes: failures.length === 0,
@@ -63,19 +104,24 @@ function evaluate(sample, dialect) {
   };
 }
 
+const translate = live
+  ? await createLiveTranslate()
+  : async (sample, dialect) => mockTranslate(sample.source, dialect);
+
 const results = [];
 for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort()) {
   const dialect = basename(file, ".json");
   if (dialectFilter.size > 0 && !dialectFilter.has(dialect)) continue;
   const samples = JSON.parse(readFileSync(join(fixtureDir, file), "utf-8"));
   for (const sample of samples) {
-    results.push(evaluate(sample, dialect));
+    results.push(await evaluate(sample, dialect, translate));
   }
 }
 
 const summary = {
   generatedAt: new Date().toISOString(),
-  provider,
+  provider: live ? providerName : "mock-semantic",
+  live,
   fixtureDir,
   total: results.length,
   passed: results.filter((r) => r.passes).length,
@@ -85,7 +131,7 @@ const summary = {
 
 mkdirSync(outDir, { recursive: true });
 writeFileSync(join(outDir, "results.json"), `${JSON.stringify(summary, null, 2)}\n`);
-console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed }, null, 2));
+console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed, live }, null, 2));
 
 if (summary.failed > 0) {
   process.exit(1);


### PR DESCRIPTION
## Summary
- add opt-in `--live` mode to `scripts/dialect-eval.mjs`
- use the existing CLI provider registry when live mode is enabled
- pass semantic translation context into live provider calls
- keep deterministic mock provider as the default for CI/offline use
- add regression for clear no-provider configured errors

## Verification
- `pnpm dialect:eval -- --out=/tmp/dialect-eval-livecap-smoke --dialects=es-PA,es-PR,es-MX,es-AR,es-ES`
- `pnpm --filter=@espanol/cli test -- dialect-eval-script.test.ts`
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run package-content check

## Notes
- Live provider success with credentials was not run; the new mode is opt-in and guarded by config errors.