### PR TITLE
Make semantic LLMs the primary translation provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-641%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-650%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -36,7 +36,7 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 | Gender-neutral language | ❌ | ❌ | ✅ **elles / latine / -x** |
 | Formality checking (tú vs usted) | ❌ | ❌ | ✅ **Cross-dialect consistency** |
 | Adversarial quality gates | ❌ | ❌ | ✅ **Semantic drift + structure validation** |
-| Self-hosted / free tier | ❌ Paid | ⚠️ Limited free | ✅ **LibreTranslate + opt-in MyMemory fallback** |
+| LLM-first dialect adaptation | ❌ Generic MT | ⚠️ Limited dialect control | ✅ **Any OpenAI-compatible LLM + dialect contracts** |
 
 ---
 
@@ -68,7 +68,9 @@ Add to your Claude Desktop, Cursor, or any MCP client:
       "command": "npx",
       "args": ["-y", "@espanol/mcp"],
       "env": {
-        "DEEPL_AUTH_KEY": "your-key",
+        "LLM_API_URL": "https://your-llm-gateway/v1/chat/completions",
+        "LLM_MODEL": "your-dialect-capable-model",
+        "LLM_API_KEY": "your-key-if-required",
         "ALLOWED_LOCALE_DIRS": "/path/to/locales"
       }
     }
