### PR TITLE
Record v0.1.0 release candidate evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-692%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-693%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -79,6 +79,17 @@ Add to your Claude Desktop, Cursor, or any MCP client:
 }
 ```
 
+### Recommended certified models
+
+For `v0.1.0-rc1`, the recommended default cloud model is `glm-4.5-air` through the Z.ai international Anthropic-compatible endpoint. It passed basic, expanded adversarial, and long-document certification. Use `glm-5.1` when you want the higher-confidence/premium option, and `qwen3.5-9b` via LM Studio for local/offline certification.
+
+```bash
+export LLM_API_URL="https://api.z.ai/api/anthropic/v1/messages"
+export LLM_MODEL="glm-4.5-air"
+export LLM_API_FORMAT="anthropic"
+export LLM_API_KEY="..."
+```
+
 ### LM Studio local model testing
 
 Start LM Studio's local server, then point DialectOS at any downloaded local model. `LLM_API_FORMAT=lmstudio` uses LM Studio's native REST API and loads the model just-in-time when needed.
@@ -143,7 +154,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 692 tests passing
+pnpm test        # 693 tests passing
 ```
 
 ---
@@ -185,14 +196,14 @@ pnpm test        # 692 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 290 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 291 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 692 tests across 7 packages**
+**Total: 693 tests across 7 packages**
 
 ---
 

