### PR TITLE
Make LLM provider model API agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-650%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-653%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -36,7 +36,7 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 | Gender-neutral language | ❌ | ❌ | ✅ **elles / latine / -x** |
 | Formality checking (tú vs usted) | ❌ | ❌ | ✅ **Cross-dialect consistency** |
 | Adversarial quality gates | ❌ | ❌ | ✅ **Semantic drift + structure validation** |
-| LLM-first dialect adaptation | ❌ Generic MT | ⚠️ Limited dialect control | ✅ **Any OpenAI-compatible LLM + dialect contracts** |
+| LLM-first dialect adaptation | ❌ Generic MT | ⚠️ Limited dialect control | ✅ **Any OpenAI/Anthropic-compatible LLM + dialect contracts** |
 
 ---
 
@@ -71,6 +71,7 @@ Add to your Claude Desktop, Cursor, or any MCP client:
         "LLM_API_URL": "https://your-llm-gateway/v1/chat/completions",
         "LLM_MODEL": "your-dialect-capable-model",
         "LLM_API_KEY": "your-key-if-required",
+        "LLM_API_FORMAT": "openai",
         "ALLOWED_LOCALE_DIRS": "/path/to/locales"
       }
     }
@@ -104,7 +105,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 650 tests passing
+pnpm test        # 653 tests passing
 ```
 
 ---
@@ -146,14 +147,14 @@ pnpm test        # 650 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 253 |
-| [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 66 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 254 |
+| [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 68 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 650 tests across 7 packages**
+**Total: 653 tests across 7 packages**
 
 ---
 
@@ -267,7 +268,7 @@ See [`ROADMAP.md`](ROADMAP.md) for upcoming features including:
 - Portuguese dialect support (pt-BR, pt-PT)
 - Real-time collaborative translation
 - Custom provider plugins
-- OpenAI-compatible LLM gateways via `LLM_API_URL` + `LLM_MODEL`
+- OpenAI-compatible and Anthropic-compatible LLM gateways via `LLM_API_URL` + `LLM_MODEL` + `LLM_API_FORMAT`
 - VS Code extension
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        650 tests passing · BSL 1.1 · GitHub Pages
+        653 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">650</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">653</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 650 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 653 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-650 tests. 7 packages. pnpm monorepo. TypeScript.
+653 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -85,13 +85,13 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 
 **Features:**
 - 25 Spanish dialects with metadata
-- Connect any OpenAI-compatible LLM, with LibreTranslate/DeepL/MyMemory as fallback utilities
+- Connect any OpenAI-compatible or Anthropic-compatible LLM, with LibreTranslate/DeepL/MyMemory as fallback utilities
 - MCP server — integrates with Claude, Cursor, etc.
 - Structure-preserving markdown translation
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 650 tests
+**Tech:** TypeScript, pnpm monorepo, 653 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 650 tests passing.
+Source available, BSL 1.1 licensed, 653 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 650 tests
+**Tech stack:** TypeScript, pnpm monorepo, 653 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/provider-factory.test.ts
+++ b/packages/cli/src/__tests__/provider-factory.test.ts
@@ -39,6 +39,21 @@ describe("provider factory", () => {
     expect(registry.getCapabilities("llm")?.dialectHandling).toBe("semantic");
   });
 
+  it("passes Anthropic compatibility mode into configured LLM providers", async () => {
+    clearProviderEnv();
+    process.env.LLM_API_URL = "https://api.anthropic.com/v1/messages";
+    process.env.LLM_MODEL = "claude-dialect";
+    process.env.LLM_API_KEY = "test-key";
+    process.env.LLM_API_FORMAT = "anthropic";
+
+    const registry = createProviderRegistry();
+    const provider = registry.get("llm");
+
+    expect(registry.getAuto().name).toBe("llm");
+    expect(provider.getCapabilities?.().dialectHandling).toBe("semantic");
+    expect((provider as any).apiFormat).toBe("anthropic");
+  });
+
   it("does not register generic fallback providers unless explicitly configured", () => {
     clearProviderEnv();
 

--- a/packages/cli/src/lib/provider-factory.ts
+++ b/packages/cli/src/lib/provider-factory.ts
@@ -27,6 +27,7 @@ export function createProviderRegistry(): ProviderRegistry {
     const llmProvider = new LLMProvider({
       endpoint: llmEndpoint,
       model: llmModel,
+      apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
       apiKey: process.env.LLM_API_KEY,
       allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
     });

--- a/packages/mcp/src/lib/provider-factory.ts
+++ b/packages/mcp/src/lib/provider-factory.ts
@@ -29,6 +29,7 @@ export function createProviderRegistry(): ProviderRegistry {
     registry.register(new LLMProvider({
       endpoint: llmEndpoint,
       model: llmModel,
+      apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
       apiKey: process.env.LLM_API_KEY,
       allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
     }));

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -1,12 +1,12 @@
 # @espanol/providers
 
-Translation providers with circuit breaker, retry logic, and capability negotiation.
+Translation providers with circuit breaker, retry logic, model-agnostic LLM compatibility, and capability negotiation.
 
 ## Supported Providers
 
 | Provider | Auth Required | Dialect Support | Max Payload |
 |----------|---------------|-----------------|-------------|
-| LLM | Optional by gateway | Semantic dialect-aware | 50,000 chars default |
+| LLM | Optional by gateway | Semantic dialect-aware (OpenAI/Anthropic-compatible) | 50,000 chars default |
 | DeepL | ✅ API key | Native/approximate | 50,000 chars |
 | LibreTranslate | Optional | None | 5,000 chars |
 | MyMemory | ❌ Free | None | 500 chars |
@@ -23,6 +23,7 @@ registry.register(new LLMProvider({
   endpoint: process.env.LLM_API_URL,
   model: process.env.LLM_MODEL,
   apiKey: process.env.LLM_API_KEY,
+  apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
 }));
 
 // Register fallback utilities
@@ -33,6 +34,17 @@ registry.register(new MyMemoryProvider());
 // Get best available provider; semantic dialect providers are preferred
 const provider = registry.getAuto();
 const result = await provider.translate("Hello", "en", "es");
+```
+
+### LLM compatibility
+
+Use `LLM_API_FORMAT=openai` for OpenAI-compatible chat-completions gateways and `LLM_API_FORMAT=anthropic` for Anthropic-compatible messages gateways.
+
+```bash
+LLM_API_URL="https://api.anthropic.com/v1/messages"
+LLM_MODEL="claude-sonnet-4-5"
+LLM_API_KEY="..."
+LLM_API_FORMAT="anthropic"
 ```
 
 ## Capability Negotiation