@@ -102,7 +104,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 641 tests passing
+pnpm test        # 650 tests passing
 ```
 
 ---
@@ -144,14 +146,14 @@ pnpm test        # 641 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 249 |
-| [`@espanol/providers`](packages/providers) | `0.1.0` | DeepL, LibreTranslate, MyMemory with circuit breaker | 61 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 253 |
+| [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 66 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 641 tests across 7 packages**
+**Total: 650 tests across 7 packages**
 
 ---
 
@@ -219,8 +221,8 @@ See [`SECURITY.md`](SECURITY.md) for details.
 ┌──────────────────────▼──────────────────────────────────────┐
 │                @espanol/providers                            │
 │   ┌─────────┐  ┌─────────────────┐  ┌─────────────────┐    │
-│   │  DeepL  │  │ LibreTranslate  │  │ MyMemory opt-in │    │
-│   │ Primary │  │ Self-hosted     │  │ Free fallback   │    │
+│   │   LLM   │  │     DeepL       │  │ Libre/MyMemory │   │
+│   │ Primary │  │ Paid fallback   │  │ Generic fallback│    │
 │   └─────────┘  └─────────────────┘  └─────────────────┘    │
 │        │                │                    │              │
 │        └────────────────┴────────────────────┘              │
@@ -265,6 +267,7 @@ See [`ROADMAP.md`](ROADMAP.md) for upcoming features including:
 - Portuguese dialect support (pt-BR, pt-PT)
 - Real-time collaborative translation
 - Custom provider plugins
+- OpenAI-compatible LLM gateways via `LLM_API_URL` + `LLM_MODEL`
 - VS Code extension
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        641 tests passing · BSL 1.1 · GitHub Pages
+        650 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">641</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">650</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -19,9 +19,9 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - Translate to es-MX, es-AR, es-CO, es-ES, and 21 more
 - Structure-preserving markdown translation (tables, code blocks, links)
 - i18n operations: detect missing keys, batch translate, check formality
-- 3 providers with automatic fallback (DeepL → LibreTranslate → MyMemory)
+- LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 641 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 650 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-641 tests. 7 packages. pnpm monorepo. TypeScript.
+650 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -85,13 +85,13 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 
 **Features:**
 - 25 Spanish dialects with metadata
-- Self-hosted via LibreTranslate (or use DeepL/MyMemory)
+- Connect any OpenAI-compatible LLM, with LibreTranslate/DeepL/MyMemory as fallback utilities
 - MCP server — integrates with Claude, Cursor, etc.
 - Structure-preserving markdown translation
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 641 tests
+**Tech:** TypeScript, pnpm monorepo, 650 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 641 tests passing.
+Source available, BSL 1.1 licensed, 650 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -133,10 +133,10 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - 16 MCP tools for AI assistants
 - Structure-preserving markdown translation
 - i18n operations (missing key detection, batch translation, formality checking)
-- 3 providers with automatic fallback
+- LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 641 tests
+**Tech stack:** TypeScript, pnpm monorepo, 650 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/provider-factory.test.ts
+++ b/packages/cli/src/__tests__/provider-factory.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createProviderRegistry, resetDefaultProviderRegistryForTests } from "../lib/provider-factory.js";
+
+const ENV_KEYS = [
+  "DEEPL_AUTH_KEY",
+  "LIBRETRANSLATE_URL",
+  "ENABLE_MYMEMORY",
+  "LLM_API_URL",
+  "LLM_ENDPOINT",
+  "LLM_MODEL",
+  "LLM_API_KEY",
+  "LLM_ALLOW_LOCAL",
+];
+
+function clearProviderEnv() {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  resetDefaultProviderRegistryForTests();
+}
+
+describe("provider factory", () => {
+  afterEach(() => {
+    clearProviderEnv();
+  });
+
+  it("registers a configured LLM provider as the semantic auto provider", () => {
+    clearProviderEnv();
+    process.env.LLM_API_URL = "https://llm.example/v1/chat/completions";
+    process.env.LLM_MODEL = "dialect-model";
+    process.env.LLM_API_KEY = "test-key";
+    process.env.LIBRETRANSLATE_URL = "https://libretranslate.example";
+
+    const registry = createProviderRegistry();
+
+    expect(registry.listProviders()).toContain("llm");
+    expect(registry.listProviders()).toContain("libretranslate");
+    expect(registry.getAuto().name).toBe("llm");
+    expect(registry.getCapabilities("llm")?.dialectHandling).toBe("semantic");
+  });
+
+  it("does not register generic fallback providers unless explicitly configured", () => {
+    clearProviderEnv();
+
+    const registry = createProviderRegistry();
+
+    expect(registry.listProviders()).toEqual([]);
+  });
+});

--- a/packages/cli/src/__tests__/resilient-translation.test.ts
+++ b/packages/cli/src/__tests__/resilient-translation.test.ts
@@ -36,6 +36,32 @@ class TestRegistry implements Partial<ProviderRegistry> {
 }
 
 describe("translateWithFallback", () => {
+  it("should prefer llm before generic machine translation providers by default", async () => {
+    const llm: TranslationProvider = {
+      name: "llm",
+      translate: vi.fn().mockResolvedValue({ translatedText: "Vos podés" }),
+    };
+    const libre: TranslationProvider = {
+      name: "libre",
+      translate: vi.fn().mockResolvedValue({ translatedText: "Puedes" }),
+    };
+    const registry = new TestRegistry({ libre, llm }) as ProviderRegistry;
+
+    const result = await translateWithFallback(
+      registry,
+      undefined,
+      "You can",
+      "en",
+      "es",
+      { dialect: "es-AR" },
+      { delayMs: 0 }
+    );
+
+    expect(result.translatedText).toBe("Vos podés");
+    expect(result.providerUsed).toBe("llm");
+    expect(libre.translate).not.toHaveBeenCalled();
+  });
+
   it("should report the provider used and fallback count", async () => {
     const failing: TranslationProvider = {
       name: "primary",

--- a/packages/cli/src/__tests__/translate.test.ts
+++ b/packages/cli/src/__tests__/translate.test.ts
@@ -107,6 +107,20 @@ describe("translate command", () => {
     expect(provider.translate).not.toHaveBeenCalled();
   });
 
+  it("should accept llm as a first-class provider name", async () => {
+    const provider = makeProvider((text) => `llm: ${text}`);
+    const getProvider = vi.fn().mockReturnValue(provider);
+
+    await executeTranslate("Hello", { provider: "llm", dialect: "es-PR" }, getProvider);
+
+    expect(getProvider).toHaveBeenCalledWith("llm");
+    expect(provider.translate).toHaveBeenCalledWith("Hello", "auto", "es", expect.objectContaining({
+      dialect: "es-PR",
+      context: expect.stringContaining("Puerto Rican"),
+    }));
+    expect(stdoutSpy).toHaveBeenCalledWith("llm: Hello");
+  });
+
   it("should reject unsupported provider names", async () => {
     const provider = makeProvider();
 

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -113,7 +113,7 @@ function validateDialect(dialect: string): SpanishDialect {
 function validateProvider(provider: string | undefined): string | undefined {
   if (!provider) return undefined;
 
-  const validProviders: ProviderName[] = ["deepl", "libre", "mymemory"];
+  const validProviders: ProviderName[] = ["llm", "deepl", "libre", "mymemory"];
   if (provider !== "auto" && !validProviders.includes(provider as ProviderName)) {
     throw new Error(
       `Invalid provider: ${provider}. Valid providers are: auto, ${validProviders.join(", ")}`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ program
   .description("Translate text to Spanish with dialect awareness")
   .argument("[text]", "Text to translate (can also be provided via stdin or --input-file)")
   .option("--dialect <dialect>", "Spanish dialect (e.g., es-ES, es-MX, es-AR)", "es-ES")
-  .option("--provider <provider>", "Translation provider (deepl, libre, mymemory, or auto for automatic selection)", "auto")
+  .option("--provider <provider>", "Translation provider (llm, deepl, libre, mymemory, or auto for automatic selection)", "auto")
   .option("--formal", "Use formal language (usted)", false)
   .option("--informal", "Use informal language (tú)", false)
   .option("--auto-formality", "Auto-detect formality", false)
@@ -92,7 +92,7 @@ program
   .description("Translate an API documentation markdown file")
   .argument("<input>", "Input markdown file")
   .option("--dialect <dialect>", "Spanish dialect (e.g., es-ES, es-MX, es-AR)", "es-ES")
-  .option("--provider <provider>", "Translation provider (deepl, libre, mymemory, or auto for automatic selection)", "auto")
+  .option("--provider <provider>", "Translation provider (llm, deepl, libre, mymemory, or auto for automatic selection)", "auto")
   .option("--output <path>", "Write translation to file instead of stdout")
   .option("--protect-tokens <file>", "JSON file with protected tokens")
   .option("--glossary-file <file>", "JSON glossary file with term mappings")
@@ -256,7 +256,7 @@ i18nCommand
   .argument("<base>", "Base locale file (e.g., ./locales/en.json)")
   .argument("<target>", "Target locale file (e.g., ./locales/es.json)")
   .option("--dialect <dialect>", "Spanish dialect (e.g., es-MX, es-AR, es-CO)", "es-ES")
-  .option("--provider <provider>", "Translation provider (deepl, libre, mymemory, or auto for automatic selection)", "auto")
+  .option("--provider <provider>", "Translation provider (llm, deepl, libre, mymemory, or auto for automatic selection)", "auto")
   .action(async (base, target, options) => {
     try {
       const registry = getDefaultProviderRegistry();
@@ -281,7 +281,7 @@ i18nCommand
   .argument("<directory>", "Directory containing locale files (e.g., ./locales)")
   .option("--base <locale>", "Base locale code (e.g., en)", "en")
   .option("--targets <dialects>", "Comma-separated target dialects (e.g., es-MX,es-AR,es-CO)", "es-ES")
-  .option("--provider <provider>", "Translation provider (deepl, libre, mymemory, or auto for automatic selection)", "auto")
+  .option("--provider <provider>", "Translation provider (llm, deepl, libre, mymemory, or auto for automatic selection)", "auto")
   .action(async (directory, options) => {
     try {
       const registry = getDefaultProviderRegistry();

--- a/packages/cli/src/lib/provider-factory.ts
+++ b/packages/cli/src/lib/provider-factory.ts
@@ -7,16 +7,31 @@ import { ProviderRegistry } from "@espanol/providers";
 import { DeepLProvider } from "@espanol/providers";
 import { LibreTranslateProvider } from "@espanol/providers";
 import { MyMemoryProvider } from "@espanol/providers";
+import { LLMProvider } from "@espanol/providers";
 
 /**
  * Create a ProviderRegistry with all available providers
  * Providers are registered based on environment variables:
+ * - LLM_API_URL + LLM_MODEL → LLMProvider (semantic dialect-aware primary)
  * - DEEPL_AUTH_KEY → DeepLProvider
  * - LIBRETRANSLATE_URL → LibreTranslateProvider
- * - MyMemoryProvider is always registered (free, no auth required)
+ * - ENABLE_MYMEMORY=1 → MyMemoryProvider (legacy fallback)
  */
 export function createProviderRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
+
+  // Register LLM first when configured; getAuto also ranks semantic providers first.
+  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT;
+  const llmModel = process.env.LLM_MODEL;
+  if (llmEndpoint && llmModel) {
+    const llmProvider = new LLMProvider({
+      endpoint: llmEndpoint,
+      model: llmModel,
+      apiKey: process.env.LLM_API_KEY,
+      allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
+    });
+    registry.register(llmProvider);
+  }
 
   // Register DeepL if API key is available
   const deeplKey = process.env.DEEPL_AUTH_KEY;
@@ -60,4 +75,8 @@ export function getDefaultProviderRegistry(): ProviderRegistry {
     defaultRegistry = createProviderRegistry();
   }
   return defaultRegistry;
+}
+
+export function resetDefaultProviderRegistryForTests(): void {
+  defaultRegistry = null;
 }

--- a/packages/cli/src/lib/resilient-translation.ts
+++ b/packages/cli/src/lib/resilient-translation.ts
@@ -96,7 +96,7 @@ function buildProviderChain(
   const priority =
     envPriority.length > 0
       ? envPriority
-      : ["libre", "deepl", "mymemory"];
+      : ["llm", "deepl", "libre", "mymemory"];
   const available = registry.listProviders().filter((name) => registry.isAvailable(name));
   const ordered = priority.filter((name) => available.includes(name));
   const remainder = available.filter((name) => !ordered.includes(name));

--- a/packages/mcp/src/__tests__/docs.test.ts
+++ b/packages/mcp/src/__tests__/docs.test.ts
@@ -66,6 +66,7 @@ vi.mock("@espanol/providers", () => ({
   DeepLProvider: vi.fn(),
   LibreTranslateProvider: vi.fn(),
   MyMemoryProvider: vi.fn(),
+  LLMProvider: vi.fn(),
 }));
 
 import {

--- a/packages/mcp/src/__tests__/i18n.test.ts
+++ b/packages/mcp/src/__tests__/i18n.test.ts
@@ -80,6 +80,7 @@ vi.mock("@espanol/providers", () => ({
   DeepLProvider: vi.fn(),
   LibreTranslateProvider: vi.fn(),
   MyMemoryProvider: vi.fn(),
+  LLMProvider: vi.fn(),
 }));
 
 import {

--- a/packages/mcp/src/__tests__/translator.test.ts
+++ b/packages/mcp/src/__tests__/translator.test.ts
@@ -68,6 +68,7 @@ vi.mock("@espanol/providers", () => ({
   DeepLProvider: vi.fn(),
   LibreTranslateProvider: vi.fn(),
   MyMemoryProvider: vi.fn(),
+  LLMProvider: vi.fn(),
 }));
 
 import {

--- a/packages/mcp/src/lib/provider-factory.ts
+++ b/packages/mcp/src/lib/provider-factory.ts
@@ -8,17 +8,31 @@ import {
   DeepLProvider,
   LibreTranslateProvider,
   MyMemoryProvider,
+  LLMProvider,
 } from "@espanol/providers";
 
 /**
  * Create a ProviderRegistry with all available providers
  * Providers are registered based on environment variables:
+ * - LLM_API_URL + LLM_MODEL → LLMProvider (semantic dialect-aware primary)
  * - DEEPL_AUTH_KEY → DeepLProvider
  * - LIBRETRANSLATE_URL → LibreTranslateProvider
  * - MyMemoryProvider is opt-in only (legacy fallback). Set ENABLE_MYMEMORY=1 to register it.
  */
 export function createProviderRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
+
+  // Register LLM first when configured; ProviderRegistry also ranks semantic providers first.
+  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT;
+  const llmModel = process.env.LLM_MODEL;
+  if (llmEndpoint && llmModel) {
+    registry.register(new LLMProvider({
+      endpoint: llmEndpoint,
+      model: llmModel,
+      apiKey: process.env.LLM_API_KEY,
+      allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
+    }));
+  }
 
   // Register DeepL if API key is available
   const deeplKey = process.env.DEEPL_AUTH_KEY;

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -440,7 +440,7 @@ export function registerDocsTools(
     {
       filePath: z.string().describe("Path to the markdown file to translate"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
       formal: z.boolean().optional().describe("Use formal tone (for languages that distinguish formal/informal)"),
       informal: z.boolean().optional().describe("Use informal tone (for languages that distinguish formal/informal)"),
     },
@@ -468,7 +468,7 @@ export function registerDocsTools(
     {
       filePath: z.string().describe("Path to the API documentation markdown file"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
     },
     async (params) => {
       return handleTranslateApiDocs(params as TranslateApiDocsParams, registry, rateLimiter);
@@ -482,7 +482,7 @@ export function registerDocsTools(
     {
       filePath: z.string().describe("Path to the markdown file to translate"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
     },
     async (params) => {
       return handleCreateBilingualDoc(params as CreateBilingualDocParams, registry, rateLimiter);

--- a/packages/mcp/src/tools/i18n.ts
+++ b/packages/mcp/src/tools/i18n.ts
@@ -858,7 +858,7 @@ export function registerI18nTools(
       basePath: z.string().describe("Path to the base locale file"),
       targetPath: z.string().describe("Path to the target locale file"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
     },
     async (params) => {
       return handleTranslateMissingKeys(params as TranslateMissingKeysParams, registry, rateLimiter);
@@ -873,7 +873,7 @@ export function registerI18nTools(
       directory: z.string().describe("Directory containing locale files"),
       baseLocale: z.string().optional().describe("Base locale name (e.g., en, es-ES)"),
       targets: z.array(z.string()).describe("Array of target Spanish dialect codes"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
     },
     async (params) => {
       return handleBatchTranslateLocales(params as BatchTranslateLocalesParams, registry, rateLimiter);

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -961,7 +961,7 @@ export function registerTranslatorTools(
     {
       text: z.string().describe("Text to translate"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
       formal: z.boolean().optional().describe("Use formal tone"),
       informal: z.boolean().optional().describe("Use informal tone"),
     },
@@ -989,7 +989,7 @@ export function registerTranslatorTools(
     {
       code: z.string().describe("Source code with comments to translate"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
     },
     async (params) => {
       return handleTranslateCodeComment(params as TranslateCodeCommentParams, registry, rateLimiter);
@@ -1003,7 +1003,7 @@ export function registerTranslatorTools(
     {
       filePath: z.string().describe("Path to the README markdown file"),
       dialect: z.string().optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: z.string().optional().describe("Translation provider name (deepl, libre, mymemory)"),
+      provider: z.string().optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
       formal: z.boolean().optional().describe("Use formal tone"),
       informal: z.boolean().optional().describe("Use informal tone"),
     },

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -5,24 +5,32 @@ Translation providers with circuit breaker, retry logic, and capability negotiat
 ## Supported Providers
 
 | Provider | Auth Required | Dialect Support | Max Payload |
-|----------|--------------|-----------------|-------------|
-| DeepL | ✅ API key | Native (25 variants) | 50,000 chars |
+|----------|---------------|-----------------|-------------|
+| LLM | Optional by gateway | Semantic dialect-aware | 50,000 chars default |
+| DeepL | ✅ API key | Native/approximate | 50,000 chars |
 | LibreTranslate | Optional | None | 5,000 chars |
 | MyMemory | ❌ Free | None | 500 chars |
 
 ## Usage
 
 ```typescript