--- a/audits/release-candidate-2026-04-22/README.md
+++ b/audits/release-candidate-2026-04-22/README.md
@@ -1,0 +1,113 @@
+# DialectOS v0.1.0-rc1 Release Candidate Report
+
+Date: 2026-04-22
+Commit base: `51922ac` plus this report branch
+Status: **RC approved for tagging after this report lands**
+
+## Launch decision
+
+**Decision: GO for `v0.1.0-rc1`.**
+
+DialectOS has passed:
+
+- unit/integration suite
+- package allowlist checks
+- low-severity npm audit
+- basic 25-dialect certification
+- expanded 125-sample adversarial certification
+- long-document certification for README/API-doc/locale JSON flows
+- local LM Studio certification
+- Z.ai cloud model certification via Anthropic-compatible API
+
+## Recommended model policy
+
+| Use case | Recommendation | Evidence |
+| --- | --- | --- |
+| Default cloud launch | `glm-4.5-air` | Passed basic cert, expanded adversarial cert, and long-document cert with zero failures. Fastest cloud cert observed. |
+| Higher-confidence cloud option | `glm-5.1` | Passed full basic 25-dialect cert with zero failures/warnings. |
+| Alternate cloud option | `glm-4.7` | Passed full basic 25-dialect cert with zero failures/warnings. |
+| Local/offline mode | `qwen3.5-9b` via LM Studio | Passed basic cert and expanded adversarial cert with zero failures/warnings. |
+| Local high-capability mode | `qwen3.6-35b-a3b` via LM Studio | Passed targeted fixes and adversarial subset; slower, with one transient provider error observed/recovered on retry. |
+
+## Final verification commands
+
+Run on current main before this report branch:
+
+```bash
+pnpm build
+pnpm -r exec tsc --noEmit
+pnpm test
+pnpm audit --audit-level low
+npm pack --dry-run guard for all packages
+```
+
+Results:
+
+| Check | Result |
+| --- | --- |
+| `pnpm build` | pass |
+| `pnpm -r exec tsc --noEmit` | pass |
+| `pnpm test` | pass, 693 tests |
+| `pnpm audit --audit-level low` | pass |
+| npm pack dry-run guard | pass, no test/fixture artifacts packed |
+
+## Certification matrix
+
+See `model-matrix.json` in this directory for machine-readable summaries.
+
+| Certification | Result | Artifact |
+| --- | --- | --- |
+| GLM 5.1 basic 25-dialect cert | 27/27 pass, 0 warnings | `/tmp/dialectos-zai-glm51-full/results.json` |
+| GLM 4.7 basic 25-dialect cert | 27/27 pass, 0 warnings | `/tmp/dialectos-zai-glm47-full/results.json` |
+| GLM 4.5 Air basic 25-dialect cert | 27/27 pass, 0 warnings | `/tmp/dialectos-zai-glm45air-full/results.json` |
+| GLM 4.5 Air expanded adversarial cert | 125/125 pass, 0 warnings | `/tmp/dialectos-expanded-adversarial-glm45air-v2/results.json` |
+| GLM 4.5 Air long-document cert | 7/7 pass | `/tmp/dialectos-doc-cert-cloud-glm45air-final/results.json` |
+| qwen3.5-9b basic cert | 27/27 pass, 0 warnings | `/tmp/dialectos-certify-qwen35-9b-final/results.json` |
+| qwen3.5-9b expanded adversarial cert | 125/125 pass, 0 warnings | `/tmp/dialectos-expanded-adversarial-qwen35-9b-v2/results.json` |
+| qwen3.6-35b targeted fix cert | 2/2 pass | `/tmp/dialectos-certify-qwen36-gq-mx/results.json` |
+| qwen3.6-35b adversarial subset | 11/11 pass | `/tmp/dialectos-adversarial-qwen36/results.json` |
+| Mock expanded adversarial cert on current main | 125/125 pass | `/tmp/dialectos-main-expanded-adversarial-final/results.json` |
+| Mock document cert on current main | 7/7 pass | `/tmp/dialectos-main-doc-cert-final/results.json` |
+
+## Known limitations / non-blockers
+
+1. **Long-document live cert was run for GLM 4.5 Air only.**
+   - GLM 5.1 and GLM 4.7 passed basic cert, but not the live document cert in this run.
+   - Non-blocking because GLM 4.5 Air is the recommended default.
+
+2. **qwen3.6 full monolithic runs are too slow for the old `dialect:eval` shape.**
+   - This is why `dialect:certify` exists.
+   - qwen3.6 passed targeted fixes and adversarial subset; use incremental cert for future qwen3.6 tests.
+
+3. **Expanded adversarial suite is still finite.**
+   - It covers 125 samples across 25 dialects, but not every false friend, domain, or document structure.
+   - Future hardening should add domain packs: legal, medical, finance, education, e-commerce, gaming, government.
+
+4. **No semantic judge scoring yet.**
+   - Current gates are deterministic and strong for known traits, but they do not fully judge naturalness or deep semantic adequacy.
+   - A future LLM-as-judge or bilingual embedding rubric can add another quality layer.
+
+5. **Live cloud credentials must be passed through environment/session configuration.**
+   - Do not inline secrets in scripts/docs.
+
+## Release instructions
+
+After this report lands on `main`:
+
+```bash
+git tag v0.1.0-rc1
+git push origin v0.1.0-rc1
+```
+
+Then publish packages/docs if desired.
+
+## Verdict
+
+**DialectOS is ready for `v0.1.0-rc1`.**
+
+Recommended launch posture:
+
+- Default provider: `llm`
+- Default cloud model recommendation: `glm-4.5-air`
+- Premium/safer cloud option: `glm-5.1`
+- Local/offline recommendation: `qwen3.5-9b` via LM Studio

