### PR TITLE
Support LM Studio local model certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-653%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-659%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -36,7 +36,7 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 | Gender-neutral language | ❌ | ❌ | ✅ **elles / latine / -x** |
 | Formality checking (tú vs usted) | ❌ | ❌ | ✅ **Cross-dialect consistency** |
 | Adversarial quality gates | ❌ | ❌ | ✅ **Semantic drift + structure validation** |
-| LLM-first dialect adaptation | ❌ Generic MT | ⚠️ Limited dialect control | ✅ **Any OpenAI/Anthropic-compatible LLM + dialect contracts** |
+| LLM-first dialect adaptation | ❌ Generic MT | ⚠️ Limited dialect control | ✅ **Any OpenAI/Anthropic/LM Studio local LLM + dialect contracts** |
 
 ---
 
@@ -79,6 +79,17 @@ Add to your Claude Desktop, Cursor, or any MCP client:
 }
 ```
 
+### LM Studio local model testing
+
+Start LM Studio's local server, then point DialectOS at any downloaded local model. `LLM_API_FORMAT=lmstudio` uses LM Studio's native REST API and loads the model just-in-time when needed.
+
+```bash
+LM_STUDIO_URL="http://127.0.0.1:1234" \
+LLM_MODEL="publisher/model-key-or-api-identifier" \
+LLM_API_FORMAT="lmstudio" \
+pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-lmstudio-eval
+```
+
 ### CLI install
 
 ```bash
