### PR TITLE
Add adversarial dialect certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-663%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-664%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -101,6 +101,14 @@ LLM_API_FORMAT="lmstudio" \
 pnpm dialect:certify -- --live --provider=llm --sample-timeout-ms=300000 --out=/tmp/dialectos-certify
 ```
 
+### Adversarial dialect certification
+
+Use `dialect:certify:adversarial` to run paraphrase, dialect-collision, taboo-copy, placeholder, register, and repeatability traps. It wraps `dialect:certify` and writes a `failure-matrix.md` plus aggregate repeatability results.
+
+```bash
+pnpm dialect:certify:adversarial -- --live --provider=llm --repeat=2 --sample-timeout-ms=300000 --out=/tmp/dialectos-adversarial
+```
+
 ### CLI install
 
 ```bash
@@ -127,7 +135,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 663 tests passing
+pnpm test        # 664 tests passing
 ```
 
 ---
@@ -169,14 +177,14 @@ pnpm test        # 663 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 261 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 262 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 663 tests across 7 packages**
+**Total: 664 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        663 tests passing · BSL 1.1 · GitHub Pages
+        664 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">663</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">664</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 663 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 664 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-663 tests. 7 packages. pnpm monorepo. TypeScript.
+664 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 663 tests
+**Tech:** TypeScript, pnpm monorepo, 664 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 663 tests passing.
+Source available, BSL 1.1 licensed, 664 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 663 tests
+**Tech stack:** TypeScript, pnpm monorepo, 664 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:coverage": "pnpm -r test:coverage",
     "clean": "pnpm -r clean",
     "dialect:eval": "node scripts/dialect-eval.mjs",
-    "dialect:certify": "node scripts/dialect-certify.mjs"
+    "dialect:certify": "node scripts/dialect-certify.mjs",
+    "dialect:certify:adversarial": "node scripts/dialect-certify-adversarial.mjs"
   },
   "keywords": [
     "spanish",

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -165,4 +165,37 @@ describe("dialect eval script", () => {
     rmSync(failDir, { recursive: true, force: true });
   });
 
+
+  it("adversarial certify writes a failure matrix and repeatability summary", () => {
+    const outDir = join(tmpdir(), `dialect-adversarial-certify-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    execFileSync("node", [
+      "scripts/dialect-certify-adversarial.mjs",
+      `--out=${outDir}`,
+      "--repeat=2",
+      "--sample-timeout-ms=10000",
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
+
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      totalRuns: number;
+      totalSamples: number;
+      failed: number;
+      unstableCount: number;
+      results: Array<{ category: string; severity: string; run: number }>;
+    };
+    const matrix = readFileSync(join(outDir, "failure-matrix.md"), "utf-8");
+
+    expect(results.totalRuns).toBe(2);
+    expect(results.totalSamples).toBeGreaterThanOrEqual(20);
+    expect(results.failed).toBe(0);
+    expect(results.unstableCount).toBe(0);
+    expect(results.results.some((result) => result.category === "dialect-collision")).toBe(true);
+    expect(results.results.some((result) => result.severity === "critical")).toBe(true);
+    expect(matrix).toContain("Adversarial Dialect Certification Matrix");
+    expect(matrix).toContain("dialect-collision");
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
 });

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-AR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-AR.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "ar-formal-support-no-voseo",
+    "category": "register-trap",
+    "severity": "critical",
+    "tags": ["formal", "voseo", "support"],
+    "source": "Please update your password before continuing.",
+    "domain": "security",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": ["Argentine Spanish", "Use usted"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["vos", "podés", "vosotros", "boludo"],
+    "requiredOutputAny": ["usted", "actualice", "su contraseña"],
+    "preferredOutputAny": ["actualice", "su contraseña"],
+    "notes": "Formal Argentine support copy should not use informal voseo."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-CL.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-CL.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "cl-avocado-paraphrase",
+    "category": "under-localization",
+    "severity": "critical",
+    "tags": ["food", "palta"],
+    "source": "Buy avocado for lunch.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Chilean Spanish", "palta"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["aguacate", "vosotros", "wea", "hueón"],
+    "requiredOutputAny": ["palta"],
+    "preferredOutputAny": ["palta"],
+    "notes": "Chilean food localization should use palta, not aguacate."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-CU.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-CU.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "cu-bus-paraphrase-get-on",
+    "category": "dialect-collision",
+    "severity": "critical",
+    "tags": ["transit", "paraphrase"],
+    "source": "Get on the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Cuban Spanish", "Caribbean/Cuban flavor"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["vos", "vosotros", "asere", "yuma"],
+    "requiredOutputAny": ["guagua"],
+    "preferredOutputAny": ["guagua"],
+    "notes": "Cuba transit paraphrase should use guagua while avoiding relationship slang."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-ES.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-ES.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "es-bus-paraphrase-catch",
+    "category": "dialect-collision",
+    "severity": "high",
+    "tags": ["transit", "negative-control"],
+    "source": "Catch the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Peninsular Spanish", "vosotros/vosotras"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["guagua", "güey", "parce", "boludo"],
+    "requiredOutputAny": ["autobús", "bus"],
+    "preferredOutputAny": ["autobús", "bus"],
+    "notes": "Spain transit should not be Caribbean-localized to guagua."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-GT.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-GT.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "gt-informal-voseo-paraphrase",
+    "category": "morphology-trap",
+    "severity": "critical",
+    "tags": ["voseo", "central-america"],
+    "source": "You can update your account now.",
+    "domain": "support",
+    "register": "informal",
+    "documentKind": "plain",
+    "requiredContext": ["Guatemalan Spanish", "Use vos"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["vosotros", "cerote", "culero"],
+    "requiredOutputAny": ["vos podés", "podés", "vos puedes"],
+    "preferredOutputAny": ["vos", "podés"],
+    "notes": "Central American informal output should preserve voseo."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "mx-pickup-package",
+    "category": "intent-ambiguity",
+    "severity": "critical",
+    "tags": ["pick-up", "coger", "package"],
+    "source": "Pick up the package from reception.",
+    "domain": "support",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Mexican Spanish", "Avoid literal coger"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["coger", "vos", "vosotros", "descarga"],
+    "requiredOutputAny": ["recoge", "recoger", "toma", "agarra"],
+    "preferredOutputAny": ["recoge", "recoger"],
+    "notes": "Pick up package should preserve pickup intent, not become download or coger."
+  },
+  {
+    "id": "mx-placeholder-url",
+    "category": "structure-preservation",
+    "severity": "critical",
+    "tags": ["placeholder", "url"],
+    "source": "Hi {userName}, your %{count} files are ready at https://example.com/app.",
+    "domain": "technical",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Mexican Spanish", "Preserve product names"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["coger", "vos", "vosotros"],
+    "requiredOutputAny": ["{userName}"],
+    "preferredOutputAny": ["%{count}", "https://example.com/app"],
+    "notes": "Placeholders and URLs must survive translation."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PA.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PA.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "pa-bus-paraphrase-catch",
+    "category": "dialect-collision",
+    "severity": "critical",
+    "tags": ["transit", "paraphrase", "taboo-copy"],
+    "source": "Catch the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Panamanian", "Use neutral Panamanian Spanish"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["vosotros", "cueco", "chombo", "yeyé", "guagua"],
+    "preferredOutputAny": ["bus"],
+    "notes": "Panama transit paraphrase should keep bus and must not copy taboo examples or PR/Cuba/DR guagua."
+  },
+  {
+    "id": "pa-placeholder-support",
+    "category": "structure-preservation",
+    "severity": "critical",
+    "tags": ["placeholder", "url", "support"],
+    "source": "Hi {userName}, your %{count} files are ready at https://example.com/app.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": ["Panamanian", "Preserve product names"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["cueco", "chombo", "yeyé"],
+    "requiredOutputAny": ["{userName}"],
+    "preferredOutputAny": ["%{count}", "https://example.com/app"],
+    "notes": "Provider must preserve placeholders and URLs under dialect prompting."
+  }
+]

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PR.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "pr-bus-paraphrase-ride",
+    "category": "dialect-collision",
+    "severity": "critical",
+    "tags": ["transit", "paraphrase"],
+    "source": "Ride the bus to the office.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": ["Puerto Rican", "Use Puerto Rican vocabulary naturally"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["vosotros", "cabrón", "bicho", "puñeta"],
+    "requiredOutputAny": ["guagua"],
+    "preferredOutputAny": ["guagua"],
+    "notes": "PR transit paraphrase should use guagua without strong slang."
+  },
+  {
+    "id": "pr-taboo-negative-control",
+    "category": "negative-control",
+    "severity": "high",
+    "tags": ["taboo", "support"],
+    "source": "Do not use slang in this customer support message.",
+    "domain": "support",
+    "register": "formal",
+    "documentKind": "plain",
+    "requiredContext": ["Puerto Rican", "Avoid strong slang"],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": ["cabrón", "bicho", "puñeta", "vosotros"],
+    "preferredOutputAny": ["jerga", "argot", "soporte", "atención al cliente"],
+    "notes": "A negative control should not inject PR slang just because the target dialect is Puerto Rican."
+  }
+]