--- a/audits/release-candidate-2026-04-22/model-matrix.json
+++ b/audits/release-candidate-2026-04-22/model-matrix.json
@@ -1,0 +1,118 @@
+[
+  {
+    "label": "GLM 5.1 basic cert",
+    "file": "/tmp/dialectos-zai-glm51-full/results.json",
+    "total": 27,
+    "dialects": 25,
+    "passed": 27,
+    "failed": 0,
+    "warnings": 0,
+    "failures": []
+  },
+  {
+    "label": "GLM 4.7 basic cert",
+    "file": "/tmp/dialectos-zai-glm47-full/results.json",
+    "total": 27,
+    "dialects": 25,
+    "passed": 27,
+    "failed": 0,
+    "warnings": 0,
+    "failures": []
+  },
+  {
+    "label": "GLM 4.5 Air basic cert",
+    "file": "/tmp/dialectos-zai-glm45air-full/results.json",
+    "total": 27,
+    "dialects": 25,
+    "passed": 27,
+    "failed": 0,
+    "warnings": 0,
+    "failures": []
+  },
+  {
+    "label": "GLM 4.5 Air expanded adversarial cert",
+    "file": "/tmp/dialectos-expanded-adversarial-glm45air-v2/results.json",
+    "total": 125,
+    "dialects": 25,
+    "passed": 125,
+    "failed": 0,
+    "warnings": 0,
+    "unstable": 0,
+    "outputVariance": 0,
+    "failures": []
+  },
+  {
+    "label": "GLM 4.5 Air long document cert",
+    "file": "/tmp/dialectos-doc-cert-cloud-glm45air-final/results.json",
+    "total": 7,
+    "dialects": 7,
+    "passed": 7,
+    "failed": 0,
+    "failures": []
+  },
+  {
+    "label": "qwen3.5-9b basic cert",
+    "file": "/tmp/dialectos-certify-qwen35-9b-final/results.json",
+    "total": 27,
+    "dialects": 25,
+    "passed": 27,
+    "failed": 0,
+    "warnings": 0,
+    "failures": []
+  },
+  {
+    "label": "qwen3.5-9b expanded adversarial cert",
+    "file": "/tmp/dialectos-expanded-adversarial-qwen35-9b-v2/results.json",
+    "total": 125,
+    "dialects": 25,
+    "passed": 125,
+    "failed": 0,
+    "warnings": 0,
+    "unstable": 0,
+    "outputVariance": 0,
+    "failures": []
+  },
+  {
+    "label": "qwen3.6-35b targeted fix cert",
+    "file": "/tmp/dialectos-certify-qwen36-gq-mx/results.json",
+    "total": 2,
+    "dialects": 2,
+    "passed": 2,
+    "failed": 0,
+    "warnings": 0,
+    "failures": []
+  },
+  {
+    "label": "qwen3.6-35b adversarial cert",
+    "file": "/tmp/dialectos-adversarial-qwen36/results.json",
+    "total": 11,
+    "dialects": 8,
+    "passed": 11,
+    "failed": 0,
+    "warnings": 0,
+    "unstable": 0,
+    "outputVariance": 0,
+    "failures": []
+  },
+  {
+    "label": "mock expanded adversarial cert on current main",
+    "file": "/tmp/dialectos-main-expanded-adversarial-final/results.json",
+    "total": 125,
+    "dialects": 25,
+    "passed": 125,
+    "failed": 0,
+    "warnings": 0,
+    "unstable": 0,
+    "outputVariance": 0,
+    "failures": []
+  },
+  {
+    "label": "mock document cert on current main",
+    "file": "/tmp/dialectos-main-doc-cert-final/results.json",
+    "total": 7,
+    "dialects": 7,
+    "passed": 7,
+    "failed": 0,
+    "failures": []
+  }
+]

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        692 tests passing · BSL 1.1 · GitHub Pages
+        693 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">692</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">693</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 692 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 693 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-692 tests. 7 packages. pnpm monorepo. TypeScript.
+693 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 692 tests
+**Tech:** TypeScript, pnpm monorepo, 693 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 692 tests passing.
+Source available, BSL 1.1 licensed, 693 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 692 tests
+**Tech stack:** TypeScript, pnpm monorepo, 693 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 


### PR DESCRIPTION
## Summary
- Add `audits/release-candidate-2026-04-22/README.md` with the `v0.1.0-rc1` launch decision.
- Add machine-readable model/certification matrix.
- Update README/social/docs test counts to 693 and document recommended certified models.

## Recommendation
- Default cloud launch model: `glm-4.5-air`
- Premium/safer option: `glm-5.1`
- Local/offline option: `qwen3.5-9b` via LM Studio

## Verification represented in report
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 693 tests
- `pnpm audit --audit-level low`
- npm pack guard
- Basic 25-dialect certs for GLM 5.1 / 4.7 / 4.5 Air
- Expanded adversarial cert for GLM 4.5 Air and qwen3.5-9b
- Long-document cloud cert for GLM 4.5 Air