--- a/packages/providers/src/__tests__/providers.test.ts
+++ b/packages/providers/src/__tests__/providers.test.ts
@@ -895,6 +895,66 @@ describe("Provider capabilities", () => {
       "LLM response did not include translated content"
     );
   });
+
+  it("LLM should send dialect context to an Anthropic-compatible messages endpoint", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) => name === "content-type" ? "application/json" : null,
+      },
+      json: async () => ({
+        content: [{ type: "text", text: "Vos podés actualizar tu cuenta ahora." }],
+      }),
+    } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "https://api.anthropic.com/v1/messages",
+      model: "claude-dialect",
+      apiKey: "anthropic-key",
+      apiFormat: "anthropic",
+    });
+
+    const result = await provider.translate("You can update your account now.", "en", "es", {
+      dialect: "es-AR",
+      formality: "informal",
+      context: "Use pronominal and verbal voseo.",
+    });
+
+    expect(result.translatedText).toBe("Vos podés actualizar tu cuenta ahora.");
+    expect(global.fetch).toHaveBeenCalledWith("https://api.anthropic.com/v1/messages", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({
+        "Content-Type": "application/json",
+        "x-api-key": "anthropic-key",
+        "anthropic-version": "2023-06-01",
+      }),
+    }));
+    const body = JSON.parse(vi.mocked(global.fetch).mock.calls.at(-1)![1]!.body as string);
+    expect(body.model).toBe("claude-dialect");
+    expect(body.system).toContain("semantic dialect-aware Spanish translation engine");
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[0].content).toContain("Target dialect: es-AR");
+    expect(body.messages[0].content).toContain("Use pronominal and verbal voseo");
+  });
+
+  it("LLM should reject missing Anthropic message content", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({ content: [] }),
+    } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "https://api.anthropic.com/v1/messages",
+      model: "claude-dialect",
+      apiFormat: "anthropic",
+    });
+
+    await expect(provider.translate("Hello", "en", "es", { dialect: "es-MX" })).rejects.toThrow(
+      "LLM response did not include translated content"
+    );
+  });
   it("DeepL should report native dialect support", () => {
     const provider = new DeepLProvider("test-key", undefined, {
       timeout: 5000,

--- a/packages/providers/src/providers/llm.ts
+++ b/packages/providers/src/providers/llm.ts
@@ -1,5 +1,5 @@
 /**
- * Generic OpenAI-compatible LLM provider.
+ * Generic LLM provider for OpenAI-compatible and Anthropic-compatible APIs.
  *
  * This is the semantic provider path for DialectOS: the provider receives the
  * full dialect/context/formality prompt and is expected to perform translation
@@ -14,14 +14,21 @@ import { ALL_SPANISH_DIALECTS, languageCodeSchema } from "@espanol/types";
 const DEFAULT_MAX_PAYLOAD_CHARS = 50000;
 const DEFAULT_MAX_REQUESTS = 60;
 const DEFAULT_WINDOW_MS = 60000;
+const DEFAULT_ANTHROPIC_VERSION = "2023-06-01";
+
+export type LLMApiFormat = "openai" | "anthropic";
 
 export interface LLMProviderOptions {
-  /** Full OpenAI-compatible chat completions endpoint. */
+  /** Full chat/message endpoint URL. */
   endpoint?: string;
   /** Model name understood by the configured LLM endpoint. */
   model?: string;
+  /** Wire protocol to use for the configured endpoint. */
+  apiFormat?: LLMApiFormat;
   /** Optional bearer token. Required by most hosted LLM endpoints, optional for local gateways. */
   apiKey?: string;
+  /** Anthropic API version header. Only used when apiFormat is "anthropic". */
+  anthropicVersion?: string;
   /** Allow localhost/private endpoint URLs for explicitly configured local LLM gateways. */
   allowLocal?: boolean;
   timeoutMs?: number;
@@ -82,6 +89,23 @@ function extractChatCompletionText(data: unknown): string | undefined {
     : undefined;
 }
 
+function extractAnthropicText(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const content = (data as { content?: unknown }).content;
+  if (!Array.isArray(content)) return undefined;
+
+  const text = content
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const maybeText = (part as { text?: unknown }).text;
+      return typeof maybeText === "string" ? maybeText : "";
+    })
+    .join("")
+    .trim();
+
+  return text.length > 0 ? text : undefined;
+}
+
 function buildSystemPrompt(): string {
   return [
     "You are a semantic dialect-aware Spanish translation engine for DialectOS.",
@@ -107,7 +131,9 @@ export class LLMProvider implements TranslationProvider {
   readonly name = "llm";
   private endpoint: string;
   private model: string;
+  private apiFormat: LLMApiFormat;
   private apiKey?: string;
+  private anthropicVersion: string;
   private timeoutMs: number;
   private maxPayloadChars: number;
   private breaker: CircuitBreaker;
@@ -117,6 +143,7 @@ export class LLMProvider implements TranslationProvider {
   constructor(options: LLMProviderOptions = {}) {
     const endpoint = options.endpoint || process.env.LLM_API_URL || process.env.LLM_ENDPOINT || "";
     const model = options.model || process.env.LLM_MODEL || "";
+    const apiFormat = options.apiFormat || process.env.LLM_API_FORMAT || "openai";
     const allowLocal = options.allowLocal ?? process.env.LLM_ALLOW_LOCAL === "1";
 
     if (!endpoint) {
@@ -125,10 +152,15 @@ export class LLMProvider implements TranslationProvider {
     if (!model) {
       throw new Error("LLM_MODEL environment variable is required");
     }
+    if (apiFormat !== "openai" && apiFormat !== "anthropic") {
+      throw new Error("LLM_API_FORMAT must be 'openai' or 'anthropic'");
+    }
 
     this.endpoint = validateLLMEndpoint(endpoint, allowLocal);
     this.model = model;
+    this.apiFormat = apiFormat;
     this.apiKey = options.apiKey || process.env.LLM_API_KEY;
+    this.anthropicVersion = options.anthropicVersion || process.env.LLM_ANTHROPIC_VERSION || DEFAULT_ANTHROPIC_VERSION;
     this.needsApiKey = Boolean(this.apiKey);
     this.timeoutMs = options.timeoutMs || parseInt(process.env.LLM_TIMEOUT_MS || "", 10) || HTTP_TIMEOUT;
     this.maxPayloadChars = options.maxPayloadChars || parseInt(process.env.LLM_MAX_PAYLOAD_CHARS || "", 10) || DEFAULT_MAX_PAYLOAD_CHARS;
@@ -181,22 +213,13 @@ export class LLMProvider implements TranslationProvider {
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
 
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (this.apiKey) {
-        headers.Authorization = `Bearer ${this.apiKey}`;
-      }
-
+      const systemPrompt = buildSystemPrompt();
+      const userPrompt = buildUserPrompt(text, sourceLang, targetLang, options);
+      const headers = this.buildHeaders();
       const response = await fetch(this.endpoint, {
         method: "POST",
         headers,
-        body: JSON.stringify({
-          model: this.model,
-          temperature: 0.2,
-          messages: [
-            { role: "system", content: buildSystemPrompt() },
-            { role: "user", content: buildUserPrompt(text, sourceLang, targetLang, options) },
-          ],
-        }),
+        body: JSON.stringify(this.buildRequestBody(systemPrompt, userPrompt)),
         signal: controller.signal,
       });
 
@@ -213,7 +236,7 @@ export class LLMProvider implements TranslationProvider {
 
       const data = await response.json();
       clearTimeout(timeoutId);
-      const translatedText = extractChatCompletionText(data);
+      const translatedText = this.extractResponseText(data);
       if (!translatedText) {
         throw new Error("LLM response did not include translated content");
       }
@@ -232,5 +255,51 @@ export class LLMProvider implements TranslationProvider {
       }
       throw new Error(sanitizeErrorMessage(error instanceof Error ? error.message : String(error)));
     }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+    if (this.apiFormat === "anthropic") {
+      headers["anthropic-version"] = this.anthropicVersion;
+      if (this.apiKey) {
+        headers["x-api-key"] = this.apiKey;
+      }
+      return headers;
+    }
+
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private buildRequestBody(systemPrompt: string, userPrompt: string): Record<string, unknown> {
+    if (this.apiFormat === "anthropic") {
+      return {
+        model: this.model,
+        max_tokens: 4096,
+        temperature: 0.2,
+        system: systemPrompt,
+        messages: [
+          { role: "user", content: userPrompt },
+        ],
+      };
+    }
+
+    return {
+      model: this.model,
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+    };
+  }
+
+  private extractResponseText(data: unknown): string | undefined {
+    return this.apiFormat === "anthropic"
+      ? extractAnthropicText(data)
+      : extractChatCompletionText(data);
   }
 }


### PR DESCRIPTION
## Summary
- Extend `LLMProvider` from OpenAI-compatible only to OpenAI-compatible **and Anthropic-compatible** wire formats.
- Add `LLM_API_FORMAT=openai|anthropic` and pass it through CLI/MCP provider factories.
- Send Anthropic requests using `system`, `messages`, `max_tokens`, `x-api-key`, and `anthropic-version` headers.
- Parse Anthropic `content[].text` responses while preserving OpenAI `choices[].message.content` support.
- Update docs and test counts to 653.

## Configuration
OpenAI-compatible default:
```bash
LLM_API_URL="https://your-openai-compatible-gateway/v1/chat/completions"
LLM_MODEL="your-model"
LLM_API_KEY="optional"
LLM_API_FORMAT="openai"
```

Anthropic-compatible:
```bash
LLM_API_URL="https://api.anthropic.com/v1/messages"
LLM_MODEL="claude-sonnet-4-5"
LLM_API_KEY="your-key"
LLM_API_FORMAT="anthropic"
# optional override
LLM_ANTHROPIC_VERSION="2023-06-01"
```

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 653 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-eval.mjs --out=/tmp/dialectos-anthropic-provider-mock` — 27/27 across 25 dialects
- Anthropic-compatible local mock live run: `LLM_API_URL=http://127.0.0.1:<port>/v1/messages LLM_MODEL=mock-anthropic-dialect-llm LLM_API_FORMAT=anthropic LLM_ALLOW_LOCAL=1 pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-anthropic-live-mock` — 27/27 across 25 dialects