--- a/scripts/dialect-certify-adversarial.mjs
+++ b/scripts/dialect-certify-adversarial.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = new Map();
+for (const arg of process.argv.slice(2)) {
+  if (arg === "--") continue;
+  const [key, value = ""] = arg.replace(/^--/, "").split("=");
+  args.set(key, value || "true");
+}
+
+const repeat = parsePositiveInt(args.get("repeat"), 1);
+const outDir = resolve(args.get("out") || `audits/dialect-adversarial-${new Date().toISOString().slice(0, 10)}`);
+const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/dialect-adversarial";
+const strictOutputStability = args.get("strict-output-stability") === "true";
+
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function passThroughArgs(runOutDir) {
+  const forwarded = [
+    "scripts/dialect-certify.mjs",
+    `--fixtures=${fixtureDir}`,
+    `--out=${runOutDir}`,
+  ];
+  for (const key of ["provider", "dialects", "sample-timeout-ms", "sample-retries"]) {
+    if (args.has(key)) forwarded.push(`--${key}=${args.get(key)}`);
+  }
+  if (args.get("live") === "true") forwarded.push("--live");
+  return forwarded;
+}
+
+function summarizeRuns(runSummaries) {
+  const flattened = [];
+  const bySample = new Map();
+  for (const run of runSummaries) {
+    for (const result of run.results) {
+      const key = `${result.dialect}/${result.fixture}`;
+      const enriched = { ...result, run: run.run };
+      flattened.push(enriched);
+      if (!bySample.has(key)) bySample.set(key, []);
+      bySample.get(key).push(enriched);
+    }
+  }
+
+  const unstable = [];
+  const outputVariance = [];
+  for (const [key, results] of bySample) {
+    const passStates = new Set(results.map((result) => result.passes));
+    const warningCounts = new Set(results.map((result) => result.warnings.length + result.qualityWarnings.length));
+    const failureCounts = new Set(results.map((result) => result.failures.length));
+    const outputs = new Set(results.map((result) => result.output));
+    if (passStates.size > 1 || warningCounts.size > 1 || failureCounts.size > 1 || (strictOutputStability && outputs.size > 1)) {
+      unstable.push({ key, passStates: [...passStates], outputs: [...outputs], results });
+    } else if (outputs.size > 1) {
+      outputVariance.push({ key, outputs: [...outputs] });
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    fixtureDir,
+    repeat,
+    totalRuns: runSummaries.length,
+    totalSamples: flattened.length,
+    passed: flattened.filter((result) => result.passes).length,
+    failed: flattened.filter((result) => !result.passes).length,
+    warnings: flattened.reduce((count, result) => count + result.qualityWarnings.length + result.warnings.length, 0),
+    unstableCount: unstable.length,
+    outputVarianceCount: outputVariance.length,
+    unstable,
+    outputVariance,
+    results: flattened,
+  };
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFailureMatrix(summary) {
+  const lines = [
+    "# Adversarial Dialect Certification Matrix",
+    "",
+    `Generated: ${summary.generatedAt}`,
+    `Fixture dir: ${summary.fixtureDir}`,
+    `Repeats: ${summary.repeat}`,
+    `Total sample-runs: ${summary.totalSamples}`,
+    `Passed: ${summary.passed}`,
+    `Failed: ${summary.failed}`,
+    `Warnings: ${summary.warnings}`,
+    `Unstable samples: ${summary.unstableCount}`,
+    `Output variance samples: ${summary.outputVarianceCount}`,
+    "",
+    "| Run | Dialect | Fixture | Category | Severity | Pass | Warnings | Failures | Output |",
+    "| --- | --- | --- | --- | --- | --- | ---: | --- | --- |",
+  ];
+  for (const result of summary.results) {
+    lines.push(`| ${result.run} | ${result.dialect} | ${result.fixture} | ${result.category || ""} | ${result.severity || ""} | ${result.passes ? "yes" : "no"} | ${(result.warnings.length + result.qualityWarnings.length)} | ${[...result.failures, ...result.qualityWarnings].join("; ").replace(/\|/g, "\\|")} | ${(result.output || "").replace(/\|/g, "\\|")} |`);
+  }
+  if (summary.unstable.length > 0) {
+    lines.push("", "## Unstable samples", "");
+    for (const item of summary.unstable) {
+      lines.push(`- ${item.key}: ${item.outputs.map((output) => JSON.stringify(output)).join(" vs ")}`);
+    }
+  }
+  if (summary.outputVariance.length > 0) {
+    lines.push("", "## Output variance (passing)", "");
+    for (const item of summary.outputVariance) {
+      lines.push(`- ${item.key}: ${item.outputs.map((output) => JSON.stringify(output)).join(" vs ")}`);
+    }
+  }
+  writeFileSync(join(outDir, "failure-matrix.md"), `${lines.join("\n")}\n`);
+}
+
+mkdirSync(outDir, { recursive: true });
+const runSummaries = [];
+for (let run = 1; run <= repeat; run++) {
+  const runOutDir = join(outDir, `run-${run}`);
+  const child = spawnSync(process.execPath, passThroughArgs(runOutDir), {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: "utf-8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  process.stdout.write(child.stdout || "");
+  process.stderr.write(child.stderr || "");
+  const resultsPath = join(runOutDir, "results.json");
+  const summary = JSON.parse(readFileSync(resultsPath, "utf-8"));
+  runSummaries.push({ ...summary, run });
+}
+
+const summary = summarizeRuns(runSummaries);
+writeJson(join(outDir, "results.json"), summary);
+writeFailureMatrix(summary);
+console.log(JSON.stringify({ outDir, totalSamples: summary.totalSamples, passed: summary.passed, failed: summary.failed, warnings: summary.warnings, unstable: summary.unstableCount, outputVariance: summary.outputVarianceCount }, null, 2));
+
+if (summary.failed > 0 || summary.unstableCount > 0) {
+  process.exit(1);
+}

--- a/scripts/dialect-certify.mjs
+++ b/scripts/dialect-certify.mjs
@@ -53,19 +53,24 @@ function mockTranslate(source, dialect, sample = {}) {
     .replace(/\bPark the car near the office\./i, "Estacione el carro cerca de la oficina.")
     .replace(/\bUse Belizean Spanish for public service copy\./i, "Use español beliceño para textos de servicio público.")
     .replace(/\bPreserve Philippine names in the file\./i, "Preserve los nombres filipinos en el archivo.")
+    .replace(/\bDo not use slang in this customer support message\./i, "No use jerga en este mensaje de soporte al cliente.")
     .replace(/\bUse yam in the recipe\./i, dialect === "es-GQ" ? "Use ñame en la receta." : "Use yam en la receta.")
     .replace(/\bBuy hot sauce for lunch\./i, dialect === "es-BO" ? "Compre llajwa para el almuerzo." : "Compre salsa picante para el almuerzo.")
     .replace(/\bBuy avocado for lunch\./i, dialect === "es-CL" ? "Compra palta para el almuerzo." : "Compra aguacate para el almuerzo.")
     .replace(/\bUse the computer to open the file\./i, ["es-CO", "es-EC"].includes(dialect) ? "Usa el computador para abrir el archivo." : "Usa la computadora para abrir el archivo.")
+    .replace(/\b(Catch|Ride|Get on)\b/i, "Toma")
     .replace(/\bTake\b/i, "Toma")
     .replace(/\bbus\b/i, GUAGUA_BUS_DIALECTS.has(dialect) ? "guagua" : "bus")
     .replace(/\boffice\b/i, "oficina")
+    .replace(/\bpackage\b/i, "paquete")
+    .replace(/\breception\b/i, "recepción")
     .replace(/\bpassword\b/i, "contraseña")
     .replace(/\baccount settings\b/i, "configuración de la cuenta")
     .replace(/\bPlease update your contraseña before continuing\./i, formalSupport ? "Por favor, actualice su contraseña antes de continuar." : "Actualiza tu contraseña antes de continuar.")
     .replace(/\bContact support\b/i, formalSupport ? "Comuníquese con soporte" : "Contacta a soporte")
     .replace(/\bpayment fails\b/i, "pago falla")
     .replace(/\bPick up\b/i, "Recoge")
+    .replace(/\bfiles\b/i, "archivos")
     .replace(/\bfile\b/i, "archivo")
     .replace(/\bdeployment\b/i, "despliegue")
     .replace(/\bYou can update\b/i, VOSEO_DIALECTS.has(dialect) ? "Vos podés actualizar" : "Puedes actualizar")
@@ -148,6 +153,9 @@ async function evaluate(sample, dialect, translate) {
   return {
     dialect,
     fixture: sample.id,
+    category: sample.category,
+    severity: sample.severity,
+    tags: sample.tags || [],
     provider: live ? providerName : "mock-semantic",
     live,
     source: sample.source,


### PR DESCRIPTION
## Summary
- Add `pnpm dialect:certify:adversarial`.
- Add adversarial fixtures for:
  - dialect-collision transit paraphrases
  - taboo-copy traps
  - placeholder/URL preservation
  - register traps
  - pick-up intent ambiguity
  - over/under-localization controls
  - repeatability/output variance reporting
- Generate `failure-matrix.md` plus aggregate `results.json` for adversarial runs.
- Keep passing output variance visible without failing by default; `--strict-output-stability=true` can make wording variance fatal.
- Update docs/test count to 664.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 664 tests passing across 7 packages
- `pnpm audit --audit-level low` — no known vulnerabilities
- npm pack dry-run guard across all 7 packages — no tests/fixtures packed
- Mock adversarial cert: 11/11, 0 failures, 0 warnings, matrix generated
- qwen3.5-9b LM Studio adversarial `repeat=2`: 22/22, 0 failures, 0 unstable, output variance reported
- qwen3.6-35b LM Studio adversarial `repeat=1`: 11/11, 0 failures
- glm-4.5-air Z.ai adversarial `repeat=2`: 22/22, 0 failures, 0 unstable, output variance reported
