### PR TITLE
Add customer certification report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-693%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-695%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -128,6 +128,14 @@ Use `dialect:certify:documents` to certify README/API-doc/locale JSON flows, not
 pnpm dialect:certify:documents -- --live --provider=llm --dialects=es-MX,es-PA,es-PR --out=/tmp/dialectos-doc-cert
 ```
 
+### Customer-facing certification report
+
+Use `dialect:report` to turn certification artifacts into a customer-facing Markdown deliverable for paid launch audits.
+
+```bash
+pnpm dialect:report -- --input=audits/release-candidate-2026-04-22/model-matrix.json --out=customer-report.md --customer="Acme SaaS" --product="Spanish launch"
+```
+
 ### CLI install
 
 ```bash
@@ -154,7 +162,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 693 tests passing
+pnpm test        # 695 tests passing
 ```
 
 ---
@@ -196,14 +204,14 @@ pnpm test        # 693 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 291 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 293 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 693 tests across 7 packages**
+**Total: 695 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        693 tests passing · BSL 1.1 · GitHub Pages
+        695 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">693</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">695</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 693 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 695 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-693 tests. 7 packages. pnpm monorepo. TypeScript.
+695 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 693 tests
+**Tech:** TypeScript, pnpm monorepo, 695 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 693 tests passing.
+Source available, BSL 1.1 licensed, 695 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 693 tests
+**Tech stack:** TypeScript, pnpm monorepo, 695 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dialect:eval": "node scripts/dialect-eval.mjs",
     "dialect:certify": "node scripts/dialect-certify.mjs",
     "dialect:certify:adversarial": "node scripts/dialect-certify-adversarial.mjs",
-    "dialect:certify:documents": "node scripts/dialect-certify-documents.mjs"
+    "dialect:certify:documents": "node scripts/dialect-certify-documents.mjs",
+    "dialect:report": "node scripts/dialect-report.mjs"
   },
   "keywords": [
     "spanish",

--- a/packages/cli/src/__tests__/dialect-report-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-report-script.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("dialect report script", () => {
+  it("renders a customer-facing launch report from certification artifacts", () => {
+    const dir = join(tmpdir(), `dialect-report-${process.pid}`);
+    const input = join(dir, "matrix.json");
+    const out = join(dir, "report.md");
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(input, JSON.stringify([
+      { label: "Basic cert", total: 27, passed: 27, failed: 0, warnings: 0, dialects: 25, failures: [] },
+      { label: "Adversarial cert", total: 125, passed: 125, failed: 0, warnings: 0, dialects: 25, unstable: 0, outputVariance: 0, failures: [] },
+    ], null, 2));
+
+    execFileSync("node", [
+      "scripts/dialect-report.mjs",
+      `--input=${input}`,
+      `--out=${out}`,
+      "--customer=Acme SaaS",
+      "--product=Spanish launch",
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
+
+    const report = readFileSync(out, "utf-8");
+    expect(report).toContain("DialectOS Certification Report: Acme SaaS");
+    expect(report).toContain("Overall grade: **Pass**");
+    expect(report).toContain("Launch candidate is certified");
+    expect(report).toContain("Basic cert");
+    expect(report).toContain("Adversarial cert");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("grades reports with failures as no-go", () => {
+    const dir = join(tmpdir(), `dialect-report-fail-${process.pid}`);
+    const input = join(dir, "matrix.json");
+    const out = join(dir, "report.md");
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(input, JSON.stringify({
+      label: "Failed cert",
+      total: 1,
+      passed: 0,
+      failed: 1,
+      warnings: 0,
+      failures: [{ dialect: "es-PA", fixture: "taboo", failures: ["Forbidden output term present: chombo"], output: "chombo" }],
+    }, null, 2));
+
+    execFileSync("node", [
+      "scripts/dialect-report.mjs",
+      `--input=${input}`,
+      `--out=${out}`,
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" });
+
+    const report = readFileSync(out, "utf-8");
+    expect(report).toContain("Overall grade: **No-Go**");
+    expect(report).toContain("Do not launch");
+    expect(report).toContain("Forbidden output term present: chombo");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/scripts/dialect-report.mjs
+++ b/scripts/dialect-report.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+
+const args = new Map();
+for (const arg of process.argv.slice(2)) {
+  if (arg === "--") continue;
+  const [key, value = ""] = arg.replace(/^--/, "").split("=");
+  args.set(key, value || "true");
+}
+
+const input = args.get("input") || args.get("cert") || "audits/release-candidate-2026-04-22/model-matrix.json";
+const out = args.get("out") || "audits/dialect-report.md";
+const customer = args.get("customer") || "Customer";
+const product = args.get("product") || "Spanish localization";
+const generatedAt = new Date().toISOString();
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function normalizeResult(result, label = "Certification") {
+  return {
+    label: result.label || label,
+    file: result.file,
+    total: result.total ?? result.totalSamples ?? result.results?.length ?? 0,
+    passed: result.passed ?? result.results?.filter((row) => row.passes).length ?? 0,
+    failed: result.failed ?? result.results?.filter((row) => row.passes === false).length ?? 0,
+    warnings: result.warnings ?? 0,
+    unstable: result.unstable ?? result.unstableCount ?? 0,
+    outputVariance: result.outputVariance ?? result.outputVarianceCount ?? 0,
+    dialects: result.dialects ?? (result.results ? new Set(result.results.map((row) => row.dialect).filter(Boolean)).size : undefined),
+    failures: result.failures || result.results?.filter((row) => row.passes === false).map((row) => ({
+      dialect: row.dialect,
+      fixture: row.fixture,
+      output: row.output,
+      failures: row.failures || [],
+      qualityWarnings: row.qualityWarnings || [],
+    })) || [],
+  };
+}
+
+function loadInputs(inputPath) {
+  const resolved = resolve(inputPath);
+  if (!existsSync(resolved)) {
+    throw new Error(`Input not found: ${inputPath}`);
+  }
+  const parsed = readJson(resolved);
+  if (Array.isArray(parsed)) {
+    return parsed.map((item, index) => normalizeResult(item, item.label || `Certification ${index + 1}`));
+  }
+  return [normalizeResult(parsed, basename(inputPath))];
+}
+
+function gradeFor(summary) {
+  if (summary.failed > 0) return "No-Go";
+  if (summary.unstable > 0) return "Conditional";
+  if (summary.warnings > 0 || summary.outputVariance > 0) return "Pass with Notes";
+  return "Pass";
+}
+
+function escapePipes(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function collectSummary(results) {
+  const totals = results.reduce((acc, result) => {
+    acc.total += result.total || 0;
+    acc.passed += result.passed || 0;
+    acc.failed += result.failed || 0;
+    acc.warnings += result.warnings || 0;
+    acc.unstable += result.unstable || 0;
+    acc.outputVariance += result.outputVariance || 0;
+    return acc;
+  }, { total: 0, passed: 0, failed: 0, warnings: 0, unstable: 0, outputVariance: 0 });
+  return { ...totals, grade: gradeFor(totals) };
+}
+
+function recommendedAction(summary) {
+  if (summary.failed > 0) return "Do not launch until failed checks are resolved and certification is rerun.";
+  if (summary.unstable > 0) return "Launch only after repeatability instability is triaged or accepted in writing.";
+  if (summary.warnings > 0 || summary.outputVariance > 0) return "Launch is acceptable with documented notes; review warnings before high-risk campaigns.";
+  return "Launch candidate is certified for the tested scope.";
+}
+
+function render(results) {
+  const summary = collectSummary(results);
+  const lines = [];
+  lines.push(`# DialectOS Certification Report: ${customer}`);
+  lines.push("");
+  lines.push(`Generated: ${generatedAt}`);
+  lines.push(`Product/scope: ${product}`);
+  lines.push(`Overall grade: **${summary.grade}**`);
+  lines.push("");
+  lines.push("## Executive summary");
+  lines.push("");
+  lines.push(`- Total checks: ${summary.total}`);
+  lines.push(`- Passed: ${summary.passed}`);
+  lines.push(`- Failed: ${summary.failed}`);
+  lines.push(`- Warnings: ${summary.warnings}`);
+  lines.push(`- Unstable samples: ${summary.unstable}`);
+  lines.push(`- Output-variance notes: ${summary.outputVariance}`);
+  lines.push(`- Recommendation: ${recommendedAction(summary)}`);
+  lines.push("");
+  lines.push("## Certification matrix");
+  lines.push("");
+  lines.push("| Certification | Grade | Passed | Failed | Warnings | Dialects | Notes |");
+  lines.push("| --- | --- | ---: | ---: | ---: | ---: | --- |");
+  for (const result of results) {
+    lines.push(`| ${escapePipes(result.label)} | ${gradeFor(result)} | ${result.passed}/${result.total} | ${result.failed} | ${result.warnings} | ${result.dialects ?? ""} | ${result.unstable ? `${result.unstable} unstable` : result.outputVariance ? `${result.outputVariance} output variance` : ""} |`);
+  }
+  lines.push("");
+  lines.push("## Failure details");
+  lines.push("");
+  const failures = results.flatMap((result) => result.failures.map((failure) => ({ ...failure, certification: result.label })));
+  if (failures.length === 0) {
+    lines.push("No failed certification rows in the supplied artifacts.");
+  } else {
+    lines.push("| Certification | Dialect | Fixture | Failures | Output |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const failure of failures) {
+      lines.push(`| ${escapePipes(failure.certification)} | ${escapePipes(failure.dialect)} | ${escapePipes(failure.fixture)} | ${escapePipes([...(failure.failures || []), ...(failure.qualityWarnings || [])].join("; "))} | ${escapePipes(failure.output)} |`);
+    }
+  }
+  lines.push("");
+  lines.push("## Commercial packaging suggestion");
+  lines.push("");
+  lines.push("- Use this report as the customer-facing deliverable for a paid Spanish Localization Launch Certification.");
+  lines.push("- Recommended entry package: fixed-scope launch audit with certified dialect matrix and remediation notes.");
+  lines.push("- Recommended recurring package: CI/GitHub certification on localization pull requests.");
+  lines.push("");
+  lines.push("## Limits");
+  lines.push("");
+  lines.push("This report certifies only the supplied artifacts and test scope. It does not replace native-speaker review for legal, medical, regulated, or brand-sensitive campaigns.");
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+const results = loadInputs(input);
+mkdirSync(dirname(resolve(out)), { recursive: true });
+writeFileSync(out, render(results));
+console.log(JSON.stringify({ out, certifications: results.length, grade: collectSummary(results).grade }, null, 2));


### PR DESCRIPTION
## Summary
- Add `pnpm dialect:report` to turn certification JSON into a customer-facing Markdown launch report.
- Report includes executive summary, launch grade, certification matrix, failure details, commercial packaging guidance, and limits.
- Add tests for pass and no-go report grading.
- Update docs/test count to 695.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 695 tests passing across 7 packages
- `pnpm audit --audit-level low`
- npm pack guard
- Generated `/tmp/dialectos-customer-report-final.md` from RC model matrix
