### PR TITLE
Expose generic provider output before launch testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-619%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-620%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 619 tests passing
+pnpm test        # 620 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 619 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 228 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 229 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 619 tests across 7 packages**
+**Total: 620 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        619 tests passing · BSL 1.1 · GitHub Pages
+        620 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">619</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">620</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 619 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 620 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-619 tests. 7 packages. pnpm monorepo. TypeScript.
+620 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 619 tests
+**Tech:** TypeScript, pnpm monorepo, 620 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 619 tests passing.
+Source available, BSL 1.1 licensed, 620 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 619 tests
+**Tech stack:** TypeScript, pnpm monorepo, 620 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -20,7 +20,7 @@ describe("dialect eval script", () => {
       passed: number;
       failed: number;
       live: boolean;
-      results: Array<{ fixture: string; passes: boolean; output: string; provider: string; live: boolean }>;
+      results: Array<{ fixture: string; passes: boolean; output: string; provider: string; live: boolean; qualityWarnings: string[] }>;
     };
 
     expect(results.total).toBeGreaterThanOrEqual(7);
@@ -29,6 +29,7 @@ describe("dialect eval script", () => {
     expect(results.live).toBe(false);
     expect(results.results.some((result) => result.fixture === "pa-transit-neutral")).toBe(true);
     expect(results.results.every((result) => result.provider === "mock-semantic" && result.live === false)).toBe(true);
+    expect(results.results.some((result) => result.qualityWarnings.length > 0)).toBe(true);
 
     rmSync(outDir, { recursive: true, force: true });
   });

--- a/packages/cli/src/__tests__/dialect-eval.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval.test.ts
@@ -13,6 +13,8 @@ interface DialectEvalSample {
   requiredContext: string[];
   forbiddenContext: string[];
   forbiddenOutputTerms: string[];
+  requiredOutputAny?: string[];
+  preferredOutputAny?: string[];
   notes: string;
 }
 
@@ -51,6 +53,7 @@ describe("dialect evaluation harness", () => {
           expect(context, `${sample.id} should not contain ${forbidden}`).not.toContain(forbidden);
         }
         expect(sample.forbiddenOutputTerms.length).toBeGreaterThan(0);
+        expect(sample.requiredOutputAny || sample.preferredOutputAny).toBeDefined();
         expect(sample.notes.length).toBeGreaterThan(10);
       }
     });

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-AR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-AR.json
@@ -15,6 +15,15 @@
     "forbiddenOutputTerms": [
       "vosotros"
     ],
-    "notes": "Informal Argentine output should preserve voseo but avoid unsafe slang unless requested."
+    "notes": "Informal Argentine output should preserve voseo but avoid unsafe slang unless requested.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-ES.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-ES.json
@@ -17,6 +17,15 @@
       "parce",
       "boludo"
     ],
-    "notes": "Spain can use vosotros and should not get Latin American slang."
+    "notes": "Spain can use vosotros and should not get Latin American slang.",
+    "requiredOutputAny": [
+      "vosotros",
+      "podéis",
+      "vuestras"
+    ],
+    "preferredOutputAny": [
+      "vosotros",
+      "podéis"
+    ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
@@ -17,6 +17,16 @@
       "vos",
       "vosotros"
     ],
-    "notes": "Mexico should avoid literal coger for pick up/take."
+    "notes": "Mexico should avoid literal coger for pick up/take.",
+    "requiredOutputAny": [
+      "recoge",
+      "recoger",
+      "toma",
+      "agarra"
+    ],
+    "preferredOutputAny": [
+      "recoge",
+      "recoger"
+    ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PA.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PA.json
@@ -19,7 +19,10 @@
       "chombo",
       "yeyé"
     ],
-    "notes": "Panama should default to bus/tomar-style neutral wording, not voseo or sensitive slang."
+    "notes": "Panama should default to bus/tomar-style neutral wording, not voseo or sensitive slang.",
+    "preferredOutputAny": [
+      "bus"
+    ]
   },
   {
     "id": "pa-support-formal",
@@ -38,6 +41,11 @@
       "chombo",
       "yeyé"
     ],