@@ -105,7 +116,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 653 tests passing
+pnpm test        # 659 tests passing
 ```
 
 ---
@@ -147,14 +158,14 @@ pnpm test        # 653 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 254 |
-| [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 68 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 257 |
+| [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 653 tests across 7 packages**
+**Total: 659 tests across 7 packages**
 
 ---
 
@@ -268,7 +279,7 @@ See [`ROADMAP.md`](ROADMAP.md) for upcoming features including:
 - Portuguese dialect support (pt-BR, pt-PT)
 - Real-time collaborative translation
 - Custom provider plugins
-- OpenAI-compatible and Anthropic-compatible LLM gateways via `LLM_API_URL` + `LLM_MODEL` + `LLM_API_FORMAT`
+- OpenAI-compatible, Anthropic-compatible, and LM Studio local gateways via `LLM_API_URL`/`LM_STUDIO_URL` + `LLM_MODEL` + `LLM_API_FORMAT`
 - VS Code extension
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        653 tests passing · BSL 1.1 · GitHub Pages
+        659 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">653</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">659</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 653 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 659 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-653 tests. 7 packages. pnpm monorepo. TypeScript.
+659 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -85,13 +85,13 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 
 **Features:**
 - 25 Spanish dialects with metadata
-- Connect any OpenAI-compatible or Anthropic-compatible LLM, with LibreTranslate/DeepL/MyMemory as fallback utilities
+- Connect any OpenAI-compatible, Anthropic-compatible, or LM Studio local LLM, with LibreTranslate/DeepL/MyMemory as fallback utilities
 - MCP server — integrates with Claude, Cursor, etc.
 - Structure-preserving markdown translation
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 653 tests
+**Tech:** TypeScript, pnpm monorepo, 659 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 653 tests passing.
+Source available, BSL 1.1 licensed, 659 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 653 tests
+**Tech stack:** TypeScript, pnpm monorepo, 659 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/provider-factory.test.ts
+++ b/packages/cli/src/__tests__/provider-factory.test.ts
@@ -10,6 +10,7 @@ const ENV_KEYS = [
   "LLM_MODEL",
   "LLM_API_KEY",
   "LLM_ALLOW_LOCAL",
+  "LM_STUDIO_URL",
 ];
 
 function clearProviderEnv() {
@@ -52,6 +53,41 @@ describe("provider factory", () => {
     expect(registry.getAuto().name).toBe("llm");
     expect(provider.getCapabilities?.().dialectHandling).toBe("semantic");
     expect((provider as any).apiFormat).toBe("anthropic");
+  });
+
+  it("passes LM Studio compatibility mode into configured LLM providers", async () => {
+    clearProviderEnv();
+    process.env.LLM_API_URL = "http://127.0.0.1:1234";
+    process.env.LLM_MODEL = "local/dialect-model";
+    process.env.LLM_API_FORMAT = "lmstudio";
+    process.env.LLM_ALLOW_LOCAL = "1";
+
+    const registry = createProviderRegistry();
+    const provider = registry.get("llm");
+
+    expect(registry.getAuto().name).toBe("llm");
+    expect((provider as any).apiFormat).toBe("lmstudio");
+  });
+
+  it("accepts LM_STUDIO_URL as the LM Studio endpoint", async () => {
+    clearProviderEnv();
+    process.env.LM_STUDIO_URL = "http://127.0.0.1:1234";
+    process.env.LLM_MODEL = "local/dialect-model";
+    process.env.LLM_API_FORMAT = "lmstudio";
+
+    const registry = createProviderRegistry();
+
+    expect(registry.getAuto().name).toBe("llm");
+  });
+
+  it("registers LM Studio against the default local server when no URL is provided", async () => {
+    clearProviderEnv();
+    process.env.LLM_MODEL = "local/dialect-model";
+    process.env.LLM_API_FORMAT = "lmstudio";
+
+    const registry = createProviderRegistry();
+
+    expect(registry.getAuto().name).toBe("llm");
   });
 
   it("does not register generic fallback providers unless explicitly configured", () => {

--- a/packages/cli/src/lib/provider-factory.ts
+++ b/packages/cli/src/lib/provider-factory.ts
@@ -21,15 +21,15 @@ export function createProviderRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
 
   // Register LLM first when configured; getAuto also ranks semantic providers first.
-  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT;
+  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT || process.env.LM_STUDIO_URL;
   const llmModel = process.env.LLM_MODEL;
-  if (llmEndpoint && llmModel) {
+  if ((llmEndpoint || process.env.LLM_API_FORMAT === "lmstudio") && llmModel) {
     const llmProvider = new LLMProvider({
       endpoint: llmEndpoint,
       model: llmModel,
-      apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
+      apiFormat: parseLLMApiFormat(process.env.LLM_API_FORMAT),
       apiKey: process.env.LLM_API_KEY,
-      allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
+      allowLocal: process.env.LLM_API_FORMAT === "lmstudio" || process.env.LLM_ALLOW_LOCAL === "1",
     });
     registry.register(llmProvider);
   }
@@ -80,4 +80,8 @@ export function getDefaultProviderRegistry(): ProviderRegistry {
 
 export function resetDefaultProviderRegistryForTests(): void {
   defaultRegistry = null;
+}
+
+function parseLLMApiFormat(value: string | undefined): "openai" | "anthropic" | "lmstudio" {
+  return value === "anthropic" || value === "lmstudio" ? value : "openai";
 }

--- a/packages/mcp/src/lib/provider-factory.ts
+++ b/packages/mcp/src/lib/provider-factory.ts
@@ -23,15 +23,15 @@ export function createProviderRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
 
   // Register LLM first when configured; ProviderRegistry also ranks semantic providers first.
-  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT;
+  const llmEndpoint = process.env.LLM_API_URL || process.env.LLM_ENDPOINT || process.env.LM_STUDIO_URL;
   const llmModel = process.env.LLM_MODEL;
-  if (llmEndpoint && llmModel) {
+  if ((llmEndpoint || process.env.LLM_API_FORMAT === "lmstudio") && llmModel) {
     registry.register(new LLMProvider({
       endpoint: llmEndpoint,
       model: llmModel,
-      apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
+      apiFormat: parseLLMApiFormat(process.env.LLM_API_FORMAT),
       apiKey: process.env.LLM_API_KEY,
-      allowLocal: process.env.LLM_ALLOW_LOCAL === "1",
+      allowLocal: process.env.LLM_API_FORMAT === "lmstudio" || process.env.LLM_ALLOW_LOCAL === "1",
     }));
   }
 
@@ -71,4 +71,8 @@ export function getDefaultProviderRegistry(): ProviderRegistry {
     defaultRegistry = createProviderRegistry();
   }
   return defaultRegistry;
+}
+
+function parseLLMApiFormat(value: string | undefined): "openai" | "anthropic" | "lmstudio" {
+  return value === "anthropic" || value === "lmstudio" ? value : "openai";
 }

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -6,7 +6,7 @@ Translation providers with circuit breaker, retry logic, model-agnostic LLM comp
 
 | Provider | Auth Required | Dialect Support | Max Payload |
 |----------|---------------|-----------------|-------------|
-| LLM | Optional by gateway | Semantic dialect-aware (OpenAI/Anthropic-compatible) | 50,000 chars default |
+| LLM | Optional by gateway | Semantic dialect-aware (OpenAI/Anthropic/LM Studio-compatible) | 50,000 chars default |
 | DeepL | ✅ API key | Native/approximate | 50,000 chars |
 | LibreTranslate | Optional | None | 5,000 chars |
 | MyMemory | ❌ Free | None | 500 chars |
@@ -23,7 +23,11 @@ registry.register(new LLMProvider({
   endpoint: process.env.LLM_API_URL,
   model: process.env.LLM_MODEL,
   apiKey: process.env.LLM_API_KEY,
-  apiFormat: process.env.LLM_API_FORMAT === "anthropic" ? "anthropic" : "openai",
+  apiFormat: process.env.LLM_API_FORMAT === "anthropic"
+    ? "anthropic"
+    : process.env.LLM_API_FORMAT === "lmstudio"
+      ? "lmstudio"
+      : "openai",
 }));
 
 // Register fallback utilities
@@ -38,7 +42,7 @@ const result = await provider.translate("Hello", "en", "es");
 
 ### LLM compatibility
 
-Use `LLM_API_FORMAT=openai` for OpenAI-compatible chat-completions gateways and `LLM_API_FORMAT=anthropic` for Anthropic-compatible messages gateways.
+Use `LLM_API_FORMAT=openai` for OpenAI-compatible chat-completions gateways, `LLM_API_FORMAT=anthropic` for Anthropic-compatible messages gateways, and `LLM_API_FORMAT=lmstudio` for LM Studio native REST with just-in-time local model loading.
 
 ```bash
 LLM_API_URL="https://api.anthropic.com/v1/messages"