-import { ProviderRegistry, DeepLProvider, LibreTranslateProvider, MyMemoryProvider } from "@espanol/providers";
+import { ProviderRegistry, LLMProvider, DeepLProvider, LibreTranslateProvider, MyMemoryProvider } from "@espanol/providers";
 
 const registry = new ProviderRegistry();
 
-// Register providers
+// Register semantic provider first
+registry.register(new LLMProvider({
+  endpoint: process.env.LLM_API_URL,
+  model: process.env.LLM_MODEL,
+  apiKey: process.env.LLM_API_KEY,
+}));
+
+// Register fallback utilities
 registry.register(new DeepLProvider(process.env.DEEPL_AUTH_KEY));
 registry.register(new LibreTranslateProvider({ endpoint: "https://libretranslate.de" }));
 registry.register(new MyMemoryProvider());
 
-// Get first available provider
+// Get best available provider; semantic dialect providers are preferred
 const provider = registry.getAuto();
 const result = await provider.translate("Hello", "en", "es");
 ```

--- a/packages/providers/src/__tests__/providers.test.ts
+++ b/packages/providers/src/__tests__/providers.test.ts
@@ -11,6 +11,7 @@ import {
   DeepLProvider,
   LibreTranslateProvider,
   MyMemoryProvider,
+  LLMProvider,
   TranslationProvider,
   TranslationResult,
   ChaosProvider,
@@ -820,6 +821,80 @@ describe("Rate limiting", () => {
 });
 
 describe("Provider capabilities", () => {
+
+  it("LLM should report semantic dialect support", () => {
+    const provider = new LLMProvider({
+      endpoint: "https://llm.example/v1/chat/completions",
+      model: "dialect-model",
+      apiKey: "test-key",
+    });
+    const caps = provider.getCapabilities!();
+    expect(caps.name).toBe("llm");
+    expect(caps.supportsFormality).toBe(true);
+    expect(caps.supportsContext).toBe(true);
+    expect(caps.supportsDialect).toBe(true);
+    expect(caps.dialectHandling).toBe("semantic");
+    expect(caps.needsApiKey).toBe(true);
+    expect(caps.supportedTargetLangs).toContain("es");
+  });
+
+  it("LLM should send dialect context to an OpenAI-compatible chat endpoint", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) => name === "content-type" ? "application/json" : null,
+      },
+      json: async () => ({
+        choices: [{ message: { content: "Vos podés actualizar tu cuenta ahora." } }],
+      }),
+    } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "https://llm.example/v1/chat/completions",
+      model: "dialect-model",
+      apiKey: "test-key",
+    });
+
+    const result = await provider.translate("You can update your account now.", "en", "es", {
+      dialect: "es-AR",
+      formality: "informal",
+      context: "Use pronominal and verbal voseo.",
+    });
+
+    expect(result.translatedText).toBe("Vos podés actualizar tu cuenta ahora.");
+    expect(result.provider).toBe("llm");
+    expect(result.dialect).toBe("es-AR");
+    expect(global.fetch).toHaveBeenCalledWith("https://llm.example/v1/chat/completions", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({
+        "Content-Type": "application/json",
+        Authorization: "Bearer test-key",
+      }),
+    }));
+    const body = JSON.parse(vi.mocked(global.fetch).mock.calls.at(-1)![1]!.body as string);
+    expect(body.model).toBe("dialect-model");
+    expect(body.messages[0].content).toContain("semantic dialect-aware Spanish translation engine");
+    expect(body.messages[1].content).toContain("Target dialect: es-AR");
+    expect(body.messages[1].content).toContain("Use pronominal and verbal voseo");
+    expect(body.messages[1].content).toContain("You can update your account now.");
+  });
+
+  it("LLM should reject missing chat completions content", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({ choices: [] }),
+    } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "https://llm.example/v1/chat/completions",
+      model: "dialect-model",
+    });
+
+    await expect(provider.translate("Hello", "en", "es", { dialect: "es-MX" })).rejects.toThrow(
+      "LLM response did not include translated content"
+    );
+  });
   it("DeepL should report native dialect support", () => {
     const provider = new DeepLProvider("test-key", undefined, {
       timeout: 5000,
@@ -859,6 +934,68 @@ describe("Provider capabilities", () => {
     expect(caps.maxPayloadChars).toBe(500);
     expect(caps.dialectHandling).toBe("none");
     expect(caps.rateLimitHints).toEqual({ maxRequests: 10, windowMs: 60000 });
+  });
+
+
+  it("Registry auto should prefer semantic dialect providers over generic providers", () => {
+    const registry = new ProviderRegistry();
+    const generic: TranslationProvider = {
+      name: "generic",
+      translate: async () => ({ translatedText: "genérico" }),
+      getCapabilities: () => ({
+        name: "generic",
+        displayName: "Generic",
+        needsApiKey: false,
+        supportsFormality: false,
+        supportsContext: false,
+        supportsDialect: false,
+        supportedSourceLangs: ["en", "auto"],
+        supportedTargetLangs: ["es"],
+        maxPayloadChars: 1000,
+        dialectHandling: "none",
+      }),
+    };
+    const semantic: TranslationProvider = {
+      name: "semantic",
+      translate: async () => ({ translatedText: "vos podés" }),
+      getCapabilities: () => ({
+        name: "semantic",
+        displayName: "Semantic",
+        needsApiKey: true,
+        supportsFormality: true,
+        supportsContext: true,
+        supportsDialect: true,
+        supportedSourceLangs: ["en", "auto"],
+        supportedTargetLangs: ["es"],
+        maxPayloadChars: 1000,
+        dialectHandling: "semantic",
+      }),
+    };
+
+    registry.register(generic);
+    registry.register(semantic);
+
+    expect(registry.getAuto().name).toBe("semantic");
+  });
+
+  it("Registry should preserve dialect and context for semantic providers", () => {
+    const registry = new ProviderRegistry();
+    registry.register(new LLMProvider({
+      endpoint: "https://llm.example/v1/chat/completions",
+      model: "dialect-model",
+    }));
+
+    const prepared = registry.prepareRequest("llm", "hello", "auto", "es", {
+      dialect: "es-PR",
+      formality: "formal",
+      context: "Use Puerto Rican vocabulary naturally.",
+    });
+
+    expect(prepared.targetLang).toBe("es");
+    expect(prepared.options.dialect).toBe("es-PR");
+    expect(prepared.options.context).toContain("Puerto Rican");
+    expect(prepared.options.formality).toBe("formal");
+    expect(prepared.warnings).toEqual([]);
   });
 
   it("Registry should return capabilities by name", () => {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -16,6 +16,7 @@ export { ProviderRegistry } from "./registry.js";
 export { DeepLProvider } from "./providers/deepl.js";
 export { LibreTranslateProvider } from "./providers/libre-translate.js";
 export { MyMemoryProvider } from "./providers/my-memory.js";
+export { LLMProvider } from "./providers/llm.js";
 
 // Chaos testing
 export { ChaosProvider } from "./chaos-provider.js";

--- a/packages/providers/src/providers/llm.ts
+++ b/packages/providers/src/providers/llm.ts
@@ -1,0 +1,236 @@
+/**
+ * Generic OpenAI-compatible LLM provider.
+ *
+ * This is the semantic provider path for DialectOS: the provider receives the
+ * full dialect/context/formality prompt and is expected to perform translation
+ * plus dialect adaptation, not generic machine translation.
+ */
+
+import type { ProviderCapability, TranslateOptions, TranslationProvider, TranslationResult } from "../types.js";
+import { CircuitBreaker } from "../circuit-breaker.js";
+import { RateLimiter, sanitizeErrorMessage, HTTP_TIMEOUT, validateContentLength, SecurityError, ErrorCode } from "@espanol/security";
+import { ALL_SPANISH_DIALECTS, languageCodeSchema } from "@espanol/types";
+
+const DEFAULT_MAX_PAYLOAD_CHARS = 50000;
+const DEFAULT_MAX_REQUESTS = 60;
+const DEFAULT_WINDOW_MS = 60000;
+
+export interface LLMProviderOptions {
+  /** Full OpenAI-compatible chat completions endpoint. */
+  endpoint?: string;
+  /** Model name understood by the configured LLM endpoint. */
+  model?: string;
+  /** Optional bearer token. Required by most hosted LLM endpoints, optional for local gateways. */
+  apiKey?: string;
+  /** Allow localhost/private endpoint URLs for explicitly configured local LLM gateways. */
+  allowLocal?: boolean;
+  timeoutMs?: number;
+  maxPayloadChars?: number;
+  failureThreshold?: number;
+  resetTimeoutMs?: number;
+  maxRequests?: number;
+  windowMs?: number;
+}
+
+function validateLLMEndpoint(urlStr: string, allowLocal: boolean): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    throw new SecurityError("Invalid LLM endpoint URL", ErrorCode.INVALID_INPUT);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new SecurityError("LLM endpoint must use http or https", ErrorCode.INVALID_INPUT);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const isLocal =
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "0.0.0.0" ||
+    hostname.startsWith("127.") ||
+    hostname.startsWith("10.") ||
+    hostname.startsWith("192.168.") ||
+    hostname.startsWith("169.254.") ||
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname) ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    hostname.startsWith("fc") ||
+    hostname.startsWith("fd") ||
+    hostname.startsWith("[fc") ||
+    hostname.startsWith("[fd");
+
+  if (isLocal && !allowLocal) {
+    throw new SecurityError(
+      "LLM endpoint cannot point to localhost/private addresses unless LLM_ALLOW_LOCAL=1",
+      ErrorCode.INVALID_INPUT
+    );
+  }
+
+  return urlStr;
+}
+
+function extractChatCompletionText(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const choices = (data as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return undefined;
+  const first = choices[0] as { message?: { content?: unknown }; text?: unknown } | undefined;
+  const content = first?.message?.content ?? first?.text;
+  return typeof content === "string" && content.trim().length > 0
+    ? content.trim()
+    : undefined;
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You are a semantic dialect-aware Spanish translation engine for DialectOS.",
+    "Translate meaning, intent, register, and audience expectations; never do word-by-word literal substitution when it damages dialect fidelity.",
+    "Use the requested dialect grammar, formality, taboo, ambiguity, glossary, and style context exactly.",
+    "Return only the translated text. Do not add explanations, labels, markdown fences, or alternatives.",
+  ].join(" ");
+}
+
+function buildUserPrompt(text: string, sourceLang: string, targetLang: string, options: TranslateOptions = {}): string {
+  return [
+    `Source language: ${sourceLang}.`,
+    `Target language: ${targetLang}.`,
+    options.dialect ? `Target dialect: ${options.dialect}.` : undefined,
+    options.formality ? `Formality: ${options.formality}.` : undefined,
+    options.context ? `Dialect/context instructions: ${options.context}` : undefined,
+    "Source text:",
+    text,
+  ].filter(Boolean).join("\n");
+}
+
+export class LLMProvider implements TranslationProvider {
+  readonly name = "llm";
+  private endpoint: string;
+  private model: string;
+  private apiKey?: string;
+  private timeoutMs: number;
+  private maxPayloadChars: number;
+  private breaker: CircuitBreaker;
+  private rateLimiter: RateLimiter;
+  private needsApiKey: boolean;
+
+  constructor(options: LLMProviderOptions = {}) {
+    const endpoint = options.endpoint || process.env.LLM_API_URL || process.env.LLM_ENDPOINT || "";
+    const model = options.model || process.env.LLM_MODEL || "";
+    const allowLocal = options.allowLocal ?? process.env.LLM_ALLOW_LOCAL === "1";
+
+    if (!endpoint) {
+      throw new Error("LLM_API_URL environment variable is required");
+    }
+    if (!model) {
+      throw new Error("LLM_MODEL environment variable is required");
+    }
+
+    this.endpoint = validateLLMEndpoint(endpoint, allowLocal);
+    this.model = model;
+    this.apiKey = options.apiKey || process.env.LLM_API_KEY;
+    this.needsApiKey = Boolean(this.apiKey);
+    this.timeoutMs = options.timeoutMs || parseInt(process.env.LLM_TIMEOUT_MS || "", 10) || HTTP_TIMEOUT;
+    this.maxPayloadChars = options.maxPayloadChars || parseInt(process.env.LLM_MAX_PAYLOAD_CHARS || "", 10) || DEFAULT_MAX_PAYLOAD_CHARS;
+    this.breaker = new CircuitBreaker(options.failureThreshold || 5, options.resetTimeoutMs || 60000);
+    this.rateLimiter = new RateLimiter(
+      options.maxRequests || parseInt(process.env.LLM_RATE_LIMIT || "", 10) || DEFAULT_MAX_REQUESTS,
+      options.windowMs || parseInt(process.env.LLM_RATE_WINDOW_MS || "", 10) || DEFAULT_WINDOW_MS
+    );
+  }
+
+  getCapabilities(): ProviderCapability {
+    return {
+      name: this.name,
+      displayName: "Generic LLM",
+      needsApiKey: this.needsApiKey,
+      supportsFormality: true,
+      supportsContext: true,
+      supportsDialect: true,
+      supportedSourceLangs: ["auto", "en", "es"],
+      supportedTargetLangs: ["es", ...ALL_SPANISH_DIALECTS],
+      maxPayloadChars: this.maxPayloadChars,
+      dialectHandling: "semantic",
+      rateLimitHints: { maxRequests: DEFAULT_MAX_REQUESTS, windowMs: DEFAULT_WINDOW_MS },
+    };
+  }
+
+  async translate(
+    text: string,
+    sourceLang: string,
+    targetLang: string,
+    options?: TranslateOptions
+  ): Promise<TranslationResult> {
+    validateContentLength(text);
+    if (text.length > this.maxPayloadChars) {
+      throw new Error(`Payload too large: ${text.length} chars exceeds max ${this.maxPayloadChars}`);
+    }
+
+    const sourceResult = languageCodeSchema.safeParse(sourceLang === "auto" ? "en" : sourceLang);
+    const targetResult = languageCodeSchema.safeParse(targetLang.split("-")[0]);
+    if (!sourceResult.success || !targetResult.success) {
+      throw new SecurityError("Invalid language code", ErrorCode.INVALID_INPUT);
+    }
+
+    if (!this.breaker.canExecute()) {
+      throw new Error("LLM provider is temporarily unavailable (circuit open)");
+    }
+    await this.rateLimiter.acquire();
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      const response = await fetch(this.endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: this.model,
+          temperature: 0.2,
+          messages: [
+            { role: "system", content: buildSystemPrompt() },
+            { role: "user", content: buildUserPrompt(text, sourceLang, targetLang, options) },
+          ],
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        clearTimeout(timeoutId);
+        throw new Error(`LLM API error: ${response.statusText}`);
+      }
+
+      const contentType = response.headers.get("content-type");
+      if (!contentType?.includes("application/json")) {
+        clearTimeout(timeoutId);
+        throw new Error("Invalid response content type");
+      }
+
+      const data = await response.json();
+      clearTimeout(timeoutId);
+      const translatedText = extractChatCompletionText(data);
+      if (!translatedText) {
+        throw new Error("LLM response did not include translated content");
+      }
+
+      this.breaker.recordSuccess();
+      return {
+        translatedText,
+        provider: "llm",
+        dialect: options?.dialect,
+      };
+    } catch (error) {
+      clearTimeout(timeoutId);
+      this.breaker.recordFailure();
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error("Request timed out");
+      }
+      throw new Error(sanitizeErrorMessage(error instanceof Error ? error.message : String(error)));
+    }
+  }
+}

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -60,16 +60,37 @@ export class ProviderRegistry {
   }
 
   /**
-   * Get the first available provider (with closed circuit)
+   * Get the best available provider (with closed circuit).
+   * Semantic dialect-aware providers win over generic machine translation.
    */
   getAuto(): TranslationProvider {
-    for (const [_, entry] of this.providers) {
+    const rankedEntries = Array.from(this.providers.values()).sort((a, b) =>
+      this.providerRank(b.provider) - this.providerRank(a.provider)
+    );
+
+    for (const entry of rankedEntries) {
       if (entry.breaker.canExecute()) {
         return entry.provider;
       }
     }
 
     throw new Error("No translation providers are currently available");
+  }
+
+  private providerRank(provider: TranslationProvider): number {
+    const caps = provider.getCapabilities?.();
+    switch (caps?.dialectHandling) {
+      case "semantic":
+        return 4;
+      case "native":
+        return 3;
+      case "approximate":
+        return 2;
+      case "none":
+        return 1;
+      default:
+        return 0;
+    }
   }
 
   /**

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -237,6 +237,7 @@ describe("Zod Validation Schemas", () => {
 
   describe("providerNameSchema", () => {
     it("should accept valid providers", () => {
+      expect(() => providerNameSchema.parse("llm")).not.toThrow();
       expect(() => providerNameSchema.parse("deepl")).not.toThrow();
       expect(() => providerNameSchema.parse("libre")).not.toThrow();
       expect(() => providerNameSchema.parse("mymemory")).not.toThrow();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,7 +48,7 @@ export const DEFAULT_DIALECT: SpanishDialect = "es-ES";
 /**
  * Supported translation providers
  */
-export type ProviderName = "deepl" | "libre" | "mymemory";
+export type ProviderName = "llm" | "deepl" | "libre" | "mymemory";
 
 /**
  * Translation options
@@ -116,7 +116,7 @@ export interface ProviderCapability {
   /** Maximum payload size in characters */
   maxPayloadChars: number;
   /** How the provider handles dialect variants */
-  dialectHandling: "native" | "approximate" | "none";
+  dialectHandling: "semantic" | "native" | "approximate" | "none";
   /** Rate limit hints (requests per window) */
   rateLimitHints?: {
     maxRequests: number;
@@ -348,7 +348,7 @@ export const dialectSchema = z.enum([
 /**
  * Validates translation provider names
  */
-export const providerNameSchema = z.enum(["deepl", "libre", "mymemory"], {
+export const providerNameSchema = z.enum(["llm", "deepl", "libre", "mymemory"], {
   message: "Invalid translation provider",
 });
 

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -54,7 +54,7 @@ async function createLiveTranslate() {
   const registry = createProviderRegistry();
   const available = registry.listProviders();
   if (available.length === 0) {
-    throw new Error("No live providers are configured. Set DEEPL_AUTH_KEY, LIBRETRANSLATE_URL, or ENABLE_MYMEMORY=1.");
+    throw new Error("No live providers are configured. Set LLM_API_URL + LLM_MODEL, DEEPL_AUTH_KEY, LIBRETRANSLATE_URL, or ENABLE_MYMEMORY=1.");
   }
 
   return async (sample, dialect) => {


### PR DESCRIPTION
## Summary
- Add a dependency-free OpenAI-compatible `LLMProvider` as the semantic dialect provider path.
- Register LLM providers in both CLI and MCP factories via `LLM_API_URL` + `LLM_MODEL` (+ optional `LLM_API_KEY`).
- Rank semantic dialect providers ahead of generic machine-translation providers in `ProviderRegistry.getAuto()` and fallback chains.
- Keep DeepL/LibreTranslate/MyMemory as fallback utilities, not silent launch-primary dialect providers.
- Update provider schemas, CLI/MCP provider labels, docs, and test counts.

## Why
LibreTranslate and MyMemory do not consume context/dialect instructions, so they can produce fluent generic Spanish while ignoring voseo, vosotros, regional terms, formality, taboo policy, and semantic prompt guidance. DialectOS needs an LLM path that receives the full dialect contract.

## Configuration
```bash
LLM_API_URL="https://your-llm-gateway/v1/chat/completions"
LLM_MODEL="your-dialect-capable-model"
LLM_API_KEY="optional-bearer-token"
```

Local/private gateways are blocked unless explicitly enabled:
```bash
LLM_ALLOW_LOCAL=1
```

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 650 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-eval.mjs --out=/tmp/dialectos-llm-provider-mock` — 27/27 across 25 dialects
- OpenAI-compatible local mock LLM live run: `LLM_API_URL=http://127.0.0.1:<port>/v1/chat/completions LLM_MODEL=mock-dialect-llm LLM_ALLOW_LOCAL=1 pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-llm-live-mock` — 27/27 across 25 dialects
