### PR TITLE
Publish Spanish launch audit offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 
 ---
 
+
+## Spanish Launch Certification
+
+DialectOS is available as a paid Spanish localization launch audit. We certify your Spanish docs, app strings, support macros, or locale files across target dialects and deliver an MQM-aligned launch-readiness report.
+
+- Beta pilot: **$500**
+- Scope: up to 10,000 source words and 5 target dialects
+- Deliverables: certification report, issue list, severity table, recommended fixes, launch decision
+- Sample report: [`audits/sample-customer-report.md`](audits/sample-customer-report.md)
+- Offer details: [`docs/spanish-launch-certification.md`](docs/spanish-launch-certification.md)
+
 ## ✨ What makes DialectOS different?
 
 | Feature | Google Translate | DeepL API | **DialectOS** |
@@ -81,7 +92,7 @@ Add to your Claude Desktop, Cursor, or any MCP client:
 
 ### Recommended certified models
 
-For `v0.1.0-rc1`, the recommended default cloud model is `glm-4.5-air` through the Z.ai international Anthropic-compatible endpoint. It passed basic, expanded adversarial, and long-document certification. Use `glm-5.1` when you want the higher-confidence/premium option, and `qwen3.5-9b` via LM Studio for local/offline certification.
+For `v0.1.0-rc3`, the recommended default cloud model is `glm-4.5-air` through the Z.ai international Anthropic-compatible endpoint. It passed basic, expanded adversarial, and long-document certification. Use `glm-5.1` when you want the higher-confidence/premium option, and `qwen3.5-9b` via LM Studio for local/offline certification.
 
 ```bash
 export LLM_API_URL="https://api.z.ai/api/anthropic/v1/messages"

--- a/audits/sample-customer-report.md
+++ b/audits/sample-customer-report.md
@@ -1,0 +1,63 @@
+# DialectOS Certification Report: Sample SaaS
+
+Generated: 2026-04-22T15:12:36.643Z
+Product/scope: Spanish Launch
+Overall grade: **Pass**
+
+## Executive summary
+
+- Total checks: 510
+- Passed: 510
+- Failed: 0
+- Warnings: 0
+- Unstable samples: 0
+- Output-variance notes: 0
+- Recommendation: Launch candidate is certified for the tested scope.
+
+## MQM-aligned issue summary
+
+- Critical: 0
+- Major: 0
+- Minor: 0
+- Locale convention: 0
+- Taboo/safety: 0
+- Markup/placeholder: 0
+
+## Dialect validation status
+
+| Dialect | Status | Level |
+| --- | --- | --- |
+| Certified scope | automated-certified | bronze |
+| es-PA | native-reviewed | silver |
+| es-PR | native-reviewed | silver |
+
+## Certification matrix
+
+| Certification | Grade | Passed | Failed | Warnings | Dialects | Notes |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| GLM 5.1 basic cert | Pass | 27/27 | 0 | 0 | 25 |  |
+| GLM 4.7 basic cert | Pass | 27/27 | 0 | 0 | 25 |  |
+| GLM 4.5 Air basic cert | Pass | 27/27 | 0 | 0 | 25 |  |
+| GLM 4.5 Air expanded adversarial cert | Pass | 125/125 | 0 | 0 | 25 |  |
+| GLM 4.5 Air long document cert | Pass | 7/7 | 0 | 0 | 7 |  |
+| qwen3.5-9b basic cert | Pass | 27/27 | 0 | 0 | 25 |  |
+| qwen3.5-9b expanded adversarial cert | Pass | 125/125 | 0 | 0 | 25 |  |
+| qwen3.6-35b targeted fix cert | Pass | 2/2 | 0 | 0 | 2 |  |
+| qwen3.6-35b adversarial cert | Pass | 11/11 | 0 | 0 | 8 |  |
+| mock expanded adversarial cert on current main | Pass | 125/125 | 0 | 0 | 25 |  |
+| mock document cert on current main | Pass | 7/7 | 0 | 0 | 7 |  |
+
+## Failure details
+
+No failed certification rows in the supplied artifacts.
+
+## Commercial packaging suggestion
+
+- Use this report as the customer-facing deliverable for a paid Spanish Localization Launch Certification.
+- Recommended entry package: fixed-scope launch audit with certified dialect matrix and remediation notes.
+- Recommended recurring package: CI/GitHub certification on localization pull requests.
+
+## Limits
+
+This report certifies only the supplied artifacts and test scope. It does not replace native-speaker review for legal, medical, regulated, or brand-sensitive campaigns.
+

--- a/docs/spanish-launch-certification.md
+++ b/docs/spanish-launch-certification.md
@@ -1,0 +1,101 @@
+# Spanish Launch Certification
+
+Launching in Spanish? DialectOS certifies whether your AI/localized Spanish is ready for real users across priority dialects before customers find the mistakes.
+
+## What we catch
+
+- Mexico vs Spain wording issues such as risky `coger` translations
+- Puerto Rico / Cuba / Dominican Republic transit terms such as `guagua`
+- Panama-specific taboo or identity-loaded terms such as `chombo`
+- Argentine / Uruguayan / Central American voseo morphology
+- Spain `vosotros` / plural-address expectations
+- formality drift in billing, password, support, and security copy
+- broken placeholders such as `{userName}` and `%{count}`
+- broken URLs, Markdown, code fences, API tables, and locale JSON
+- AI translation drift, over-localization, under-localization, and taboo-copying
+
+## Deliverables
+
+Every audit includes:
+
+1. MQM-aligned certification report
+2. launch-readiness grade
+3. dialect risk table
+4. exact issue list with severity and category
+5. recommended fixes / remediation notes
+6. certification artifacts for your team or investors
+
+See a sample report: [`audits/sample-customer-report.md`](../audits/sample-customer-report.md)
+
+## Beta pilot package
+
+### Spanish Launch Audit — Beta
+
+**Price:** $500
+
+Includes:
+
+- up to 10,000 source words
+- up to 5 target dialects
+- README/docs, landing copy, support macros, or locale JSON
+- MQM-aligned issue report
+- deterministic dialect certification
+- adversarial dialect certification
+- document/placeholder/URL certification
+- recommended fixes
+- launch decision: pass, pass with notes, conditional, or no-go
+- 48-hour turnaround after materials are received
+
+Best for:
+
+- SaaS teams launching in LATAM / Spain / US Hispanic markets
+- AI products with Spanish docs or support content
+- startups using LLMs for localization
+- devtools shipping Spanish documentation
+- e-commerce brands entering Mexico or US Hispanic markets
+
+## Certification levels
+
+| Level | Meaning |
+| --- | --- |
+| Bronze | Automated deterministic certification passed. |
+| Silver | Automated certification plus native-speaker sampled review. |
+| Gold | Automated certification, native review, and customer glossary/style approval. |
+| Platinum | Gold plus regulated workflow controls, audit trail, and human LQA/post-editing process. |
+
+The beta audit includes Bronze by default. Panama and Puerto Rico can include Silver-level sampled native review when in scope.
+
+## What we need from you
+
+Send any of:
+
+- locale JSON files
+- Markdown docs
+- landing-page copy
+- onboarding emails
+- support macros
+- glossary/style guide
+- priority countries/dialects
+
+Example target-dialect bundle:
+
+```txt
+es-MX, es-PA, es-PR, es-AR, es-ES
+```
+
+## Contact / booking
+
+Open an issue or email the maintainer with:
+
+```txt
+Subject: Spanish Launch Audit
+Company:
+Launch date:
+Target dialects:
+Approximate word count:
+Content type: docs / app strings / emails / support / landing page
+```
+
+## Important limits
+
+DialectOS certification is an automated MQM-aligned localization QA artifact. It is not a legal guarantee, and it does not replace full native-speaker review for legal, medical, regulated, or brand-sensitive campaigns.


### PR DESCRIPTION
## Summary
- Add public Spanish Launch Certification offer page.
- Add $500 beta pilot package scope and deliverables.
- Generate and link sample customer-facing certification report.
- Add README section pointing to offer and sample report.

## Verification
- `pnpm build`
- `pnpm --filter=@espanol/cli test -- dialect-report-script.test.ts`
- generated `audits/sample-customer-report.md`
