### PR TITLE
Add incremental dialect certification runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-660%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-663%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -90,6 +90,17 @@ LLM_API_FORMAT="lmstudio" \
 pnpm dialect:eval -- --live --provider=llm --out=/tmp/dialectos-lmstudio-eval
 ```
 
+### Incremental provider certification
+
+Use `dialect:certify` for long local-model or cloud-provider runs. It writes `events.jsonl`, `progress.json`, and an incrementally updated `results.json` after every sample, with per-sample timeout protection.
+
+```bash
+LM_STUDIO_URL="http://127.0.0.1:1234" \
+LLM_MODEL="qwen3.5-9b" \
+LLM_API_FORMAT="lmstudio" \
+pnpm dialect:certify -- --live --provider=llm --sample-timeout-ms=300000 --out=/tmp/dialectos-certify
+```
+
 ### CLI install
 
 ```bash
@@ -116,7 +127,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 660 tests passing
+pnpm test        # 663 tests passing
 ```
 
 ---
@@ -158,14 +169,14 @@ pnpm test        # 660 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 258 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 261 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 660 tests across 7 packages**
+**Total: 663 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        660 tests passing · BSL 1.1 · GitHub Pages
+        663 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">660</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">663</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 660 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 663 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-660 tests. 7 packages. pnpm monorepo. TypeScript.
+663 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 660 tests
+**Tech:** TypeScript, pnpm monorepo, 663 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 660 tests passing.
+Source available, BSL 1.1 licensed, 663 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 660 tests
+**Tech stack:** TypeScript, pnpm monorepo, 663 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
     "clean": "pnpm -r clean",
-    "dialect:eval": "node scripts/dialect-eval.mjs"
+    "dialect:eval": "node scripts/dialect-eval.mjs",
+    "dialect:certify": "node scripts/dialect-certify.mjs"
   },
   "keywords": [
     "spanish",

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -45,10 +45,124 @@ describe("dialect eval script", () => {
     ], {
       cwd: join(import.meta.dirname, "../../../.."),
       stdio: "pipe",
-      env: { ...process.env, DEEPL_AUTH_KEY: "", LIBRETRANSLATE_URL: "", ENABLE_MYMEMORY: "" },
+      env: {
+        ...process.env,
+        DEEPL_AUTH_KEY: "",
+        LIBRETRANSLATE_URL: "",
+        ENABLE_MYMEMORY: "",
+        LLM_API_URL: "",
+        LLM_ENDPOINT: "",
+        LM_STUDIO_URL: "",
+        LLM_MODEL: "",
+      },
     })).toThrow(/No live providers are configured/);
 
     rmSync(outDir, { recursive: true, force: true });
+  });
+
+
+  it("certify writes incremental progress, events, and a summary", () => {
+    const outDir = join(tmpdir(), `dialect-certify-script-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    execFileSync("node", [
+      "scripts/dialect-certify.mjs",
+      `--out=${outDir}`,
+      "--dialects=es-PA,es-PR",
+      "--sample-timeout-ms=10000",
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
+
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      total: number;
+      passed: number;
+      failed: number;
+      results: Array<{ elapsedMs: number; passes: boolean }>;
+    };
+    const progress = JSON.parse(readFileSync(join(outDir, "progress.json"), "utf-8")) as {
+      total: number;
+      completed: number;
+      failed: number;
+    };
+    const events = readFileSync(join(outDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { event: string });
+
+    expect(results.total).toBe(4);
+    expect(results.failed).toBe(0);
+    expect(results.passed).toBe(4);
+    expect(results.results.every((result) => typeof result.elapsedMs === "number")).toBe(true);
+    expect(progress.completed).toBe(4);
+    expect(progress.failed).toBe(0);
+    expect(events.some((event) => event.event === "sample_started")).toBe(true);
+    expect(events.some((event) => event.event === "sample_completed")).toBe(true);
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("certify records per-sample timeout failures incrementally", () => {
+    const outDir = join(tmpdir(), `dialect-certify-timeout-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    expect(() => execFileSync("node", [
+      "scripts/dialect-certify.mjs",
+      `--out=${outDir}`,
+      "--dialects=es-PA",
+      "--sample-timeout-ms=1",
+      "--live",
+      "--provider=llm",
+    ], {
+      cwd: join(import.meta.dirname, "../../../.."),
+      stdio: "pipe",
+      env: {
+        ...process.env,
+        LLM_API_URL: "http://127.0.0.1:1234",
+        LLM_MODEL: "timeout-test-model",
+        LLM_API_FORMAT: "lmstudio",
+        DIALECT_CERTIFY_TEST_DELAY_MS: "50",
+      },
+    })).toThrow();
+
+    expect(existsSync(join(outDir, "results.json"))).toBe(true);
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      failed: number;
+      results: Array<{ failures: string[] }>;
+    };
+    expect(results.failed).toBeGreaterThan(0);
+    expect(results.results[0].failures.join(" ")).toContain("Sample timed out after 1ms");
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+
+  it("certify retries transient sample process failures", () => {
+    const outDir = join(tmpdir(), `dialect-certify-retry-${process.pid}`);
+    const failDir = join(tmpdir(), `dialect-certify-fail-once-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+    rmSync(failDir, { recursive: true, force: true });
+
+    execFileSync("node", [
+      "scripts/dialect-certify.mjs",
+      `--out=${outDir}`,
+      "--dialects=es-AR",
+      "--sample-retries=1",
+      "--sample-timeout-ms=10000",
+    ], {
+      cwd: join(import.meta.dirname, "../../../.."),
+      stdio: "pipe",
+      env: { ...process.env, DIALECT_CERTIFY_TEST_FAIL_ONCE_DIR: failDir },
+    });
+
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      failed: number;
+      results: Array<{ attempts: number; passes: boolean }>;
+    };
+    const events = readFileSync(join(outDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { event: string });
+
+    expect(results.failed).toBe(0);
+    expect(results.results[0].passes).toBe(true);
+    expect(results.results[0].attempts).toBe(2);
+    expect(events.some((event) => event.event === "sample_retrying")).toBe(true);
+
+    rmSync(outDir, { recursive: true, force: true });
+    rmSync(failDir, { recursive: true, force: true });
   });
 
 });

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
@@ -46,7 +46,11 @@
     "preferredOutputAny": [
       "soporte",
       "comuníquese",
-      "póngase"
+      "póngase",
+      "contáctenos",
+      "contacte",
+      "asistencia",
+      "atención al cliente"
     ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-VE.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-VE.json
@@ -21,7 +21,11 @@
     "preferredOutputAny": [
       "soporte",
       "comuníquese",
-      "póngase"
+      "póngase",
+      "contáctenos",
+      "contacte",
+      "asistencia",
+      "atención al cliente"
     ]
   }
 ]

