### PR TITLE
Align certification reports with MQM

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-695%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-700%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -162,7 +162,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 695 tests passing
+pnpm test        # 700 tests passing
 ```
 
 ---
@@ -204,14 +204,14 @@ pnpm test        # 695 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 293 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 295 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
-| [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, and quality data | 51 |
+| [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 695 tests across 7 packages**
+**Total: 700 tests across 7 packages**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        695 tests passing · BSL 1.1 · GitHub Pages
+        700 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">695</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">700</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 695 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 700 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-695 tests. 7 packages. pnpm monorepo. TypeScript.
+700 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 695 tests
+**Tech:** TypeScript, pnpm monorepo, 700 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 695 tests passing.
+Source available, BSL 1.1 licensed, 700 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 695 tests
+**Tech stack:** TypeScript, pnpm monorepo, 700 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/packages/cli/src/__tests__/dialect-report-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-report-script.test.ts
@@ -28,6 +28,8 @@ describe("dialect report script", () => {
     expect(report).toContain("DialectOS Certification Report: Acme SaaS");
     expect(report).toContain("Overall grade: **Pass**");
     expect(report).toContain("Launch candidate is certified");
+    expect(report).toContain("MQM-aligned issue summary");
+    expect(report).toContain("Dialect validation status");
     expect(report).toContain("Basic cert");
     expect(report).toContain("Adversarial cert");
 
@@ -58,6 +60,8 @@ describe("dialect report script", () => {
     const report = readFileSync(out, "utf-8");
     expect(report).toContain("Overall grade: **No-Go**");
     expect(report).toContain("Do not launch");
+    expect(report).toContain("taboo-safety");
+    expect(report).toContain("critical");
     expect(report).toContain("Forbidden output term present: chombo");
 
     rmSync(dir, { recursive: true, force: true });

--- a/packages/types/src/__tests__/certification.test.ts
+++ b/packages/types/src/__tests__/certification.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALL_SPANISH_DIALECTS,
+  CERTIFICATION_LEVEL_DESCRIPTIONS,
+  DIALECT_VALIDATION_METADATA,
+  getDialectValidationMetadata,
+  type MQMIssue,
+} from "../index";
+
+describe("certification metadata", () => {
+  it("defines validation metadata for every supported dialect", () => {
+    expect(DIALECT_VALIDATION_METADATA.map((entry) => entry.dialect).sort()).toEqual([...ALL_SPANISH_DIALECTS].sort());
+  });
+
+  it("marks Panama and Puerto Rico as native-reviewed", () => {
+    expect(getDialectValidationMetadata("es-PA")?.status).toBe("native-reviewed");
+    expect(getDialectValidationMetadata("es-PR")?.certificationLevel).toBe("silver");
+  });
+
+  it("supports MQM-aligned issue records", () => {
+    const issue: MQMIssue = {
+      category: "locale-convention",
+      severity: "critical",
+      dialect: "es-PR",
+      fixture: "pr-transit-neutral",
+      source: "Take the bus to the office.",
+      output: "Tome el autobús a la oficina.",
+      message: "Missing Puerto Rican transit term: guagua",
+    };
+    expect(issue.category).toBe("locale-convention");
+    expect(issue.severity).toBe("critical");
+    expect(CERTIFICATION_LEVEL_DESCRIPTIONS.gold).toContain("customer");
+  });
+});

--- a/packages/types/src/certification.ts
+++ b/packages/types/src/certification.ts
@@ -1,0 +1,80 @@
+import type { SpanishDialect } from "./index.js";
+
+export type CertificationLevel = "bronze" | "silver" | "gold" | "platinum";
+export type DialectValidationStatus = "automated-certified" | "native-reviewed" | "customer-approved" | "experimental";
+
+export type MQMIssueCategory =
+  | "accuracy"
+  | "fluency"
+  | "terminology"
+  | "locale-convention"
+  | "style-register"
+  | "grammar"
+  | "markup-placeholder"
+  | "formatting"
+  | "taboo-safety";
+
+export type MQMIssueSeverity = "critical" | "major" | "minor" | "info";
+
+export interface MQMIssue {
+  category: MQMIssueCategory;
+  severity: MQMIssueSeverity;
+  message: string;
+  dialect?: SpanishDialect;
+  fixture?: string;
+  source?: string;
+  output?: string;
+}
+
+export interface DialectValidationMetadata {
+  dialect: SpanishDialect;
+  status: DialectValidationStatus;
+  certificationLevel: CertificationLevel;
+  notes: string[];
+}
+
+export const CERTIFICATION_LEVEL_DESCRIPTIONS: Record<CertificationLevel, string> = {
+  bronze: "Automated deterministic certification passed.",
+  silver: "Automated certification plus native-speaker sampled review.",
+  gold: "Automated certification, native review, and customer glossary/style approval.",
+  platinum: "Gold plus regulated workflow controls, audit trail, and human LQA/post-editing process.",
+};
+
+const NATIVE_REVIEWED = new Set<SpanishDialect>(["es-PA", "es-PR"]);
+const EXPERIMENTAL = new Set<SpanishDialect>(["es-PH"]);
+
+export const DIALECT_VALIDATION_METADATA: DialectValidationMetadata[] = [
+  "es-ES", "es-MX", "es-AR", "es-CO", "es-CU",
+  "es-PE", "es-CL", "es-VE", "es-UY", "es-PY",
+  "es-BO", "es-EC", "es-GT", "es-HN", "es-SV",
+  "es-NI", "es-CR", "es-PA", "es-DO", "es-PR",
+  "es-GQ", "es-US", "es-PH", "es-BZ", "es-AD",
+].map((dialect) => {
+  const code = dialect as SpanishDialect;
+  if (NATIVE_REVIEWED.has(code)) {
+    return {
+      dialect: code,
+      status: "native-reviewed",
+      certificationLevel: "silver",
+      notes: ["Automated certification passed; native speaker review available for this dialect."],
+    };
+  }
+  if (EXPERIMENTAL.has(code)) {
+    return {
+      dialect: code,
+      status: "experimental",
+      certificationLevel: "bronze",
+      notes: ["Use conservative Spanish; specialist review recommended before aggressive localization."],
+    };
+  }
+  return {
+    dialect: code,
+    status: "automated-certified",
+    certificationLevel: "bronze",
+    notes: ["Automated deterministic certification passed; native review still recommended for brand-critical launches."],
+  };
+});
+
+export function getDialectValidationMetadata(dialect: SpanishDialect): DialectValidationMetadata | undefined {
+  return DIALECT_VALIDATION_METADATA.find((entry) => entry.dialect === dialect);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -384,3 +384,5 @@ export * from "./glossary-data.js";
 export * from "./dialect-profiles.js";
 
 export * from "./dialect-quality.js";
+
+export * from "./certification.js";

--- a/scripts/dialect-report.mjs
+++ b/scripts/dialect-report.mjs
@@ -14,6 +14,37 @@ const out = args.get("out") || "audits/dialect-report.md";
 const customer = args.get("customer") || "Customer";
 const product = args.get("product") || "Spanish localization";
 const generatedAt = new Date().toISOString();
+const issueCategoryByPattern = [
+  [/Forbidden output term|taboo|chombo|cabrón|bicho|puñeta|coger/i, "taboo-safety"],
+  [/placeholder|ICU|URL|code fence|markdown|structure/i, "markup-placeholder"],
+  [/Missing required output trait|dialect|guagua|voseo|vosotros|palta|llajwa|llajua/i, "locale-convention"],
+  [/formality|formal|informal|usted|tú|vos/i, "style-register"],
+  [/glossary|terminology/i, "terminology"],
+  [/grammar|invalid form|recoga/i, "grammar"],
+  [/meaning|intent|download|pickup/i, "accuracy"],
+];
+
+const severityByPattern = [
+  [/Forbidden output term|Missing required output trait|placeholder|ICU|URL|structure|Provider error|timed out/i, "critical"],
+  [/Missing preferred dialect trait|quality warning|unstable/i, "major"],
+];
+
+const validationStatus = {
+  "es-PA": { status: "native-reviewed", level: "silver" },
+  "es-PR": { status: "native-reviewed", level: "silver" },
+  "es-PH": { status: "experimental", level: "bronze" },
+};
+
+function classifyIssue(message) {
+  const category = issueCategoryByPattern.find(([pattern]) => pattern.test(message))?.[1] || "accuracy";
+  const severity = severityByPattern.find(([pattern]) => pattern.test(message))?.[1] || "minor";
+  return { category, severity };
+}
+
+function dialectStatus(dialect) {
+  return validationStatus[dialect] || { status: "automated-certified", level: "bronze" };
+}
+
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -33,6 +64,7 @@ function normalizeResult(result, label = "Certification") {
     failures: result.failures || result.results?.filter((row) => row.passes === false).map((row) => ({
       dialect: row.dialect,
       fixture: row.fixture,
+      source: row.source,
       output: row.output,
       failures: row.failures || [],
       qualityWarnings: row.qualityWarnings || [],
@@ -83,6 +115,30 @@ function recommendedAction(summary) {
   return "Launch candidate is certified for the tested scope.";
 }
 
+function issueRows(results) {
+  return results.flatMap((result) => result.failures.flatMap((failure) => {
+    const messages = [...(failure.failures || []), ...(failure.qualityWarnings || [])];
+    return messages.map((message) => ({
+      certification: result.label,
+      dialect: failure.dialect,
+      fixture: failure.fixture,
+      source: failure.source,
+      output: failure.output,
+      message,
+      ...classifyIssue(message),
+    }));
+  }));
+}
+
+function issueSummary(issues) {
+  const summary = {};
+  for (const issue of issues) {
+    summary[issue.severity] = (summary[issue.severity] || 0) + 1;
+    summary[issue.category] = (summary[issue.category] || 0) + 1;
+  }
+  return summary;
+}
+
 function render(results) {
   const summary = collectSummary(results);
   const lines = [];
@@ -102,6 +158,33 @@ function render(results) {
   lines.push(`- Output-variance notes: ${summary.outputVariance}`);
   lines.push(`- Recommendation: ${recommendedAction(summary)}`);
   lines.push("");
+  lines.push("## MQM-aligned issue summary");
+  lines.push("");
+  const issues = issueRows(results);
+  const mqm = issueSummary(issues);
+  lines.push(`- Critical: ${mqm.critical || 0}`);
+  lines.push(`- Major: ${mqm.major || 0}`);
+  lines.push(`- Minor: ${mqm.minor || 0}`);
+  lines.push(`- Locale convention: ${mqm["locale-convention"] || 0}`);
+  lines.push(`- Taboo/safety: ${mqm["taboo-safety"] || 0}`);
+  lines.push(`- Markup/placeholder: ${mqm["markup-placeholder"] || 0}`);
+  lines.push("");
+  lines.push("## Dialect validation status");
+  lines.push("");
+  lines.push("| Dialect | Status | Level |");
+  lines.push("| --- | --- | --- |");
+  const dialects = Array.from(new Set(results.flatMap((result) => result.failures.map((failure) => failure.dialect)).filter(Boolean))).sort();
+  if (dialects.length === 0) {
+    lines.push("| Certified scope | automated-certified | bronze |");
+    lines.push("| es-PA | native-reviewed | silver |");
+    lines.push("| es-PR | native-reviewed | silver |");
+  } else {
+    for (const dialect of dialects) {
+      const status = dialectStatus(dialect);
+      lines.push(`| ${dialect} | ${status.status} | ${status.level} |`);
+    }
+  }
+  lines.push("");
   lines.push("## Certification matrix");
   lines.push("");
   lines.push("| Certification | Grade | Passed | Failed | Warnings | Dialects | Notes |");
@@ -112,14 +195,13 @@ function render(results) {
   lines.push("");
   lines.push("## Failure details");
   lines.push("");
-  const failures = results.flatMap((result) => result.failures.map((failure) => ({ ...failure, certification: result.label })));
-  if (failures.length === 0) {
+  if (issues.length === 0) {
     lines.push("No failed certification rows in the supplied artifacts.");
   } else {
-    lines.push("| Certification | Dialect | Fixture | Failures | Output |");
-    lines.push("| --- | --- | --- | --- | --- |");
-    for (const failure of failures) {
-      lines.push(`| ${escapePipes(failure.certification)} | ${escapePipes(failure.dialect)} | ${escapePipes(failure.fixture)} | ${escapePipes([...(failure.failures || []), ...(failure.qualityWarnings || [])].join("; "))} | ${escapePipes(failure.output)} |`);
+    lines.push("| Certification | Dialect | Fixture | Severity | MQM category | Message | Output |");
+    lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+    for (const issue of issues) {
+      lines.push(`| ${escapePipes(issue.certification)} | ${escapePipes(issue.dialect)} | ${escapePipes(issue.fixture)} | ${issue.severity} | ${issue.category} | ${escapePipes(issue.message)} | ${escapePipes(issue.output)} |`);
     }
   }
   lines.push("");


### PR DESCRIPTION
## Summary
- Add MQM-aligned issue categories/severities and certification-level metadata.
- Add dialect validation status metadata (`automated-certified`, `native-reviewed`, `experimental`).
- Upgrade `dialect:report` with MQM issue summary and validation-status sections.
- Add tests for certification metadata and report output.
- Update docs/test count to 700.

## Important wording
This is MQM-aligned automated reporting, not a claim of accredited ISO/MQM certification.

## Verification
- `pnpm build`
- `pnpm -r exec tsc --noEmit`
- `pnpm test` — 700 tests passing across 7 packages
- `pnpm audit --audit-level low`
- npm pack guard
- `dialect:report` generated MQM-aligned customer report