@@ -46,6 +50,15 @@ LLM_MODEL="claude-sonnet-4-5"
 LLM_API_KEY="..."
 LLM_API_FORMAT="anthropic"
 ```
+
+
+```bash
+LM_STUDIO_URL="http://127.0.0.1:1234"
+LLM_MODEL="publisher/model-key-or-api-identifier"
+LLM_API_FORMAT="lmstudio"
+```
+
+LM Studio mode calls the native `/api/v1/models`, `/api/v1/models/load`, and `/api/v1/chat` endpoints so a downloaded local model can be loaded on demand before dialect evaluation.
 
 ## Capability Negotiation
 

--- a/packages/providers/src/__tests__/providers.test.ts
+++ b/packages/providers/src/__tests__/providers.test.ts
@@ -955,6 +955,109 @@ describe("Provider capabilities", () => {
       "LLM response did not include translated content"
     );
   });
+
+  it("LLM should use LM Studio native chat with JIT model loading", async () => {
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({
+          models: [{ key: "local/dialect-model", type: "llm", loaded_instances: [] }],
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({ status: "loaded", type: "llm", instance_id: "local/dialect-model" }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({
+          output: [{ type: "message", content: "Vos podés actualizar tu cuenta ahora." }],
+        }),
+      } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "http://127.0.0.1:1234",
+      model: "local/dialect-model",
+      apiFormat: "lmstudio",
+      allowLocal: true,
+    });
+
+    const result = await provider.translate("You can update your account now.", "en", "es", {
+      dialect: "es-AR",
+      formality: "informal",
+      context: "Use pronominal and verbal voseo.",
+    });
+
+    expect(result.translatedText).toBe("Vos podés actualizar tu cuenta ahora.");
+    expect(global.fetch).toHaveBeenNthCalledWith(1, "http://127.0.0.1:1234/api/v1/models", expect.objectContaining({ method: "GET" }));
+    expect(global.fetch).toHaveBeenNthCalledWith(2, "http://127.0.0.1:1234/api/v1/models/load", expect.objectContaining({
+      method: "POST",
+      body: expect.stringContaining('"model":"local/dialect-model"'),
+    }));
+    expect(global.fetch).toHaveBeenNthCalledWith(3, "http://127.0.0.1:1234/api/v1/chat", expect.objectContaining({ method: "POST" }));
+    const chatBody = JSON.parse(vi.mocked(global.fetch).mock.calls[2][1]!.body as string);
+    expect(chatBody.model).toBe("local/dialect-model");
+    expect(chatBody.system_prompt).toContain("semantic dialect-aware Spanish translation engine");
+    expect(chatBody.input).toContain("Target dialect: es-AR");
+    expect(chatBody.store).toBe(false);
+  });
+
+  it("LLM should skip LM Studio load when the model is already loaded", async () => {
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({
+          models: [{ key: "local/dialect-model", type: "llm", loaded_instances: [{ id: "local/dialect-model" }] }],
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({ output: [{ type: "message", content: "Hola" }] }),
+      } as any);
+
+    const provider = new LLMProvider({
+      endpoint: "http://127.0.0.1:1234",
+      model: "local/dialect-model",
+      apiFormat: "lmstudio",
+      allowLocal: true,
+    });
+
+    await provider.translate("Hello", "en", "es", { dialect: "es-MX" });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(global.fetch).mock.calls[1][0]).toBe("http://127.0.0.1:1234/api/v1/chat");
+  });
+
+  it("LLM should default LM Studio format to the local server URL", async () => {
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({ models: [{ key: "local/dialect-model", type: "llm", loaded_instances: [{ id: "local/dialect-model" }] }] }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({ output: [{ type: "message", content: "Hola" }] }),
+      } as any);
+
+    const provider = new LLMProvider({
+      model: "local/dialect-model",
+      apiFormat: "lmstudio",
+    });
+
+    await provider.translate("Hello", "en", "es", { dialect: "es-MX" });
+
+    expect(vi.mocked(global.fetch).mock.calls[0][0]).toBe("http://127.0.0.1:1234/api/v1/models");
+  });
   it("DeepL should report native dialect support", () => {
     const provider = new DeepLProvider("test-key", undefined, {
       timeout: 5000,

--- a/packages/providers/src/providers/llm.ts
+++ b/packages/providers/src/providers/llm.ts
@@ -1,5 +1,6 @@
 /**
- * Generic LLM provider for OpenAI-compatible and Anthropic-compatible APIs.
+ * Generic LLM provider for OpenAI-compatible, Anthropic-compatible, and
+ * LM Studio native APIs.
  *
  * This is the semantic provider path for DialectOS: the provider receives the
  * full dialect/context/formality prompt and is expected to perform translation
@@ -16,7 +17,7 @@ const DEFAULT_MAX_REQUESTS = 60;
 const DEFAULT_WINDOW_MS = 60000;
 const DEFAULT_ANTHROPIC_VERSION = "2023-06-01";
 
-export type LLMApiFormat = "openai" | "anthropic";
+export type LLMApiFormat = "openai" | "anthropic" | "lmstudio";
 
 export interface LLMProviderOptions {
   /** Full chat/message endpoint URL. */
@@ -25,6 +26,16 @@ export interface LLMProviderOptions {
   model?: string;
   /** Wire protocol to use for the configured endpoint. */
   apiFormat?: LLMApiFormat;
+  /** Load an LM Studio model before native chat if it is not already loaded. */
+  lmStudioJitLoad?: boolean;
+  /** Optional native LM Studio load configuration. */
+  lmStudioLoadConfig?: {
+    context_length?: number;
+    eval_batch_size?: number;
+    flash_attention?: boolean;
+    num_experts?: number;
+    offload_kv_cache_to_gpu?: boolean;
+  };
   /** Optional bearer token. Required by most hosted LLM endpoints, optional for local gateways. */
   apiKey?: string;
   /** Anthropic API version header. Only used when apiFormat is "anthropic". */
@@ -106,6 +117,25 @@ function extractAnthropicText(data: unknown): string | undefined {
   return text.length > 0 ? text : undefined;
 }
 
+function extractLMStudioText(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const output = (data as { output?: unknown }).output;
+  if (!Array.isArray(output)) return undefined;
+
+  const text = output
+    .map((item) => {
+      if (!item || typeof item !== "object") return "";
+      const typed = item as { type?: unknown; content?: unknown };
+      return typed.type === "message" && typeof typed.content === "string"
+        ? typed.content
+        : "";
+    })
+    .join("")
+    .trim();
+
+  return text.length > 0 ? text : undefined;
+}
+
 function buildSystemPrompt(): string {
   return [
     "You are a semantic dialect-aware Spanish translation engine for DialectOS.",
@@ -134,6 +164,8 @@ export class LLMProvider implements TranslationProvider {
   private apiFormat: LLMApiFormat;
   private apiKey?: string;
   private anthropicVersion: string;
+  private lmStudioJitLoad: boolean;
+  private lmStudioLoadConfig: LLMProviderOptions["lmStudioLoadConfig"];
   private timeoutMs: number;
   private maxPayloadChars: number;
   private breaker: CircuitBreaker;
@@ -141,10 +173,14 @@ export class LLMProvider implements TranslationProvider {
   private needsApiKey: boolean;
 
   constructor(options: LLMProviderOptions = {}) {
-    const endpoint = options.endpoint || process.env.LLM_API_URL || process.env.LLM_ENDPOINT || "";
     const model = options.model || process.env.LLM_MODEL || "";
     const apiFormat = options.apiFormat || process.env.LLM_API_FORMAT || "openai";
-    const allowLocal = options.allowLocal ?? process.env.LLM_ALLOW_LOCAL === "1";
+    const endpoint = options.endpoint ||
+      process.env.LLM_API_URL ||
+      process.env.LLM_ENDPOINT ||
+      process.env.LM_STUDIO_URL ||
+      (apiFormat === "lmstudio" ? "http://127.0.0.1:1234" : "");
+    const allowLocal = options.allowLocal ?? (apiFormat === "lmstudio" || process.env.LLM_ALLOW_LOCAL === "1");
 
     if (!endpoint) {
       throw new Error("LLM_API_URL environment variable is required");
@@ -152,15 +188,20 @@ export class LLMProvider implements TranslationProvider {
     if (!model) {
       throw new Error("LLM_MODEL environment variable is required");
     }
-    if (apiFormat !== "openai" && apiFormat !== "anthropic") {
-      throw new Error("LLM_API_FORMAT must be 'openai' or 'anthropic'");
+    if (apiFormat !== "openai" && apiFormat !== "anthropic" && apiFormat !== "lmstudio") {
+      throw new Error("LLM_API_FORMAT must be 'openai', 'anthropic', or 'lmstudio'");
     }
 
-    this.endpoint = validateLLMEndpoint(endpoint, allowLocal);
+    this.endpoint = this.normalizeEndpoint(validateLLMEndpoint(endpoint, allowLocal));
     this.model = model;
     this.apiFormat = apiFormat;
     this.apiKey = options.apiKey || process.env.LLM_API_KEY;
     this.anthropicVersion = options.anthropicVersion || process.env.LLM_ANTHROPIC_VERSION || DEFAULT_ANTHROPIC_VERSION;
+    this.lmStudioJitLoad = options.lmStudioJitLoad ?? process.env.LM_STUDIO_JIT_LOAD !== "0";
+    this.lmStudioLoadConfig = {
+      ...this.loadConfigFromEnv(),
+      ...(options.lmStudioLoadConfig || {}),
+    };
     this.needsApiKey = Boolean(this.apiKey);
     this.timeoutMs = options.timeoutMs || parseInt(process.env.LLM_TIMEOUT_MS || "", 10) || HTTP_TIMEOUT;
     this.maxPayloadChars = options.maxPayloadChars || parseInt(process.env.LLM_MAX_PAYLOAD_CHARS || "", 10) || DEFAULT_MAX_PAYLOAD_CHARS;
@@ -216,7 +257,11 @@ export class LLMProvider implements TranslationProvider {
       const systemPrompt = buildSystemPrompt();
       const userPrompt = buildUserPrompt(text, sourceLang, targetLang, options);
       const headers = this.buildHeaders();
-      const response = await fetch(this.endpoint, {
+      if (this.apiFormat === "lmstudio" && this.lmStudioJitLoad) {
+        await this.ensureLMStudioModelLoaded(headers, controller.signal);
+      }
+
+      const response = await fetch(this.inferenceUrl(), {
         method: "POST",
         headers,
         body: JSON.stringify(this.buildRequestBody(systemPrompt, userPrompt)),
@@ -275,6 +320,17 @@ export class LLMProvider implements TranslationProvider {
   }
 
   private buildRequestBody(systemPrompt: string, userPrompt: string): Record<string, unknown> {
+    if (this.apiFormat === "lmstudio") {
+      return {
+        model: this.model,
+        system_prompt: systemPrompt,
+        input: userPrompt,
+        temperature: 0.2,
+        max_output_tokens: 4096,
+        store: false,
+      };
+    }
+
     if (this.apiFormat === "anthropic") {
       return {
         model: this.model,
@@ -298,8 +354,81 @@ export class LLMProvider implements TranslationProvider {
   }
 
   private extractResponseText(data: unknown): string | undefined {
-    return this.apiFormat === "anthropic"
-      ? extractAnthropicText(data)
-      : extractChatCompletionText(data);
+    switch (this.apiFormat) {
+      case "anthropic":
+        return extractAnthropicText(data);
+      case "lmstudio":
+        return extractLMStudioText(data);
+      default:
+        return extractChatCompletionText(data);
+    }
   }
+
+  private normalizeEndpoint(endpoint: string): string {
+    return this.apiFormat === "lmstudio"
+      ? endpoint.replace(/\/+$/, "")
+      : endpoint;
+  }
+
+  private inferenceUrl(): string {
+    return this.apiFormat === "lmstudio"
+      ? `${this.endpoint}/api/v1/chat`
+      : this.endpoint;
+  }
+
+  private async ensureLMStudioModelLoaded(headers: Record<string, string>, signal: AbortSignal): Promise<void> {
+    const listResponse = await fetch(`${this.endpoint}/api/v1/models`, {
+      method: "GET",
+      headers,
+      signal,
+    });
+    if (!listResponse.ok) {
+      throw new Error(`LM Studio models API error: ${listResponse.statusText}`);
+    }
+    const listContentType = listResponse.headers.get("content-type");
+    if (!listContentType?.includes("application/json")) {
+      throw new Error("Invalid LM Studio models response content type");
+    }
+    const listData = await listResponse.json() as { models?: Array<{ key?: string; loaded_instances?: unknown[] }> };
+    const model = listData.models?.find((candidate) => candidate.key === this.model);
+    if (model?.loaded_instances && model.loaded_instances.length > 0) {
+      return;
+    }
+
+    const loadResponse = await fetch(`${this.endpoint}/api/v1/models/load`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: this.model,
+        ...this.lmStudioLoadConfig,
+      }),
+      signal,
+    });
+    if (!loadResponse.ok) {
+      throw new Error(`LM Studio load API error: ${loadResponse.statusText}`);
+    }
+  }
+
+  private loadConfigFromEnv(): LLMProviderOptions["lmStudioLoadConfig"] {
+    return {
+      context_length: parseOptionalInteger(process.env.LM_STUDIO_CONTEXT_LENGTH),
+      eval_batch_size: parseOptionalInteger(process.env.LM_STUDIO_EVAL_BATCH_SIZE),
+      flash_attention: parseOptionalBoolean(process.env.LM_STUDIO_FLASH_ATTENTION),
+      num_experts: parseOptionalInteger(process.env.LM_STUDIO_NUM_EXPERTS),
+      offload_kv_cache_to_gpu: parseOptionalBoolean(process.env.LM_STUDIO_OFFLOAD_KV_CACHE_TO_GPU),
+    };
+  }
+}
+
+function parseOptionalInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === "1" || value.toLowerCase() === "true") return true;
+  if (value === "0" || value.toLowerCase() === "false") return false;
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Add `LLM_API_FORMAT=lmstudio` for LM Studio native REST integration.
- Support `LM_STUDIO_URL` and default to `http://127.0.0.1:1234` when `LLM_API_FORMAT=lmstudio` is selected.
- Use LM Studio native endpoints to list, load, and chat with local models:
  - `GET /api/v1/models`
  - `POST /api/v1/models/load`
  - `POST /api/v1/chat`
- Keep the semantic `llm` provider as the single model-agnostic provider surface.
- Update docs and test counts to 659.

## How to run local model certification
Start LM Studio's local server, ensure the model is downloaded, then run:

```bash
LM_STUDIO_URL="http://127.0.0.1:1234" \
LLM_MODEL="publisher/model-key-or-api-identifier" \
LLM_API_FORMAT="lmstudio" \
pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-lmstudio-eval
```

If `LM_STUDIO_URL` is omitted, LM Studio mode defaults to `http://127.0.0.1:1234`.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 659 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-eval.mjs --out=/tmp/dialectos-lmstudio-provider-mock-final` — 27/27 across 25 dialects
- LM Studio-native local mock live run: `LM_STUDIO_URL=http://127.0.0.1:<port> LLM_MODEL=local/dialect-model LLM_API_FORMAT=lmstudio pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-lmstudio-live-mock-final` — 27/27 across 25 dialects

## Source confirmation
LM Studio docs describe the native `/api/v1/models`, `/api/v1/models/load`, and `/api/v1/chat` endpoints and note that the local server defaults to port 1234.
