### PR TITLE
Make the browser demo exercise the real app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.git
+.worktrees
+dist
+coverage
+*.tgz
+.env
+.env.*
+!.env.example
+

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,20 @@
+FROM node:24-bookworm-slim
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json vitest.workspace.ts ./
+COPY packages ./packages
+COPY scripts ./scripts
+COPY docs ./docs
+COPY README.md LICENSE ./
+
+RUN pnpm install --frozen-lockfile && pnpm build
+
+ENV DIALECTOS_DEMO_HOST=0.0.0.0
+ENV DIALECTOS_DEMO_PORT=8080
+EXPOSE 8080
+
+CMD ["node", "scripts/demo-server.mjs"]
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-701%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-707%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -67,6 +67,24 @@ Spanish is not one language — it's **25 regional variants** with different voc
 ---
 
 ## 🚀 Quick Start
+
+### Full-app browser demo
+
+The browser demo is no longer a fake/static rule replacer. It calls a local
+DialectOS backend, and that backend calls the configured provider stack.
+
+```bash
+LLM_API_URL="http://127.0.0.1:1234/v1/chat/completions" \
+LLM_API_FORMAT="openai" \
+LLM_MODEL="your-local-model-name" \
+LLM_ALLOW_LOCAL=1 \
+pnpm demo
+```
+
+Open `http://127.0.0.1:8080`.
+
+For the beginner container walkthrough, see
+[`docs/full-app-demo.md`](docs/full-app-demo.md).
 
 ### 30-second MCP setup
 