-    "notes": "Support/security copy should be respectful and neutral."
+    "notes": "Support/security copy should be respectful and neutral.",
+    "preferredOutputAny": [
+      "usted",
+      "actualice",
+      "su contraseña"
+    ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
@@ -19,7 +19,10 @@
       "bicho",
       "puñeta"
     ],
-    "notes": "PR can use guagua in the right context, but strong slang must not be introduced by default."
+    "notes": "PR can use guagua in the right context, but strong slang must not be introduced by default.",
+    "preferredOutputAny": [
+      "guagua"
+    ]
   },
   {
     "id": "pr-support-formal",
@@ -39,6 +42,11 @@
       "bicho",
       "puñeta"
     ],
-    "notes": "Formal PR support copy should avoid slang."
+    "notes": "Formal PR support copy should avoid slang.",
+    "preferredOutputAny": [
+      "soporte",
+      "comuníquese",
+      "póngase"
+    ]
   }
 ]

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -70,6 +70,7 @@ function hasForbiddenTerm(output, term) {
 async function evaluate(sample, dialect, translate) {
   const failures = [];
   const warnings = [];
+  const qualityWarnings = [];
   let output = "";
 
   try {
@@ -81,6 +82,20 @@ async function evaluate(sample, dialect, translate) {
   for (const term of sample.forbiddenOutputTerms || []) {
     if (output && hasForbiddenTerm(output, term)) {
       failures.push(`Forbidden output term present: ${term}`);
+    }
+  }
+
+  if (output && sample.requiredOutputAny?.length) {
+    const matched = sample.requiredOutputAny.some((term) => hasForbiddenTerm(output, term));
+    if (!matched) {
+      failures.push(`Missing required output trait; expected one of: ${sample.requiredOutputAny.join(", ")}`);
+    }
+  }
+
+  if (output && sample.preferredOutputAny?.length) {
+    const matched = sample.preferredOutputAny.some((term) => hasForbiddenTerm(output, term));
+    if (!matched) {
+      qualityWarnings.push(`Missing preferred dialect trait; expected one of: ${sample.preferredOutputAny.join(", ")}`);
     }
   }
 
@@ -101,6 +116,7 @@ async function evaluate(sample, dialect, translate) {
     passes: failures.length === 0,
     failures,
     warnings,
+    qualityWarnings,
   };
 }
 
@@ -126,12 +142,13 @@ const summary = {
   total: results.length,
   passed: results.filter((r) => r.passes).length,
   failed: results.filter((r) => !r.passes).length,
+  warnings: results.reduce((count, result) => count + result.qualityWarnings.length + result.warnings.length, 0),
   results,
 };
 
 mkdirSync(outDir, { recursive: true });
 writeFileSync(join(outDir, "results.json"), `${JSON.stringify(summary, null, 2)}\n`);
-console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed, live }, null, 2));
+console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed, warnings: summary.warnings, live }, null, 2));
 
 if (summary.failed > 0) {
   process.exit(1);


### PR DESCRIPTION
## Summary
- Add required/preferred output trait scoring to `scripts/dialect-eval.mjs`.
- Upgrade launch-critical dialect fixtures so the harness checks visible dialect behavior, not just forbidden terms/context.
- Separate hard dialect failures from quality warnings for provider dogfood runs.
- Update public test-count docs to 620 after the new script assertion.

## Why
Provider dogfood exposed that MyMemory can return safe fluent Spanish while ignoring dialect identity markers like Argentine voseo, Spain plural address, Panama/PR transit terms, and formal support tone. This PR makes those misses explicit before provider testing.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm --filter=@espanol/cli test -- dialect-eval.test.ts dialect-eval-script.test.ts`
- `pnpm test` — 7 packages, 620 tests passing
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-eval.mjs --out=/tmp/dialectos-eval-trait-mock --dialects=es-PA,es-PR,es-MX,es-AR,es-ES` — 7/7 pass, 1 quality warning
- Live MyMemory dogfood: 5/7 pass, 2 hard failures, 5 warnings; this is expected and proves the new provider gate catches generic output before launch testing.