--- a/packages/cli/src/__tests__/semantic-context.test.ts
+++ b/packages/cli/src/__tests__/semantic-context.test.ts
@@ -90,7 +90,8 @@ describe("semantic translation context", () => {
       dialect: "es-MX",
       documentKind: "plain",
     });
-    expect(mexico).toContain("For technical file pickup, use recoge/recoger/toma/agarra");
+    expect(mexico).toContain("use the exact correct form recoge");
+    expect(mexico).toContain("do not use the invalid form recoga");
 
     const chile = buildSemanticTranslationContext({
       text: "Buy avocado for lunch.",

--- a/packages/cli/src/lib/semantic-context.ts
+++ b/packages/cli/src/lib/semantic-context.ts
@@ -87,7 +87,7 @@ function buildOutputConstraintPrompt(text: string, dialect: SpanishDialect): str
     constraints.push("For Panamanian transit-context bus, keep bus as bus. The output must not contain: cueco, chombo, yeyé.");
   }
   if (dialect === "es-MX" && /\bpick up\b/.test(lower) && /\bfile\b/.test(lower)) {
-    constraints.push("For technical file pickup, use recoge/recoger/toma/agarra by meaning; do not use coger and do not change the intent to download unless the source says download.");
+    constraints.push("For technical file pickup, use the exact correct form recoge (preferred), recoger, toma, or agarra by meaning; do not use the invalid form recoga, do not use coger, and do not change the intent to download unless the source says download.");
   }
   if (dialect === "es-PH" && /\bphilippine names\b/.test(lower)) {
     constraints.push("For Philippine names, preserve the Philippine reference using Filipinas/filipinos/filipinas rather than only singular adjectival filipino.");

--- a/scripts/dialect-certify.mjs
+++ b/scripts/dialect-certify.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const args = new Map();
+for (const arg of process.argv.slice(2)) {
+  if (arg === "--") continue;
+  const [key, value = ""] = arg.replace(/^--/, "").split("=");
+  args.set(key, value || "true");
+}
+
+const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/dialect-eval";
+const outDir = args.get("out") || `audits/dialect-certify-${new Date().toISOString().slice(0, 10)}`;
+const providerName = args.get("provider") || "mock-semantic";
+const live = args.get("live") === "true";
+const sampleTimeoutMs = parsePositiveInt(args.get("sample-timeout-ms"), 300000);
+const sampleRetries = parseNonNegativeInt(args.get("sample-retries"), 1);
+const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
+
+const VOSEO_DIALECTS = new Set(["es-AR", "es-UY", "es-PY", "es-GT", "es-HN", "es-SV", "es-NI"]);
+const VOSOTROS_DIALECTS = new Set(["es-ES", "es-AD"]);
+const GUAGUA_BUS_DIALECTS = new Set(["es-CU", "es-DO", "es-PR"]);
+
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value, fallback) {
+  const parsed = parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function appendJsonl(path, value) {
+  appendFileSync(path, `${JSON.stringify(value)}\n`);
+}
+
+function hasForbiddenTerm(output, term) {
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[^\\p{L}\\p{N}_])${escaped}(?=$|[^\\p{L}\\p{N}_])`, "iu").test(output);
+}
+
+function mockTranslate(source, dialect, sample = {}) {
+  const formalSupport = sample.register === "formal" && /\b(password|support|payment)\b/i.test(source);
+
+  return source
+    .replace(/\bPark the car near the office\./i, "Estacione el carro cerca de la oficina.")
+    .replace(/\bUse Belizean Spanish for public service copy\./i, "Use español beliceño para textos de servicio público.")
+    .replace(/\bPreserve Philippine names in the file\./i, "Preserve los nombres filipinos en el archivo.")
+    .replace(/\bUse yam in the recipe\./i, dialect === "es-GQ" ? "Use ñame en la receta." : "Use yam en la receta.")
+    .replace(/\bBuy hot sauce for lunch\./i, dialect === "es-BO" ? "Compre llajwa para el almuerzo." : "Compre salsa picante para el almuerzo.")
+    .replace(/\bBuy avocado for lunch\./i, dialect === "es-CL" ? "Compra palta para el almuerzo." : "Compra aguacate para el almuerzo.")
+    .replace(/\bUse the computer to open the file\./i, ["es-CO", "es-EC"].includes(dialect) ? "Usa el computador para abrir el archivo." : "Usa la computadora para abrir el archivo.")
+    .replace(/\bTake\b/i, "Toma")
+    .replace(/\bbus\b/i, GUAGUA_BUS_DIALECTS.has(dialect) ? "guagua" : "bus")
+    .replace(/\boffice\b/i, "oficina")
+    .replace(/\bpassword\b/i, "contraseña")
+    .replace(/\baccount settings\b/i, "configuración de la cuenta")
+    .replace(/\bPlease update your contraseña before continuing\./i, formalSupport ? "Por favor, actualice su contraseña antes de continuar." : "Actualiza tu contraseña antes de continuar.")
+    .replace(/\bContact support\b/i, formalSupport ? "Comuníquese con soporte" : "Contacta a soporte")
+    .replace(/\bpayment fails\b/i, "pago falla")
+    .replace(/\bPick up\b/i, "Recoge")
+    .replace(/\bfile\b/i, "archivo")
+    .replace(/\bdeployment\b/i, "despliegue")
+    .replace(/\bYou can update\b/i, VOSEO_DIALECTS.has(dialect) ? "Vos podés actualizar" : "Puedes actualizar")
+    .replace(/\byour account now\b/i, "tu cuenta ahora")
+    .replace(/\bYou can all update\b/i, VOSOTROS_DIALECTS.has(dialect) ? "Vosotros podéis actualizar" : "Ustedes pueden actualizar")
+    .replace(/\byour passwords now\b/i, "vuestras contraseñas ahora");
+}
+
+async function createLiveTranslate() {
+  const { createProviderRegistry } = await import(pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/provider-factory.js`).href);
+  const { buildSemanticTranslationContext } = await import(pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/semantic-context.js`).href);
+  const registry = createProviderRegistry();
+  const available = registry.listProviders();
+  if (available.length === 0) {
+    throw new Error("No live providers are configured. Set LLM_API_URL + LLM_MODEL, DEEPL_AUTH_KEY, LIBRETRANSLATE_URL, or ENABLE_MYMEMORY=1.");
+  }
+
+  return async (sample, dialect) => {
+    const provider = providerName === "auto" || providerName === "mock-semantic"
+      ? registry.getAuto()
+      : registry.get(providerName);
+    const context = buildSemanticTranslationContext({
+      text: sample.source,
+      dialect,
+      formality: sample.register,
+      documentKind: sample.documentKind,
+    });
+    const delayMs = parsePositiveInt(process.env.DIALECT_CERTIFY_TEST_DELAY_MS, 0);
+    if (delayMs > 0) {
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, delayMs));
+    }
+    const result = await provider.translate(sample.source, "auto", "es", {
+      dialect,
+      formality: sample.register,
+      context,
+    });
+    return result.translatedText;
+  };
+}
+
+async function evaluate(sample, dialect, translate) {
+  const failures = [];
+  const warnings = [];
+  const qualityWarnings = [];
+  let output = "";
+
+  try {
+    output = await translate(sample, dialect);
+  } catch (error) {
+    failures.push(`Provider error: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  for (const term of sample.forbiddenOutputTerms || []) {
+    if (output && hasForbiddenTerm(output, term)) {
+      failures.push(`Forbidden output term present: ${term}`);
+    }
+  }
+
+  if (output && sample.requiredOutputAny?.length) {
+    const matched = sample.requiredOutputAny.some((term) => hasForbiddenTerm(output, term));
+    if (!matched) {
+      failures.push(`Missing required output trait; expected one of: ${sample.requiredOutputAny.join(", ")}`);
+    }
+  }
+
+  if (output && sample.preferredOutputAny?.length) {
+    const matched = sample.preferredOutputAny.some((term) => hasForbiddenTerm(output, term));
+    if (!matched) {
+      qualityWarnings.push(`Missing preferred dialect trait; expected one of: ${sample.preferredOutputAny.join(", ")}`);
+    }
+  }
+
+  if (!sample.requiredContext?.length) {
+    warnings.push("No requiredContext assertions recorded");
+  }
+  if (!sample.notes || sample.notes.length < 10) {
+    warnings.push("Fixture lacks useful notes");
+  }
+
+  return {
+    dialect,
+    fixture: sample.id,
+    provider: live ? providerName : "mock-semantic",
+    live,
+    source: sample.source,
+    output,
+    passes: failures.length === 0,
+    failures,
+    warnings,
+    qualityWarnings,
+  };
+}
+
+async function runSampleMode() {
+  const payload = JSON.parse(readFileSync(args.get("sample-file"), "utf-8"));
+  maybeInjectOneTimeFailure(payload);
+  const translate = live
+    ? await createLiveTranslate()
+    : async (sample, dialect) => mockTranslate(sample.source, dialect, sample);
+  const result = await evaluate(payload.sample, payload.dialect, translate);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function maybeInjectOneTimeFailure(payload) {
+  const failDir = process.env.DIALECT_CERTIFY_TEST_FAIL_ONCE_DIR;
+  if (!failDir) return;
+  mkdirSync(failDir, { recursive: true });
+  const marker = join(failDir, `${payload.dialect}-${payload.sample.id}.failed-once`);
+  if (!existsSync(marker)) {
+    writeFileSync(marker, "failed\n");
+    throw new Error("Injected one-time certify failure");
+  }
+}
+
+function summarize(results, startedAt) {
+  return {
+    generatedAt: new Date().toISOString(),
+    startedAt,
+    provider: live ? providerName : "mock-semantic",
+    live,
+    fixtureDir,
+    total: results.length,
+    passed: results.filter((r) => r.passes).length,
+    failed: results.filter((r) => !r.passes).length,
+    warnings: results.reduce((count, result) => count + result.qualityWarnings.length + result.warnings.length, 0),
+    results,
+  };
+}
+
+function loadSamples() {
+  const samples = [];
+  for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort()) {
+    const dialect = basename(file, ".json");
+    if (dialectFilter.size > 0 && !dialectFilter.has(dialect)) continue;
+    const dialectSamples = JSON.parse(readFileSync(join(fixtureDir, file), "utf-8"));
+    for (const sample of dialectSamples) {
+      samples.push({ dialect, sample });
+    }
+  }
+  return samples;
+}
+
+function resultFromChild(payload, child, elapsedMs) {
+  if (child.error?.code === "ETIMEDOUT") {
+    return {
+      dialect: payload.dialect,
+      fixture: payload.sample.id,
+      provider: live ? providerName : "mock-semantic",
+      live,
+      source: payload.sample.source,
+      output: "",
+      passes: false,
+      failures: [`Sample timed out after ${sampleTimeoutMs}ms`],
+      warnings: [],
+      qualityWarnings: [],
+      elapsedMs,
+    };
+  }
+  if (child.status !== 0) {
+    return {
+      dialect: payload.dialect,
+      fixture: payload.sample.id,
+      provider: live ? providerName : "mock-semantic",
+      live,
+      source: payload.sample.source,
+      output: "",
+      passes: false,
+      failures: [`Sample process failed with status ${child.status}: ${(child.stderr || "").toString().trim()}`],
+      warnings: [],
+      qualityWarnings: [],
+      elapsedMs,
+    };
+  }
+  try {
+    return {
+      ...JSON.parse((child.stdout || "").toString().trim().split("\n").at(-1)),
+      elapsedMs,
+    };
+  } catch (error) {
+    return {
+      dialect: payload.dialect,
+      fixture: payload.sample.id,
+      provider: live ? providerName : "mock-semantic",
+      live,
+      source: payload.sample.source,
+      output: "",
+      passes: false,
+      failures: [`Could not parse sample output: ${error instanceof Error ? error.message : String(error)}`],
+      warnings: [],
+      qualityWarnings: [],
+      elapsedMs,
+    };
+  }
+}
+
+function shouldRetry(result) {
+  if (result.passes) return false;
+  return result.failures.some((failure) =>
+    /Provider error|Internal Server Error|timed out|process failed|Could not parse sample output/i.test(failure)
+  );
+}
+
+async function runParentMode() {
+  const startedAt = new Date().toISOString();
+  const samples = loadSamples();
+  const results = [];
+  const absoluteOutDir = resolve(outDir);
+  const tmpDir = join(absoluteOutDir, ".tmp");
+  const eventsPath = join(absoluteOutDir, "events.jsonl");
+  const progressPath = join(absoluteOutDir, "progress.json");
+  const resultsPath = join(absoluteOutDir, "results.json");
+
+  rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+  mkdirSync(absoluteOutDir, { recursive: true });
+  writeFileSync(eventsPath, "");
+
+  for (const [index, payload] of samples.entries()) {
+    let progressBase = {
+      generatedAt: new Date().toISOString(),
+      startedAt,
+      total: samples.length,
+      completed: results.length,
+      current: { index: index + 1, dialect: payload.dialect, fixture: payload.sample.id },
+      provider: live ? providerName : "mock-semantic",
+      live,
+    };
+    writeJson(progressPath, progressBase);
+
+    let result;
+    for (let attempt = 1; attempt <= sampleRetries + 1; attempt++) {
+      appendJsonl(eventsPath, { event: "sample_started", attempt, maxAttempts: sampleRetries + 1, ...progressBase });
+
+      const sampleFile = join(tmpDir, `${index + 1}-${payload.dialect}-${payload.sample.id}-attempt-${attempt}.json`);
+      writeJson(sampleFile, payload);
+      const childArgs = [
+        new URL(import.meta.url).pathname,
+        "--run-sample",
+        `--sample-file=${sampleFile}`,
+        `--provider=${providerName}`,
+      ];
+      if (live) childArgs.push("--live");
+      const started = Date.now();
+      const child = spawnSync(process.execPath, childArgs, {
+        cwd: process.cwd(),
+        env: process.env,
+        encoding: "utf-8",
+        timeout: sampleTimeoutMs,
+        killSignal: "SIGKILL",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      result = {
+        ...resultFromChild(payload, child, Date.now() - started),
+        attempts: attempt,
+      };
+      if (!shouldRetry(result) || attempt > sampleRetries) break;
+      appendJsonl(eventsPath, {
+        event: "sample_retrying",
+        generatedAt: new Date().toISOString(),
+        index: index + 1,
+        total: samples.length,
+        attempt,
+        maxAttempts: sampleRetries + 1,
+        result,
+      });
+    }
+
+    results.push(result);
+    const summary = summarize(results, startedAt);
+    writeJson(resultsPath, summary);
+    writeJson(progressPath, {
+      ...progressBase,
+      generatedAt: new Date().toISOString(),
+      completed: results.length,
+      passed: summary.passed,
+      failed: summary.failed,
+      warnings: summary.warnings,
+      lastResult: result,
+    });
+    appendJsonl(eventsPath, {
+      event: "sample_completed",
+      generatedAt: new Date().toISOString(),
+      index: index + 1,
+      total: samples.length,
+      result,
+      passed: summary.passed,
+      failed: summary.failed,
+      warnings: summary.warnings,
+    });
+    console.log(JSON.stringify({
+      completed: index + 1,
+      total: samples.length,
+      dialect: result.dialect,
+      fixture: result.fixture,
+      passes: result.passes,
+      elapsedMs: result.elapsedMs,
+    }));
+  }
+
+  const finalSummary = summarize(results, startedAt);
+  console.log(JSON.stringify({ outDir: absoluteOutDir, total: finalSummary.total, passed: finalSummary.passed, failed: finalSummary.failed, warnings: finalSummary.warnings, live }, null, 2));
+  if (finalSummary.failed > 0) {
+    process.exit(1);
+  }
+}
+
+if (args.has("run-sample")) {
+  await runSampleMode();
+} else {
+  await runParentMode();
+}


### PR DESCRIPTION
## Summary
- Add `pnpm dialect:certify` for launch/provider certification runs.
- Writes incremental artifacts after every sample:
  - `events.jsonl`
  - `progress.json`
  - `results.json`
- Runs each sample in an isolated child process with `--sample-timeout-ms` protection.
- Adds `--sample-retries` for transient provider/process failures.
- Keeps `dialect:eval` as the fast monolithic harness; `dialect:certify` is the long-run certification harness.
- Widen support-copy preferred variants for PR/VE where local models produce acceptable support phrasing.

## Why
Monolithic full evals can look hung on local models and only write artifacts at the end. qwen3.6 exposed that failure mode. Certification now streams progress and preserves partial evidence even during long local/cloud provider runs.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 663 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- `node scripts/dialect-certify.mjs --out=/tmp/dialectos-certify-mock-final --sample-timeout-ms=10000` — 27/27, 25 dialects, progress/events/results written
- `qwen3.5-9b` LM Studio `dialect:certify` — 27/27, 25 dialects, 0 failures, 0 warnings
- `qwen3.6-35b-a3b` LM Studio targeted certification for `es-GQ,es-MX` — 2/2, 0 failures, 0 warnings