@@ -173,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 701 tests passing
+pnpm test        # 707 tests passing
 ```
 
 ---
@@ -215,14 +233,14 @@ pnpm test        # 701 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 293 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 296 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 701 tests across 7 packages plus the static docs contract**
+**Total: 707 tests across 7 packages plus the full-app docs and demo-server contracts**
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  demo:
+    build:
+      context: .
+      dockerfile: Dockerfile.demo
+    environment:
+      DIALECTOS_DEMO_HOST: 0.0.0.0
+      DIALECTOS_DEMO_PORT: 8080
+      LLM_API_URL: http://ollama:11434/v1/chat/completions
+      LLM_API_FORMAT: openai
+      LLM_MODEL: ${DIALECTOS_DEMO_MODEL:-qwen2.5:7b-instruct}
+      LLM_ALLOW_LOCAL: "1"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+
+  ollama-pull:
+    image: ollama/ollama:latest
+    profiles:
+      - setup
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    command: ["pull", "${DIALECTOS_DEMO_MODEL:-qwen2.5:7b-instruct}"]
+    depends_on:
+      - ollama
+
+volumes:
+  ollama-models:

--- a/docs/__tests__/demo-contract.test.mjs
+++ b/docs/__tests__/demo-contract.test.mjs
@@ -5,15 +5,18 @@ import assert from "node:assert/strict";
 const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
 const engine = readFileSync(new URL("../dialectos-engine.js", import.meta.url), "utf8");
 
-test("static docs demo is honestly labeled as a rule explorer", () => {
-  assert.match(html, /Dialect Rule Explorer/);
-  assert.match(html, /not a full AI translation service/i);
-  assert.match(html, /For certified translation/i);
+test("docs demo is wired to the full app backend", () => {
+  assert.match(html, /Full-App Translator/);
+  assert.match(html, /fetch\('\/api\/translate'/);
+  assert.match(html, /browser → local demo backend → provider registry → LLM semantic dialect prompt/);
+  assert.match(html, /Translate with Full App/);
 });
 
-test("static docs demo never claims unchanged text is already compatible", () => {
+test("docs demo never silently falls back to static rule substitutions", () => {
   assert.doesNotMatch(html, /already compatible/);
-  assert.match(html, /No rule-based substitutions fired/);
+  assert.doesNotMatch(html, /applyAdaptations\(text, target\)/);
+  assert.match(html, /No static translation fallback was used/);
+  assert.match(html, /\/api\/status/);
 });
 
 test("static docs engine has common three-word regional terms", () => {

--- a/docs/full-app-demo.md
+++ b/docs/full-app-demo.md
@@ -1,0 +1,129 @@
+# DialectOS full-app demo, explained like you are five
+
+This demo is for testing the real product path from a browser.
+
+## The tiny mental model
+
+Imagine three blocks:
+
+1. **Browser page** — the buttons and text box you click.
+2. **DialectOS backend** — the safe middleman. It receives browser requests and calls DialectOS code.
+3. **Model/provider** — the brain that actually writes the translation.
+
+The browser must **not** call the model directly because that would expose API keys and skip server-side checks.
+
+So the flow is:
+
+```text
+browser -> DialectOS demo backend -> provider registry -> local/cloud model
+```
+
+## When should something go in a container?
+
+Use a container when setup would otherwise be annoying or inconsistent.
+
+Good container uses:
+
+- You need Node, pnpm, build steps, and server startup to work the same way for everyone.
+- You want to deploy the same thing locally, on a VPS, or in staging.
+- You have multiple moving parts and want one command to start them.
+
+Bad container uses:
+
+- Storing secrets inside the image.
+- Baking a huge model file into the app image when a model volume/sidecar is cleaner.
+- Hiding broken setup instead of documenting it.
+
+## Local mode: easiest if you already have LM Studio or another model server
+
+Start your model server first. It needs to expose an OpenAI-compatible chat endpoint.
+
+Then run:
+
+```bash
+LLM_API_URL="http://127.0.0.1:1234/v1/chat/completions" \
+LLM_API_FORMAT="openai" \
+LLM_MODEL="your-local-model-name" \
+LLM_ALLOW_LOCAL=1 \
+pnpm demo
+```
+
+Open:
+
+```text
+http://127.0.0.1:8080
+```
+
+What happens:
+
+- `pnpm demo` builds DialectOS.
+- It starts `scripts/demo-server.mjs`.
+- The page calls `/api/translate`.
+- The server calls the real provider stack with semantic dialect prompts.
+
+## Container mode: app container plus model container
+
+This repo includes:
+
+- `Dockerfile.demo` — builds the DialectOS demo backend image.
+- `docker-compose.yml` — starts the demo backend and an Ollama model service.
+
+Start the model container first:
+
+```bash
+docker compose up -d ollama
+```
+
+Download the model into the persistent Ollama volume:
+
+```bash
+docker compose --profile setup run --rm ollama-pull
+```
+
+Start the full demo:
+
+```bash
+docker compose up --build demo
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8080
+```
+
+What each container does:
+
+- `demo` is the website plus DialectOS backend.
+- `ollama` is the local model server.
+- `ollama-pull` is a one-shot setup helper that downloads the model.
+- `ollama-models` is a persistent volume, so the model does not download again every time.
+
+## VPS mode, like Hostinger
+
+A VPS is useful for staging because other people can open a real URL.
+
+Recommended VPS shape:
+
+```text
+public HTTPS URL
+  -> reverse proxy
+  -> DialectOS demo container
+  -> provider endpoint
+```
+
+The provider endpoint can be:
+
+- an Ollama sidecar if the VPS is strong enough,
+- a remote LM Studio/OpenAI-compatible endpoint,
+- or a cloud model provider.
+
+CPU-only VPS warning: local models can be slow without a GPU. The VPS can still host the web/API layer while the model runs somewhere else.
+
+## Safety rules
+
+- Never put API keys in browser JavaScript.
+- Never commit `.env` files.
+- Never expose a public demo without rate limits/auth if it uses paid providers.
+- If `/api/status` says no provider is configured, fix the model/provider first.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DialectOS — Spanish Dialect Rule Explorer and Certification</title>
-  <meta name="description" content="Explore deterministic Spanish dialect substitutions in the static browser demo, then use the certified CLI/MCP/LLM workflow for semantic translation QA.">
+  <title>DialectOS — Full-App Spanish Dialect Translation Demo</title>
+  <meta name="description" content="Run the full DialectOS translation stack from the browser through a local backend and configured LLM/provider.">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -30,16 +30,15 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        701 tests passing · BSL 1.1 · GitHub Pages
+        707 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
       </h1>
       <p class="text-lg text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-        This page is a <strong class="text-slate-200">static rule explorer</strong>, not a full AI translation service.
-        It shows deterministic substitutions such as <em>coche</em> → <em>carro</em>,
-        <em>vosotros</em> → <em>ustedes</em>, and <em>zumo</em> → <em>jugo</em>.
-        For semantic translation and launch decisions, use the certified CLI/MCP/LLM workflow.
+        This page now drives the <strong class="text-slate-200">full DialectOS app path</strong>:
+        browser → local demo backend → provider registry → LLM semantic dialect prompt.
+        Start it with <code class="text-sky-300">pnpm demo</code> or the Docker Compose demo, then test real translations without exposing model keys in the browser.
       </p>
       <div class="flex flex-wrap justify-center gap-3">
         <a href="https://github.com/Pastorsimon1798/DialectOS" class="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl font-semibold text-sm transition-colors flex items-center gap-2">
@@ -47,7 +46,7 @@
           Star on GitHub
         </a>
         <a href="#translate" class="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 rounded-xl font-semibold text-sm text-white transition-colors">
-          Explore Rules →
+          Run Full Demo →
         </a>
       </div>
     </div>
@@ -58,27 +57,25 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">701</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">707</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>
 
-  <!-- Main Rule Explorer -->
+  <!-- Main Full-App Demo -->
   <section id="translate" class="max-w-5xl mx-auto px-6 mb-14">
     <div class="glass rounded-2xl p-6 md:p-8">
-      <div class="mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
-        <strong class="text-amber-200">Important:</strong>
-        this browser demo only applies known rule-table substitutions from a static JavaScript file.
-        It does not infer meaning, fill missing words, or certify that unchanged text is valid for a dialect.
-        <a href="https://github.com/Pastorsimon1798/DialectOS#readme" class="text-sky-300 hover:text-sky-200 underline">For certified translation</a>,
-        run the CLI/MCP/LLM evaluation and MQM reporting flow instead.
+      <div id="backendStatus" class="mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+        <strong class="text-amber-200">Backend status:</strong>
+        checking <code>/api/status</code>… If you opened this on static GitHub Pages, start the full app locally with
+        <code class="text-sky-300">pnpm demo</code> or use the Docker Compose instructions.
       </div>
 
       <!-- Toolbar -->
       <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-5">
         <div>
-          <h2 class="text-xl font-semibold text-slate-200">Dialect Rule Explorer</h2>
-          <p class="text-sm text-slate-500 mt-0.5">Type Spanish text to inspect deterministic substitutions; this is not semantic translation.</p>
+          <h2 class="text-xl font-semibold text-slate-200">Full-App Translator</h2>
+          <p class="text-sm text-slate-500 mt-0.5">Type text, pick a dialect, then call the backend that uses the real provider stack and semantic dialect prompts.</p>
         </div>
         <div class="flex gap-2 flex-wrap">
           <button onclick="loadPreset('es-mx')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇲🇽 → Mexico</button>
@@ -131,15 +128,18 @@
             <option value="es-AD">🇦🇩 Andorra (es-AD)</option>
             <option value="es-ES">🇪🇸 Spain (es-ES)</option>
           </select>
+          <button id="translateButton" onclick="translate()" class="w-full mb-3 px-4 py-3 bg-sky-600 hover:bg-sky-500 rounded-xl font-semibold text-sm text-white transition-colors">
+            Translate with Full App
+          </button>
           <div id="outputBox" class="w-full bg-slate-900/50 border border-slate-700 rounded-xl p-4 text-slate-300 text-sm leading-relaxed min-h-[160px] font-mono">
-            <span class="text-slate-600 italic">Type Spanish text to explore deterministic rule substitutions...</span>
+            <span class="text-slate-600 italic">Start the full app demo backend, type text, then click Translate with Full App...</span>
           </div>
         </div>
       </div>
 
       <!-- Changes panel -->
       <div id="changesPanel" class="mt-5 hidden">
-        <div class="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Substitutions Applied</div>
+        <div class="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Full-App Execution</div>
         <div id="changesList" class="flex flex-wrap gap-2"></div>
       </div>
 
@@ -229,75 +229,14 @@
       return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     }
 
-    function computeChanges(text, dialect) {
-      const adaptations = DIALECT_ADAPTATIONS[dialect] || [];
-      const changes = [];
-      const seen = new Set();
-      for (const rule of adaptations) {
-        const matches = text.match(rule.from);
-        if (matches) {
-          for (const m of matches) {
-            const adapted = m.replace(rule.from, rule.to);
-            if (adapted !== m && !seen.has(m.toLowerCase())) {
-              seen.add(m.toLowerCase());
-              changes.push({ original: m, replacement: adapted, label: rule.description });
-            }
-          }
-        }
-      }
-      return changes;
-    }
+    let translateRequestId = 0;
 
-    function renderDiff(adapted, changes) {
-      if (changes.length === 0) return escapeHtml(adapted);
-      let html = escapeHtml(adapted);
-      const seen = new Set();
-      for (const c of changes) {
-        const r = c.replacement;
-        if (seen.has(r.toLowerCase())) continue;
-        seen.add(r.toLowerCase());
-        const escaped = escapeHtml(r);
-        const re = new RegExp('\\b' + escaped.replace(/[.*+?^${}()|[\]\\\\]/g, '\\$&') + '\\b', 'gi');
-        html = html.replace(re, '<span class="change">$&</span>');
-      }
-      return html;
-    }
-
-    function translate() {
-      const text = document.getElementById('sourceText').value.trim();
-      const target = document.getElementById('targetDialect').value;
-      const outputBox = document.getElementById('outputBox');
-      const changesPanel = document.getElementById('changesPanel');
-      const changesList = document.getElementById('changesList');
+    function renderDetection(result) {
       const detectPanel = document.getElementById('detectPanel');
-
-      if (!text) {
-        outputBox.innerHTML = '<span class="text-slate-600 italic">Type Spanish text to explore deterministic rule substitutions...</span>';
-        changesPanel.classList.add('hidden');
-        detectPanel.classList.add('hidden');
-        document.getElementById('detectedSource').textContent = '—';
-        return;
-      }
-
-      const adapted = applyAdaptations(text, target);
-      const changes = computeChanges(text, target);
-
-      if (changes.length === 0) {
-        outputBox.innerHTML = '<span class="text-slate-500">No rule-based substitutions fired for ' + DIALECT_INFO[target] + ' Spanish. This does not certify the text; use the CLI/MCP/LLM workflow for semantic translation.</span>';
-        changesPanel.classList.add('hidden');
-      } else {
-        outputBox.innerHTML = renderDiff(adapted, changes);
-        changesPanel.classList.remove('hidden');
-        changesList.innerHTML = changes.map(c =>
-          '<span class="px-2.5 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 text-xs font-medium border border-emerald-500/20">' + escapeHtml(c.original) + ' → ' + escapeHtml(c.replacement) + '</span>'
-        ).join('');
-      }
-
-      const result = detectDialect(text);
-      const best = result.dialect ? DIALECT_METADATA.find(d => d.code === result.dialect) : null;
+      const best = result && result.dialect ? DIALECT_METADATA.find(d => d.code === result.dialect) : null;
       const detectedLabel = best && result.confidence > 0.2
         ? FLAGS[best.code] + ' ' + best.code + ' · ' + result.registerHint
-        : 'no high-confidence demo marker';
+        : 'no high-confidence marker';
       document.getElementById('detectedSource').textContent = detectedLabel;
 
       if (best) {
@@ -317,6 +256,74 @@
       }
     }
 
+    async function refreshBackendStatus() {
+      const statusBox = document.getElementById('backendStatus');
+      try {
+        const response = await fetch('/api/status', { headers: { accept: 'application/json' } });
+        if (!response.ok) throw new Error('status endpoint returned ' + response.status);
+        const status = await response.json();
+        const color = status.configured ? 'emerald' : 'amber';
+        statusBox.className = 'mb-5 rounded-xl border border-' + color + '-400/30 bg-' + color + '-500/10 p-4 text-sm text-' + color + '-100';
+        statusBox.innerHTML = '<strong class="text-' + color + '-200">Backend status:</strong> ' +
+          escapeHtml(status.message || 'connected') +
+          ' <span class="text-slate-400">Providers: ' + escapeHtml((status.providers || []).join(', ') || 'none') + '</span>';
+      } catch (error) {
+        statusBox.className = 'mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100';
+        statusBox.innerHTML = '<strong class="text-amber-200">Backend status:</strong> full-app backend is not reachable. Run <code class="text-sky-300">pnpm demo</code> and open the local URL. Static GitHub Pages cannot call your local model.';
+      }
+    }
+
+    async function translate() {
+      const requestId = ++translateRequestId;
+      const text = document.getElementById('sourceText').value.trim();
+      const target = document.getElementById('targetDialect').value;
+      const outputBox = document.getElementById('outputBox');
+      const changesPanel = document.getElementById('changesPanel');
+      const changesList = document.getElementById('changesList');
+      const detectPanel = document.getElementById('detectPanel');
+
+      if (!text) {
+        outputBox.innerHTML = '<span class="text-slate-600 italic">Start the full app demo backend, type text, then click Translate with Full App...</span>';
+        changesPanel.classList.add('hidden');
+        detectPanel.classList.add('hidden');
+        document.getElementById('detectedSource').textContent = '—';
+        return;
+      }
+
+      outputBox.innerHTML = '<span class="text-sky-300">Calling /api/translate through the full DialectOS backend…</span>';
+      changesPanel.classList.add('hidden');
+
+      try {
+        const response = await fetch('/api/translate', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          body: JSON.stringify({ text, dialect: target, provider: 'auto', formality: 'auto' }),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (requestId !== translateRequestId) return;
+        if (!response.ok || result.ok === false) {
+          throw new Error(result.error || ('backend returned ' + response.status));
+        }
+
+        outputBox.innerHTML = escapeHtml(result.translatedText || '');
+        changesPanel.classList.remove('hidden');
+        changesList.innerHTML = [
+          '<span class="px-2.5 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 text-xs font-medium border border-emerald-500/20">provider: ' + escapeHtml(result.providerUsed || 'unknown') + '</span>',
+          '<span class="px-2.5 py-1 rounded-lg bg-sky-500/10 text-sky-300 text-xs font-medium border border-sky-500/20">target: ' + escapeHtml(target) + '</span>',
+          '<span class="px-2.5 py-1 rounded-lg bg-violet-500/10 text-violet-300 text-xs font-medium border border-violet-500/20">fallbacks: ' + escapeHtml(String(result.fallbackCount || 0)) + '</span>',
+        ].join('');
+        renderDetection(result.sourceDetection);
+        refreshBackendStatus();
+      } catch (error) {
+        if (requestId !== translateRequestId) return;
+        outputBox.innerHTML = '<span class="text-amber-300">Full-app backend error:</span> ' +
+          escapeHtml(error.message || String(error)) +
+          '<br><br><span class="text-slate-500">Start a provider-backed backend with <code>pnpm demo</code>. No static translation fallback was used.</span>';
+        changesPanel.classList.add('hidden');
+        detectPanel.classList.add('hidden');
+      }
+    }
+
     const PRESETS = {
       'es-mx': { text: 'Vosotros lleváis el ordenador en el coche para ir al piso y comer patatas.', target: 'es-MX' },
       'es-ar': { text: 'Vosotros lleváis gafas y escribís con bolígrafo en el piso. Después compráis fresas y cacahuetes.', target: 'es-AR' },
@@ -328,7 +335,6 @@
       const p = PRESETS[key];
       document.getElementById('sourceText').value = p.text;
       document.getElementById('targetDialect').value = p.target;
-      translate();
     }
 
     function renderGrid() {
@@ -337,15 +343,14 @@
         const div = document.createElement('div');
         div.className = 'glass rounded-xl p-3 text-center dialect-card';
         div.innerHTML = '<div class="text-2xl mb-1">' + FLAGS[code] + '</div><div class="text-sm font-medium text-slate-300">' + code + '</div><div class="text-xs text-slate-500">' + name + '</div>';
-        div.onclick = () => { document.getElementById('targetDialect').value = code; translate(); };
+        div.onclick = () => { document.getElementById('targetDialect').value = code; };
         grid.appendChild(div);
       }
     }
 
-    document.getElementById('sourceText').addEventListener('input', translate);
-    document.getElementById('targetDialect').addEventListener('change', translate);
     renderGrid();
     loadPreset('es-mx');
+    refreshBackendStatus();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">701</div>
+                    <div class="stat-value">707</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -476,14 +476,15 @@
         </section>
 
         <section>
-            <h2>Static Browser Demo</h2>
+            <h2>Full-App Browser Demo</h2>
             <p>
-                The GitHub Pages demo is a rule explorer for deterministic vocabulary substitutions,
-                not the certified semantic translation engine. Use the CLI/MCP/LLM workflow for
-                production certification and MQM-aligned launch reports.
+                The browser demo now calls the real DialectOS backend API instead of doing static
+                substitutions in the page. Run <code>pnpm demo</code> locally or use Docker Compose
+                to connect the page to a configured LLM/provider.
             </p>
             <p>
-                <a href="docs/index.html" class="link">Open the rule explorer</a> ·
+                <a href="docs/index.html" class="link">Open the full-app demo</a> ·
+                <a href="docs/full-app-demo.md" class="link">Container walkthrough</a> ·
                 <a href="docs/spanish-launch-certification.md" class="link">Read the launch certification offer</a>
             </p>
         </section>
@@ -493,13 +494,14 @@
             <div class="code-block">
                 <code><span class="command">pnpm install</span><br>
 <span class="command">pnpm test</span><br>
-<span class="command">pnpm build</span></code>
+<span class="command">pnpm build</span><br>
+<span class="command">pnpm demo</span></code>
             </div>
         </section>
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">701 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">707 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r build",
-    "test": "node --test docs/__tests__/*.test.mjs && pnpm -r test",
+    "test": "node --test docs/__tests__/*.test.mjs scripts/__tests__/*.test.mjs && pnpm -r test",
+    "demo": "pnpm build && node scripts/demo-server.mjs",
     "test:coverage": "pnpm -r test:coverage",
     "clean": "pnpm -r clean",
     "dialect:eval": "node scripts/dialect-eval.mjs",

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -58,7 +58,7 @@ describe("dialect eval script", () => {
     })).toThrow(/No live providers are configured/);
 
     rmSync(outDir, { recursive: true, force: true });
-  });
+  }, 10000);
 
 
   it("certify writes incremental progress, events, and a summary", () => {

--- a/packages/cli/src/__tests__/web-demo-service.test.ts
+++ b/packages/cli/src/__tests__/web-demo-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { ProviderRegistry } from "@espanol/providers";
+import type { TranslationProvider } from "@espanol/types";
+import {
+  getWebDemoProviderStatus,
+  translateForWebDemo,
+  validateWebDemoDialect,
+} from "../lib/web-demo-service.js";
+
+function makeProvider(name = "llm"): TranslationProvider {
+  return {
+    name,
+    translate: vi.fn(async (text: string, sourceLang: string, targetLang: string, options) => ({
+      translatedText: `[${options?.dialect}] ${text}`,
+      sourceLang,
+      targetLang,
+      provider: name as never,
+    })),
+    getCapabilities: () => ({
+      name,
+      displayName: "Mock semantic LLM",
+      needsApiKey: false,
+      supportsFormality: true,
+      supportsContext: true,
+      supportsDialect: true,
+      supportedSourceLangs: ["auto", "en", "es"],
+      supportedTargetLangs: ["es"],
+      maxPayloadChars: 100000,
+      dialectHandling: "semantic",
+    }),
+  };
+}
+
+describe("web demo service", () => {
+  it("runs through the provider stack with semantic dialect context", async () => {
+    const registry = new ProviderRegistry();
+    const provider = makeProvider();
+    registry.register(provider);
+
+    const result = await translateForWebDemo({
+      text: "Pick up the file before you park the car.",
+      dialect: "es-MX",
+      provider: "auto",
+    }, registry);
+
+    expect(result.translatedText).toBe("[es-MX] Pick up the file before you park the car.");
+    expect(result.providerUsed).toBe("llm");
+    expect(result.providerStatus.semanticProviders).toEqual(["llm"]);
+    expect(result.semanticContext).toContain("Target dialect: Mexican Spanish");
+    expect(result.semanticContext).toContain("do not translate literally word-by-word");
+    expect(provider.translate).toHaveBeenCalledWith(
+      "Pick up the file before you park the car.",
+      "auto",
+      "es",
+      expect.objectContaining({
+        dialect: "es-MX",
+        context: expect.stringContaining("Dialect quality contract"),
+      })
+    );
+  });
+
+  it("reports missing providers instead of falling back to static rule substitutions", async () => {
+    const registry = new ProviderRegistry();
+
+    await expect(translateForWebDemo({
+      text: "hola",
+      dialect: "es-PR",
+    }, registry)).rejects.toThrow(/No provider configured/);
+  });
+
+  it("validates dialects before touching a provider", () => {
+    expect(() => validateWebDemoDialect("es-XX")).toThrow(/Invalid dialect/);
+    expect(getWebDemoProviderStatus(new ProviderRegistry()).configured).toBe(false);
+  });
+});
+

--- a/packages/cli/src/lib/web-demo-service.ts
+++ b/packages/cli/src/lib/web-demo-service.ts
@@ -1,0 +1,120 @@
+import type { ProviderRegistry } from "@espanol/providers";
+import type { FormalityLevel, SpanishDialect } from "@espanol/types";
+import { ALL_SPANISH_DIALECTS } from "@espanol/types";
+import { validateContentLength } from "@espanol/security";
+import { detectDialect } from "./dialect-info.js";
+import { createProviderRegistry } from "./provider-factory.js";
+import { translateWithFallback } from "./resilient-translation.js";
+import { buildSemanticTranslationContext } from "./semantic-context.js";
+
+export interface WebDemoTranslateRequest {
+  text: string;
+  dialect: SpanishDialect;
+  provider?: string;
+  formality?: FormalityLevel;
+}
+
+export interface WebDemoProviderStatus {
+  configured: boolean;
+  providers: string[];
+  semanticProviders: string[];
+  message: string;
+}
+
+export interface WebDemoTranslateResult {
+  translatedText: string;
+  dialect: SpanishDialect;
+  providerUsed: string;
+  fallbackCount: number;
+  retryCount: number;
+  sourceDetection: ReturnType<typeof detectDialect>;
+  semanticContext: string;
+  providerStatus: WebDemoProviderStatus;
+}
+
+const VALID_PROVIDERS = new Set(["auto", "llm", "deepl", "libre", "mymemory"]);
+
+export function validateWebDemoDialect(dialect: string): SpanishDialect {
+  if (!ALL_SPANISH_DIALECTS.includes(dialect as SpanishDialect)) {
+    throw new Error(`Invalid dialect: ${dialect}`);
+  }
+  return dialect as SpanishDialect;
+}
+
+function validateWebDemoProvider(provider: string | undefined): string | undefined {
+  if (!provider || provider === "auto") return undefined;
+  if (!VALID_PROVIDERS.has(provider)) {
+    throw new Error(`Invalid provider: ${provider}`);
+  }
+  return provider;
+}
+
+export function getWebDemoProviderStatus(
+  registry: ProviderRegistry = createProviderRegistry()
+): WebDemoProviderStatus {
+  const providers = registry.listProviders();
+  const semanticProviders = providers.filter((name) =>
+    registry.getCapabilities(name)?.dialectHandling === "semantic"
+  );
+
+  return {
+    configured: providers.length > 0,
+    providers,
+    semanticProviders,
+    message: providers.length > 0
+      ? `Configured providers: ${providers.join(", ")}`
+      : "No provider configured. Start a local OpenAI-compatible model or set LLM_API_URL + LLM_MODEL.",
+  };
+}
+
+export async function translateForWebDemo(
+  request: WebDemoTranslateRequest,
+  registry: ProviderRegistry = createProviderRegistry()
+): Promise<WebDemoTranslateResult> {
+  const text = request.text.trim();
+  if (!text) {
+    throw new Error("No input text provided");
+  }
+  validateContentLength(text);
+
+  const dialect = validateWebDemoDialect(request.dialect);
+  const provider = validateWebDemoProvider(request.provider);
+  const formality = request.formality ?? "auto";
+  const providerStatus = getWebDemoProviderStatus(registry);
+  if (!providerStatus.configured) {
+    throw new Error(providerStatus.message);
+  }
+
+  const semanticContext = buildSemanticTranslationContext({
+    text,
+    dialect,
+    formality,
+    documentKind: "plain",
+  });
+
+  const translated = await translateWithFallback(
+    registry,
+    provider,
+    text,
+    "auto",
+    "es",
+    {
+      dialect,
+      formality,
+      context: semanticContext,
+    },
+    { delayMs: 0 }
+  );
+
+  return {
+    translatedText: translated.translatedText,
+    dialect,
+    providerUsed: translated.providerUsed,
+    fallbackCount: translated.fallbackCount,
+    retryCount: translated.retryCount,
+    sourceDetection: detectDialect(text),
+    semanticContext,
+    providerStatus,
+  };
+}
+

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -1,0 +1,134 @@
+import { once } from "node:events";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createDemoServer } from "../demo-server.mjs";
+
+async function startTestServer(services) {
+  const server = createDemoServer({ services });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+test("demo server translates through injected full-app service", async () => {
+  const calls = [];
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Configured providers: llm",
+    }),
+    translate: async (request) => {
+      calls.push(request);
+      return {
+        translatedText: "Recoge el archivo antes de estacionar el carro.",
+        dialect: request.dialect,
+        providerUsed: "llm",
+        fallbackCount: 0,
+        retryCount: 0,
+        sourceDetection: {
+          dialect: "es-ES",
+          confidence: 0.1,
+          name: "Peninsular Spanish",
+          matchedKeywords: [],
+          registerHint: "neutral",
+        },
+        semanticContext: "Translate by preserving meaning",
+        providerStatus: {
+          configured: true,
+          providers: ["llm"],
+          semanticProviders: ["llm"],
+          message: "Configured providers: llm",
+        },
+      };
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: "Pick up the file before you park the car.",
+        dialect: "es-MX",
+        provider: "auto",
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.translatedText, "Recoge el archivo antes de estacionar el carro.");
+    assert.equal(body.providerUsed, "llm");
+    assert.deepEqual(calls, [{
+      text: "Pick up the file before you park the car.",
+      dialect: "es-MX",
+      provider: "auto",
+      formality: "auto",
+    }]);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server returns provider errors instead of static fallback output", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: false,
+      providers: [],
+      semanticProviders: [],
+      message: "No provider configured",
+    }),
+    translate: async () => {
+      throw new Error("No provider configured. Start a local model.");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "hola", dialect: "es-PR" }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 503);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /No provider configured/);
+    assert.notEqual(body.translatedText, "hola");
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server exposes provider status for the browser UI", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Configured providers: llm",
+    }),
+    translate: async () => {
+      throw new Error("not used");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/status`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.configured, true);
+    assert.deepEqual(body.providers, ["llm"]);
+  } finally {
+    server.close();
+  }
+});
+

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.resolve(__dirname, "..");
+const MAX_JSON_BYTES = 128 * 1024;
+
+const CONTENT_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".svg": "image/svg+xml",
+};
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload, null, 2);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  res.end(body);
+}
+
+function safeError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function readJson(req) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX_JSON_BYTES) {
+      throw new Error("Request body too large");
+    }
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function staticPathFor(urlPath, rootDir) {
+  const pathname = decodeURIComponent(urlPath.split("?")[0] || "/");
+  const relative = pathname === "/"
+    ? "docs/index.html"
+    : pathname.replace(/^\/+/, "");
+  const absolute = path.resolve(rootDir, relative);
+  if (!absolute.startsWith(rootDir + path.sep) && absolute !== rootDir) {
+    return undefined;
+  }
+  return absolute;
+}
+
+async function serveStatic(req, res, rootDir) {
+  const absolute = staticPathFor(req.url || "/", rootDir);
+  if (!absolute) {
+    sendJson(res, 403, { error: "Forbidden" });
+    return;
+  }
+
+  try {
+    const info = await stat(absolute);
+    if (!info.isFile()) {
+      sendJson(res, 404, { error: "Not found" });
+      return;
+    }
+    const ext = path.extname(absolute);
+    res.writeHead(200, {
+      "content-type": CONTENT_TYPES[ext] || "application/octet-stream",
+      "cache-control": "no-store",
+    });
+    createReadStream(absolute).pipe(res);
+  } catch {
+    sendJson(res, 404, { error: "Not found" });
+  }
+}
+
+async function loadDefaultServices(rootDir) {
+  const serviceUrl = pathToFileURL(path.join(rootDir, "packages/cli/dist/lib/web-demo-service.js")).href;
+  const service = await import(serviceUrl);
+  return {
+    status: () => service.getWebDemoProviderStatus(),
+    translate: (request) => service.translateForWebDemo(request),
+  };
+}
+
+export function createDemoServer(options = {}) {
+  const rootDir = path.resolve(options.rootDir || DEFAULT_ROOT);
+  const servicesPromise = options.services
+    ? Promise.resolve(options.services)
+    : loadDefaultServices(rootDir);
+
+  return createServer(async (req, res) => {
+    try {
+      const method = req.method || "GET";
+      const url = new URL(req.url || "/", "http://127.0.0.1");
+
+      if (method === "GET" && url.pathname === "/api/status") {
+        const services = await servicesPromise;
+        sendJson(res, 200, { ok: true, ...(await services.status()) });
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/api/translate") {
+        const services = await servicesPromise;
+        const body = await readJson(req);
+        try {
+          const result = await services.translate({
+            text: String(body.text || ""),
+            dialect: String(body.dialect || "es-MX"),
+            provider: body.provider ? String(body.provider) : "auto",
+            formality: body.formality ? String(body.formality) : "auto",
+          });
+          sendJson(res, 200, { ok: true, ...result });
+        } catch (error) {
+          const message = safeError(error);
+          const status = /No provider configured|No translation providers|Provider not available/i.test(message)
+            ? 503
+            : /Invalid|No input|too large/i.test(message)
+              ? 400
+              : 500;
+          sendJson(res, status, { ok: false, error: message });
+        }
+        return;
+      }
+
+      if (url.pathname.startsWith("/api/")) {
+        sendJson(res, 404, { ok: false, error: "Unknown API route" });
+        return;
+      }
+
+      if (method !== "GET" && method !== "HEAD") {
+        sendJson(res, 405, { error: "Method not allowed" });
+        return;
+      }
+
+      await serveStatic(req, res, rootDir);
+    } catch (error) {
+      sendJson(res, 500, { ok: false, error: safeError(error) });
+    }
+  });
+}
+
+export async function startDemoServer(options = {}) {
+  const port = Number(options.port || process.env.DIALECTOS_DEMO_PORT || 8080);
+  const host = String(options.host || process.env.DIALECTOS_DEMO_HOST || "127.0.0.1");
+  const server = createDemoServer(options);
+  await new Promise((resolve) => server.listen(port, host, resolve));
+  // eslint-disable-next-line no-console
+  console.log(`DialectOS full-app demo: http://${host}:${port}`);
+  // eslint-disable-next-line no-console
+  console.log("The browser calls /api/translate, which calls the configured DialectOS provider stack.");
+  return server;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startDemoServer().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- replaces the browser demo's static substitution path with calls to `/api/translate`
- adds a local demo backend that serves the page and calls the real DialectOS provider stack
- adds a reusable CLI web-demo service with semantic dialect context and provider status
- adds Dockerfile/Compose support with an Ollama sidecar and beginner docs for local-model/container testing
- adds regression tests proving the page does not silently fall back to static rule substitution

## Why
The landing page must be a real test surface. A static rule table cannot prove translation quality, provider behavior, or semantic dialect prompts. This makes the page exercise the full app path while keeping provider keys/server-side model endpoints out of browser JavaScript.

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- `git diff --check`
- `node scripts/demo-server.mjs` smoke: `/api/status` returns provider status and `/api/translate` returns 503 when no provider is configured
- `docker compose --profile setup config`
- `docker compose build demo`
- npm pack dry-run guard for all publishable packages
