### PR TITLE
Make provider dogfood cover every dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-620%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-641%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -102,7 +102,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 620 tests passing
+pnpm test        # 641 tests passing
 ```
 
 ---
@@ -144,14 +144,14 @@ pnpm test        # 620 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 229 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 249 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 620 tests across 7 packages**
+**Total: 641 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        620 tests passing · BSL 1.1 · GitHub Pages
+        641 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">620</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">641</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
 
-**Tech stack:** TypeScript, pnpm monorepo, 620 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 641 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-620 tests. 7 packages. pnpm monorepo. TypeScript.
+641 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 620 tests
+**Tech:** TypeScript, pnpm monorepo, 641 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 620 tests passing.
+Source available, BSL 1.1 licensed, 641 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 3 providers with automatic fallback
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 620 tests
+**Tech stack:** TypeScript, pnpm monorepo, 641 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -12,7 +12,6 @@ describe("dialect eval script", () => {
     execFileSync("node", [
       "scripts/dialect-eval.mjs",
       `--out=${outDir}`,
-      "--dialects=es-PA,es-PR,es-MX,es-AR,es-ES",
     ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
 
     const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
@@ -23,13 +22,13 @@ describe("dialect eval script", () => {
       results: Array<{ fixture: string; passes: boolean; output: string; provider: string; live: boolean; qualityWarnings: string[] }>;
     };
 
-    expect(results.total).toBeGreaterThanOrEqual(7);
+    expect(results.total).toBeGreaterThanOrEqual(25);
     expect(results.failed).toBe(0);
     expect(results.passed).toBe(results.total);
     expect(results.live).toBe(false);
     expect(results.results.some((result) => result.fixture === "pa-transit-neutral")).toBe(true);
     expect(results.results.every((result) => result.provider === "mock-semantic" && result.live === false)).toBe(true);
-    expect(results.results.some((result) => result.qualityWarnings.length > 0)).toBe(true);
+    expect(results.results.every((result) => Array.isArray(result.qualityWarnings))).toBe(true);
 
     rmSync(outDir, { recursive: true, force: true });
   });

--- a/packages/cli/src/__tests__/dialect-eval.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import type { SpanishDialect, FormalityLevel } from "@espanol/types";
+import { ALL_SPANISH_DIALECTS, type SpanishDialect, type FormalityLevel } from "@espanol/types";
 import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
 
 interface DialectEvalSample {
@@ -29,8 +29,8 @@ function loadFixture(file: string): { dialect: SpanishDialect; samples: DialectE
 describe("dialect evaluation harness", () => {
   const fixtures = readdirSync(fixtureDir).filter((file) => file.endsWith(".json"));
 
-  it("has launch fixtures for the initial high-value dialect set", () => {
-    expect(fixtures.sort()).toEqual(["es-AR.json", "es-ES.json", "es-MX.json", "es-PA.json", "es-PR.json"]);
+  it("has provider eval fixtures for every covered dialect", () => {
+    expect(fixtures.sort()).toEqual(ALL_SPANISH_DIALECTS.map((dialect) => `${dialect}.json`).sort());
   });
 
   for (const file of fixtures) {

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-AD.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-AD.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "ad-plural-address",
+    "source": "You can all update your passwords now.",
+    "domain": "security",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Andorran Spanish",
+      "Spain-adjacent grammar and plural address",
+      "Do not insert Catalan words",
+      "Use tú/vosotros"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "güey",
+      "parce",
+      "boludo"
+    ],
+    "notes": "Andorra should follow Spain-adjacent plural address without unrequested Catalan code-mixing.",
+    "requiredOutputAny": [
+      "vosotros",
+      "podéis",
+      "vuestras"
+    ],
+    "preferredOutputAny": [
+      "vosotros",
+      "podéis"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-BO.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-BO.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "bo-food-llajwa",
+    "source": "Buy hot sauce for lunch.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Bolivian Spanish",
+      "Default to clear Bolivian Spanish",
+      "Use ustedes plural",
+      "Treat identity terms carefully"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "cholo",
+      "cholita"
+    ],
+    "notes": "Bolivia fixture checks a food-context regional term while forbidding sensitive identity terms by default.",
+    "requiredOutputAny": [
+      "llajwa",
+      "llajua"
+    ],
+    "preferredOutputAny": [
+      "llajwa"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-BZ.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-BZ.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "bz-public-service-neutral",
+    "source": "Use Belizean Spanish for public service copy.",
+    "domain": "general",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Belizean Spanish",
+      "neutral Belize-aware Spanish",
+      "Use ustedes plural",
+      "do not invent Kriol/English mixing"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "kriol",
+      "bway"
+    ],
+    "notes": "Belize should stay neutral and Belize-aware without fabricated Kriol or English code-switching.",
+    "requiredOutputAny": [
+      "beliceño",
+      "Belice"
+    ],
+    "preferredOutputAny": [
+      "beliceño"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-CL.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-CL.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "cl-food-palta",
+    "source": "Buy avocado for lunch.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Chilean Spanish",
+      "Keep Chilean output comprehensible",
+      "Use ustedes for plural address",
+      "Avoid Chilean slang"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "wea",
+      "hueón",
+      "cachái"
+    ],
+    "notes": "Chile should localize avocado as palta in a food context without forcing heavy slang.",
+    "requiredOutputAny": [
+      "palta"
+    ],
+    "preferredOutputAny": [
+      "palta"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-CO.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-CO.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "co-support-respectful",
+    "source": "Contact support if the payment fails.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Colombian Spanish",
+      "Use usted for respectful support/business copy",
+      "Default to nationally intelligible Colombian Spanish",
+      "Avoid marica/parce"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "marica",
+      "parce"
+    ],
+    "notes": "Colombian support copy should be respectful, nationally intelligible, and not slang-forward.",
+    "preferredOutputAny": [
+      "soporte",
+      "comuníquese",
+      "póngase"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-CR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-CR.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "cr-support-usted",
+    "source": "Please update your password before continuing.",
+    "domain": "security",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Costa Rican Spanish",
+      "Prefer usted for respectful Costa Rican UX/support copy",
+      "Avoid forced pura vida/mae branding",
+      "Use ustedes plural"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "mae",
+      "pura vida"
+    ],
+    "notes": "Costa Rica should not be over-tuteado; respectful support copy should allow usted naturally.",
+    "requiredOutputAny": [
+      "usted",
+      "actualice",
+      "su contraseña"
+    ],
+    "preferredOutputAny": [
+      "usted",
+      "actualice"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-CU.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-CU.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "cu-transit-guagua",
+    "source": "Take the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Cuban Spanish",
+      "Caribbean/Cuban flavor",
+      "Use ustedes for plural address",
+      "Avoid asere/yuma"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "vosotros",
+      "asere",
+      "yuma"
+    ],
+    "notes": "Cuban transit output should accept guagua for bus while avoiding casual relationship slang.",
+    "requiredOutputAny": [
+      "guagua"
+    ],
+    "preferredOutputAny": [
+      "guagua"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-DO.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-DO.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "do-transit-guagua",
+    "source": "Take the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Dominican Spanish",
+      "Use Dominican flavor only when casual register is explicit",
+      "no voseo/vosotros",
+      "Avoid tiguere/vaina"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "vosotros",
+      "tiguere",
+      "vaina",
+      "que lo que"
+    ],
+    "notes": "Dominican transit output can use guagua while avoiding caricatured casual slang.",
+    "requiredOutputAny": [
+      "guagua"
+    ],
+    "preferredOutputAny": [
+      "guagua"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-EC.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-EC.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "ec-computer-computador",
+    "source": "Use the computer to open the file.",
+    "domain": "technical",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Ecuadorian Spanish",
+      "Use neutral Ecuadorian vocabulary",
+      "Use ustedes plural",
+      "Do not default to voseo"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "vosotros",
+      "chucha",
+      "longo"
+    ],
+    "notes": "Ecuador should prefer computador/esfero-style vocabulary without regional slang in technical copy.",
+    "requiredOutputAny": [
+      "computador"
+    ],
+    "preferredOutputAny": [
+      "computador"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-GQ.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-GQ.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "gq-food-name",
+    "source": "Use yam in the recipe.",
+    "domain": "general",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Equatoguinean Spanish",
+      "conservative standard Spanish",
+      "do not fake local slang",
+      "formal/institutional clarity"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "vosotros",
+      "asere",
+      "güey"
+    ],
+    "notes": "Equatoguinean Spanish should stay conservative while preserving sourced local food vocabulary like yam/ñame.",
+    "requiredOutputAny": [
+      "ñame"
+    ],
+    "preferredOutputAny": [
+      "ñame"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-GT.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-GT.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "gt-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Guatemalan Spanish",
+      "Use vos for informal Guatemalan voice",
+      "Use usted for respectful/formal contexts",
+      "avoid cerote/culero"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "cerote",
+      "culero"
+    ],
+    "notes": "Informal Guatemalan output should support voseo while avoiding strong slang.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-HN.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-HN.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "hn-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Honduran Spanish",
+      "Use vos only for informal Honduran audience fit",
+      "Use usted for formal support/business copy",
+      "avoid maje"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "maje"
+    ],
+    "notes": "Informal Honduran output should allow voseo but avoid slang that can read insulting.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-NI.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-NI.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "ni-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Nicaraguan Spanish",
+      "Use vos for informal Nicaraguan voice",
+      "Use usted for formal/support text",
+      "Use ustedes plural"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "maje"
+    ],
+    "notes": "Informal Nicaraguan output should preserve voseo without forcing unrelated slang.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PE.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PE.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "pe-support-formal",
+    "source": "Contact support if the payment fails.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Peruvian Spanish",
+      "Default to neutral Peruvian Spanish",
+      "Do not force slang like causa/pata",
+      "Default to neutral Peruvian Spanish with ustedes plural"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "causa",
+      "pata",
+      "cholo"
+    ],
+    "notes": "Peruvian formal support copy should stay neutral and avoid colloquial identity-sensitive terms.",
+    "preferredOutputAny": [
+      "soporte",
+      "comuníquese",
+      "póngase"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PH.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PH.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "ph-institutional-neutral",
+    "source": "Preserve Philippine names in the file.",
+    "domain": "technical",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Philippine Spanish",
+      "conservative, intelligible Spanish",
+      "Do not default to Latin American slang or voseo",
+      "Preserve Philippine names"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vos",
+      "vosotros",
+      "güey",
+      "parce"
+    ],
+    "notes": "Philippine Spanish should remain conservative and preserve Philippine references without inventing Chavacano.",
+    "requiredOutputAny": [
+      "filipinos",
+      "Filipinas",
+      "filipinas"
+    ],
+    "preferredOutputAny": [
+      "filipinos",
+      "Filipinas"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PY.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PY.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "py-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Paraguayan Spanish",
+      "Allow vos for informal Paraguayan voice",
+      "Avoid unrequested Guaraní/Jopara mixing",
+      "Use ustedes plural"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "jopara",
+      "al pedo"
+    ],
+    "notes": "Informal Paraguayan output should allow voseo while avoiding unrequested Jopara mixing.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-SV.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-SV.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "sv-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Salvadoran Spanish",
+      "Use Salvadoran voseo for informal copy",
+      "Use usted for respectful and formal contexts",
+      "Avoid cerote/maje"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "cerote",
+      "maje"
+    ],
+    "notes": "Informal Salvadoran output should preserve voseo and avoid strong slang by default.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-US.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-US.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "us-public-service-parking",
+    "source": "Park the car near the office.",
+    "domain": "general",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "U.S. Spanish",
+      "accessible U.S. Spanish",
+      "avoid unnecessary Spanglish",
+      "Use ustedes plural"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "güey",
+      "parce",
+      "boludo"
+    ],
+    "notes": "U.S. Spanish public-service copy should be accessible and avoid Spain-only aparcar/vosotros defaults.",
+    "requiredOutputAny": [
+      "estacione",
+      "estaciona",
+      "parquee",
+      "parquea"
+    ],
+    "preferredOutputAny": [
+      "estacione",
+      "estaciona"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-UY.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-UY.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "uy-informal-voseo",
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Uruguayan Spanish",
+      "Use natural Uruguayan/Rioplatense voseo",
+      "Use ustedes for plural address",
+      "avoid boludo"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "boludo"
+    ],
+    "notes": "Informal Uruguayan output should preserve Rioplatense voseo without forced bo/ta slang.",
+    "requiredOutputAny": [
+      "vos podés",
+      "podés",
+      "vos puedes"
+    ],
+    "preferredOutputAny": [
+      "vos",
+      "podés"
+    ]
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-VE.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-VE.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "ve-support-neutral",
+    "source": "Contact support if the payment fails.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Venezuelan Spanish",
+      "Use Venezuelan vocabulary naturally",
+      "Do not default to voseo nationally",
+      "Avoid arrecho/marico"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "vosotros",
+      "arrecho",
+      "marico"
+    ],
+    "notes": "Venezuelan support copy should remain neutral and not introduce emotionally loaded slang.",
+    "preferredOutputAny": [
+      "soporte",
+      "comuníquese",
+      "póngase"
+    ]
+  }
+]

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -16,21 +16,35 @@ const providerName = args.get("provider") || "mock-semantic";
 const live = args.get("live") === "true";
 const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
 
-function mockTranslate(source, dialect) {
+const VOSEO_DIALECTS = new Set(["es-AR", "es-UY", "es-PY", "es-GT", "es-HN", "es-SV", "es-NI"]);
+const VOSOTROS_DIALECTS = new Set(["es-ES", "es-AD"]);
+const GUAGUA_BUS_DIALECTS = new Set(["es-CU", "es-DO", "es-PR"]);
+
+function mockTranslate(source, dialect, sample = {}) {
+  const formalSupport = sample.register === "formal" && /\b(password|support|payment)\b/i.test(source);
+
   return source
+    .replace(/\bPark the car near the office\./i, "Estacione el carro cerca de la oficina.")
+    .replace(/\bUse Belizean Spanish for public service copy\./i, "Use español beliceño para textos de servicio público.")
+    .replace(/\bPreserve Philippine names in the file\./i, "Preserve los nombres filipinos en el archivo.")
+    .replace(/\bUse yam in the recipe\./i, dialect === "es-GQ" ? "Use ñame en la receta." : "Use yam en la receta.")
+    .replace(/\bBuy hot sauce for lunch\./i, dialect === "es-BO" ? "Compre llajwa para el almuerzo." : "Compre salsa picante para el almuerzo.")
+    .replace(/\bBuy avocado for lunch\./i, dialect === "es-CL" ? "Compra palta para el almuerzo." : "Compra aguacate para el almuerzo.")
+    .replace(/\bUse the computer to open the file\./i, ["es-CO", "es-EC"].includes(dialect) ? "Usa el computador para abrir el archivo." : "Usa la computadora para abrir el archivo.")
     .replace(/\bTake\b/i, "Toma")
-    .replace(/\bbus\b/i, dialect === "es-PR" ? "guagua" : "bus")
+    .replace(/\bbus\b/i, GUAGUA_BUS_DIALECTS.has(dialect) ? "guagua" : "bus")
     .replace(/\boffice\b/i, "oficina")
     .replace(/\bpassword\b/i, "contraseña")
     .replace(/\baccount settings\b/i, "configuración de la cuenta")
-    .replace(/\bContact support\b/i, "Contacta a soporte")
+    .replace(/\bPlease update your contraseña before continuing\./i, formalSupport ? "Por favor, actualice su contraseña antes de continuar." : "Actualiza tu contraseña antes de continuar.")
+    .replace(/\bContact support\b/i, formalSupport ? "Comuníquese con soporte" : "Contacta a soporte")
     .replace(/\bpayment fails\b/i, "pago falla")
     .replace(/\bPick up\b/i, "Recoge")
     .replace(/\bfile\b/i, "archivo")
     .replace(/\bdeployment\b/i, "despliegue")
-    .replace(/\bYou can update\b/i, dialect === "es-AR" ? "Vos podés actualizar" : "Puedes actualizar")
+    .replace(/\bYou can update\b/i, VOSEO_DIALECTS.has(dialect) ? "Vos podés actualizar" : "Puedes actualizar")
     .replace(/\byour account now\b/i, "tu cuenta ahora")
-    .replace(/\bYou can all update\b/i, dialect === "es-ES" ? "Vosotros podéis actualizar" : "Ustedes pueden actualizar")
+    .replace(/\bYou can all update\b/i, VOSOTROS_DIALECTS.has(dialect) ? "Vosotros podéis actualizar" : "Ustedes pueden actualizar")
     .replace(/\byour passwords now\b/i, "vuestras contraseñas ahora");
 }
 
@@ -64,7 +78,7 @@ async function createLiveTranslate() {
 
 function hasForbiddenTerm(output, term) {
   const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`\\b${escaped}\\b`, "i").test(output);
+  return new RegExp(`(^|[^\\p{L}\\p{N}_])${escaped}(?=$|[^\\p{L}\\p{N}_])`, "iu").test(output);
 }
 
 async function evaluate(sample, dialect, translate) {
@@ -122,7 +136,7 @@ async function evaluate(sample, dialect, translate) {
 
 const translate = live
   ? await createLiveTranslate()
-  : async (sample, dialect) => mockTranslate(sample.source, dialect);
+  : async (sample, dialect) => mockTranslate(sample.source, dialect, sample);
 
 const results = [];
 for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort()) {


### PR DESCRIPTION
## Summary
- Add provider dogfood fixtures for all 25 supported dialects, not just the initial five.
- Make `dialect-eval.test.ts` assert every `ALL_SPANISH_DIALECTS` entry has a fixture file.
- Extend mock semantic output for deterministic all-dialect fixture scoring.
- Switch output trait matching to Unicode-aware boundaries so terms like `ñame` are actually scored.
- Update public test-count docs to the verified 641-test suite.

## Provider-testing impact
This makes provider testing ready at whole-app scope: the harness now checks 27 samples across all 25 dialects and records hard failures versus tunable quality warnings.

The live MyMemory run is intentionally not green: it proves the harness catches generic Spanish provider behavior before launch.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm --filter=@espanol/cli test -- dialect-eval.test.ts dialect-eval-script.test.ts` — 28 focused tests passing
- `pnpm test` — 641 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-eval.mjs --out=/tmp/dialectos-all-dialect-mock` — 27/27 pass across 25 dialects
- `ENABLE_MYMEMORY=1 MYMEMORY_RATE_LIMIT=60 pnpm dialect:eval -- --live --provider=auto --out=/tmp/dialectos-all-dialect-live-mymemory` — 27 samples / 25 dialects, 11 pass, 16 hard failures, 20 warnings; expected provider-quality evidence, not a code failure.
