### PR TITLE
Stop presenting static demo as full translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-700%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-701%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -173,7 +173,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 700 tests passing
+pnpm test        # 701 tests passing
 ```
 
 ---
@@ -215,14 +215,14 @@ pnpm test        # 700 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 295 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 293 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 700 tests across 7 packages**
+**Total: 701 tests across 7 packages plus the static docs contract**
 
 ---
 

--- a/docs/__tests__/demo-contract.test.mjs
+++ b/docs/__tests__/demo-contract.test.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+const engine = readFileSync(new URL("../dialectos-engine.js", import.meta.url), "utf8");
+
+test("static docs demo is honestly labeled as a rule explorer", () => {
+  assert.match(html, /Dialect Rule Explorer/);
+  assert.match(html, /not a full AI translation service/i);
+  assert.match(html, /For certified translation/i);
+});
+
+test("static docs demo never claims unchanged text is already compatible", () => {
+  assert.doesNotMatch(html, /already compatible/);
+  assert.match(html, /No rule-based substitutions fired/);
+});
+
+test("static docs engine has common three-word regional terms", () => {
+  assert.match(engine, /\baguacate\b/);
+  assert.match(engine, /\bpalta\b/);
+  assert.match(engine, /\bguagua\b/);
+  assert.match(engine, /\bbus\b/);
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DialectOS — Translate Spanish Across 25 Dialects</title>
-  <meta name="description" content="Type Spanish text and adapt it for any of 25 regional dialects. See every word substitution instantly.">
+  <title>DialectOS — Spanish Dialect Rule Explorer and Certification</title>
+  <meta name="description" content="Explore deterministic Spanish dialect substitutions in the static browser demo, then use the certified CLI/MCP/LLM workflow for semantic translation QA.">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -30,15 +30,16 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        700 tests passing · BSL 1.1 · GitHub Pages
+        701 tests passing · BSL 1.1 · GitHub Pages
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
       </h1>
       <p class="text-lg text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-        Type Spanish text. Pick a target dialect. See <strong class="text-slate-200">every word that changes</strong> — 
-        from <em>coche</em> to <em>carro</em>, <em>vosotros</em> to <em>ustedes</em>, <em>zumo</em> to <em>jugo</em>.
-        25 dialects. 200+ vocabulary rules. Zero signup.
+        This page is a <strong class="text-slate-200">static rule explorer</strong>, not a full AI translation service.
+        It shows deterministic substitutions such as <em>coche</em> → <em>carro</em>,
+        <em>vosotros</em> → <em>ustedes</em>, and <em>zumo</em> → <em>jugo</em>.
+        For semantic translation and launch decisions, use the certified CLI/MCP/LLM workflow.
       </p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="https://github.com/Pastorsimon1798/DialectOS" class="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl font-semibold text-sm transition-colors flex items-center gap-2">
@@ -46,7 +47,7 @@
           Star on GitHub
         </a>
         <a href="#translate" class="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 rounded-xl font-semibold text-sm text-white transition-colors">
-          Try It →
+          Explore Rules →
         </a>
       </div>
     </div>
@@ -57,19 +58,27 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">700</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">701</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>
 
-  <!-- Main Translator -->
+  <!-- Main Rule Explorer -->
   <section id="translate" class="max-w-5xl mx-auto px-6 mb-14">
     <div class="glass rounded-2xl p-6 md:p-8">
+      <div class="mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+        <strong class="text-amber-200">Important:</strong>
+        this browser demo only applies known rule-table substitutions from a static JavaScript file.
+        It does not infer meaning, fill missing words, or certify that unchanged text is valid for a dialect.
+        <a href="https://github.com/Pastorsimon1798/DialectOS#readme" class="text-sky-300 hover:text-sky-200 underline">For certified translation</a>,
+        run the CLI/MCP/LLM evaluation and MQM reporting flow instead.
+      </div>
+
       <!-- Toolbar -->
       <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-5">
         <div>
-          <h2 class="text-xl font-semibold text-slate-200">Dialect Translator</h2>
-          <p class="text-sm text-slate-500 mt-0.5">Type in Spain Spanish (es-ES) or any variant — see what changes for your target.</p>
+          <h2 class="text-xl font-semibold text-slate-200">Dialect Rule Explorer</h2>
+          <p class="text-sm text-slate-500 mt-0.5">Type Spanish text to inspect deterministic substitutions; this is not semantic translation.</p>
         </div>
         <div class="flex gap-2 flex-wrap">
           <button onclick="loadPreset('es-mx')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇲🇽 → Mexico</button>
@@ -123,7 +132,7 @@
             <option value="es-ES">🇪🇸 Spain (es-ES)</option>
           </select>
           <div id="outputBox" class="w-full bg-slate-900/50 border border-slate-700 rounded-xl p-4 text-slate-300 text-sm leading-relaxed min-h-[160px] font-mono">
-            <span class="text-slate-600 italic">Type something above and pick a target dialect to see adaptations...</span>
+            <span class="text-slate-600 italic">Type Spanish text to explore deterministic rule substitutions...</span>
           </div>
         </div>
       </div>
@@ -263,7 +272,7 @@
       const detectPanel = document.getElementById('detectPanel');
 
       if (!text) {
-        outputBox.innerHTML = '<span class="text-slate-600 italic">Type something above and pick a target dialect to see adaptations...</span>';
+        outputBox.innerHTML = '<span class="text-slate-600 italic">Type Spanish text to explore deterministic rule substitutions...</span>';
         changesPanel.classList.add('hidden');
         detectPanel.classList.add('hidden');
         document.getElementById('detectedSource').textContent = '—';
@@ -274,7 +283,7 @@
       const changes = computeChanges(text, target);
 
       if (changes.length === 0) {
-        outputBox.innerHTML = '<span class="text-slate-500">No adaptations needed — text is already compatible with ' + DIALECT_INFO[target] + ' Spanish.</span>';
+        outputBox.innerHTML = '<span class="text-slate-500">No rule-based substitutions fired for ' + DIALECT_INFO[target] + ' Spanish. This does not certify the text; use the CLI/MCP/LLM workflow for semantic translation.</span>';
         changesPanel.classList.add('hidden');
       } else {
         outputBox.innerHTML = renderDiff(adapted, changes);
@@ -288,7 +297,7 @@
       const best = result.dialect ? DIALECT_METADATA.find(d => d.code === result.dialect) : null;
       const detectedLabel = best && result.confidence > 0.2
         ? FLAGS[best.code] + ' ' + best.code + ' · ' + result.registerHint
-        : 'neutral Spanish — no dialect markers';
+        : 'no high-confidence demo marker';
       document.getElementById('detectedSource').textContent = detectedLabel;
 
       if (best) {

--- a/index.html
+++ b/index.html
@@ -221,6 +221,15 @@
             color: #f4f4f5;
         }
 
+        .link {
+            color: #f093fb;
+            font-weight: 600;
+        }
+
+        .link:hover {
+            color: #f5576c;
+        }
+
         footer {
             text-align: center;
             padding: 3rem 0;
@@ -255,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">480+</div>
+                    <div class="stat-value">701</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -267,7 +276,7 @@
                     <div class="stat-label">MCP Tools</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">20</div>
+                    <div class="stat-value">25</div>
                     <div class="stat-label">Dialects</div>
                 </div>
             </div>
@@ -458,21 +467,39 @@
                 <div class="dialect">es-PA (Panamanian)</div>
                 <div class="dialect">es-DO (Dominican)</div>
                 <div class="dialect">es-PR (Puerto Rican)</div>
+                <div class="dialect">es-GQ (Equatoguinean)</div>
+                <div class="dialect">es-US (U.S. Spanish)</div>
+                <div class="dialect">es-PH (Philippine)</div>
+                <div class="dialect">es-BZ (Belizean)</div>
+                <div class="dialect">es-AD (Andorran)</div>
             </div>
+        </section>
+
+        <section>
+            <h2>Static Browser Demo</h2>
+            <p>
+                The GitHub Pages demo is a rule explorer for deterministic vocabulary substitutions,
+                not the certified semantic translation engine. Use the CLI/MCP/LLM workflow for
+                production certification and MQM-aligned launch reports.
+            </p>
+            <p>
+                <a href="docs/index.html" class="link">Open the rule explorer</a> ·
+                <a href="docs/spanish-launch-certification.md" class="link">Read the launch certification offer</a>
+            </p>
         </section>
 
         <section>
             <h2>Development</h2>
             <div class="code-block">
                 <code><span class="command">pnpm install</span><br>
-<span class="command">pnpm -r test</span><br>
-<span class="command">pnpm -r build</span></code>
+<span class="command">pnpm test</span><br>
+<span class="command">pnpm build</span></code>
             </div>
         </section>
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">480+ tests • 7 packages • 16 MCP tools • 20 dialects</p>
+            <p style="margin-top: 0.5rem;">701 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r build",
-    "test": "pnpm -r test",
+    "test": "node --test docs/__tests__/*.test.mjs && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
     "clean": "pnpm -r clean",
     "dialect:eval": "node scripts/dialect-eval.mjs",


### PR DESCRIPTION
## Summary
- relabel the GitHub Pages sample as a static dialect rule explorer, not a full translator
- remove the false "already compatible" no-change claim and replace it with a certification warning
- add a docs contract test and wire it into `pnpm test`
- refresh stale landing-page stats and supported dialect count

## Root cause
The browser page was the static generated `docs/dialectos-engine.js` rule table, but the UI called it a translator and treated zero substitutions as proof the input was compatible with the target dialect. Short inputs outside the rule table therefore looked like broken product behavior.

## Verification
- `node --test docs/__tests__/*.test.mjs`
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- npm pack dry-run guard for all publishable packages
