### PR TITLE
Deepen lexical ambiguity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-707%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-711%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 707 tests passing
+pnpm test        # 711 tests passing
 ```
 
 ---
@@ -233,14 +233,14 @@ pnpm test        # 707 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 296 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 300 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 707 tests across 7 packages plus the full-app docs and demo-server contracts**
+**Total: 711 tests across 7 packages plus the full-app docs and demo-server contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        707 tests passing · BSL 1.1 · Full-app demo
+        711 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">707</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">711</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">707</div>
+                    <div class="stat-value">711</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">707 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">711 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/packages/cli/src/__tests__/adversarial-dialect-fixtures.test.ts
+++ b/packages/cli/src/__tests__/adversarial-dialect-fixtures.test.ts
@@ -16,6 +16,7 @@ interface AdversarialDialectSample {
   forbiddenContext: string[];
   forbiddenOutputTerms: string[];
   requiredOutputAny?: string[];
+  requiredOutputGroups?: string[][];
   preferredOutputAny?: string[];
   notes: string;
 }
@@ -68,7 +69,7 @@ describe("adversarial dialect fixtures", () => {
         expect(sample.source.length).toBeGreaterThan(5);
         expect(sample.requiredContext.length).toBeGreaterThan(0);
         expect(sample.forbiddenOutputTerms.length).toBeGreaterThan(0);
-        expect(sample.requiredOutputAny || sample.preferredOutputAny).toBeDefined();
+        expect(sample.requiredOutputAny || sample.requiredOutputGroups || sample.preferredOutputAny).toBeDefined();
         expect(sample.notes.length).toBeGreaterThan(10);
       }
     });

--- a/packages/cli/src/__tests__/dialect-eval.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval.test.ts
@@ -14,6 +14,7 @@ interface DialectEvalSample {
   forbiddenContext: string[];
   forbiddenOutputTerms: string[];
   requiredOutputAny?: string[];
+  requiredOutputGroups?: string[][];
   preferredOutputAny?: string[];
   notes: string;
 }
@@ -53,7 +54,7 @@ describe("dialect evaluation harness", () => {
           expect(context, `${sample.id} should not contain ${forbidden}`).not.toContain(forbidden);
         }
         expect(sample.forbiddenOutputTerms.length).toBeGreaterThan(0);
-        expect(sample.requiredOutputAny || sample.preferredOutputAny).toBeDefined();
+        expect(sample.requiredOutputAny || sample.requiredOutputGroups || sample.preferredOutputAny).toBeDefined();
         expect(sample.notes.length).toBeGreaterThan(10);
       }
     });

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
@@ -12,10 +12,15 @@
     "register": "auto",
     "documentKind": "plain",
     "requiredContext": [
-      "Mexican Spanish"
+      "Mexican Spanish",
+      "Lexical ambiguity constraints",
+      "tomar/toma"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [
+      "agarra",
+      "agarrar",
+      "coge",
       "coger",
       "vos",
       "vosotros"
@@ -38,7 +43,20 @@
       "buseta",
       "ómnibus"
     ],
-    "notes": "Transit paraphrase should preserve the dialect-specific public transport term without copying unrelated slang."
+    "notes": "Mexican transit take/catch must use tomar/abordar plus a Mexican-intelligible bus term; do not use coger/agarrar.",
+    "requiredOutputGroups": [
+      [
+        "bus",
+        "autobús",
+        "camión"
+      ],
+      [
+        "toma",
+        "tomar",
+        "aborda",
+        "abordar"
+      ]
+    ]
   },
   {
     "id": "mx-placeholder-url",
@@ -115,11 +133,16 @@
     "register": "auto",
     "documentKind": "plain",
     "requiredContext": [
-      "Mexican Spanish"
+      "Mexican Spanish",
+      "Lexical ambiguity constraints",
+      "Do not use coger"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [
+      "bajar",
       "coger",
+      "descarga",
+      "descargar",
       "vos",
       "vosotros"
     ],
@@ -133,7 +156,18 @@
       "recoge",
       "recoger"
     ],
-    "notes": "Mexican technical pickup should avoid coger and preserve pickup intent."
+    "notes": "Mexican file pickup must preserve retrieval intent: archivo plus recoger/recuperar; it must not become download or coger.",
+    "requiredOutputGroups": [
+      [
+        "archivo"
+      ],
+      [
+        "recoge",
+        "recoger",
+        "recupera",
+        "recuperar"
+      ]
+    ]
   },
   {
     "id": "mx-pickup-package",
@@ -148,11 +182,15 @@
     "register": "auto",
     "documentKind": "plain",
     "requiredContext": [
-      "Mexican Spanish"
+      "Mexican Spanish",
+      "Lexical ambiguity constraints",
+      "Do not use coger"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [
       "coger",
+      "descarga",
+      "descargar",
       "vos",
       "vosotros"
     ],
@@ -168,6 +206,20 @@
       "paquete",
       "recepción"
     ],
-    "notes": "Pick up package should preserve pickup/package intent and not become download."
+    "notes": "Physical pickup of a package requires item + place + pickup verb; not download and not coger.",
+    "requiredOutputGroups": [
+      [
+        "paquete"
+      ],
+      [
+        "recepción"
+      ],
+      [
+        "recoge",
+        "recoger",
+        "retira",
+        "retirar"
+      ]
+    ]
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
@@ -9,15 +9,20 @@
       "Mexican Spanish",
       "Avoid literal coger",
       "prefer-neutral-alternative",
-      "Localize grammar"
+      "Localize grammar",
+      "Lexical ambiguity constraints",
+      "Do not use coger"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [
+      "bajar",
       "coger",
+      "descarga",
+      "descargar",
       "vos",
       "vosotros"
     ],
-    "notes": "Mexico should avoid literal coger for pick up/take.",
+    "notes": "Mexican file pickup must preserve retrieval intent: archivo plus recoger/recuperar; it must not become download or coger.",
     "requiredOutputAny": [
       "recoge",
       "recoger",
@@ -27,6 +32,17 @@
     "preferredOutputAny": [
       "recoge",
       "recoger"
+    ],
+    "requiredOutputGroups": [
+      [
+        "archivo"
+      ],
+      [
+        "recoge",
+        "recoger",
+        "recupera",
+        "recuperar"
+      ]
     ]
   }
 ]

--- a/packages/cli/src/__tests__/lexical-ambiguity.test.ts
+++ b/packages/cli/src/__tests__/lexical-ambiguity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildLexicalAmbiguityGuidance } from "../lib/lexical-ambiguity.js";
+import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
+
+describe("lexical ambiguity constraints", () => {
+  it("distinguishes file pickup from download/coger in Mexican Spanish", () => {
+    const guidance = buildLexicalAmbiguityGuidance(
+      "Pick up the file before deployment.",
+      "es-MX"
+    );
+
+    expect(guidance).toContain("[pickup-file]");
+    expect(guidance).toContain("recoger/recoge/recuperar");
+    expect(guidance).toContain("Do not use coger");
+    expect(guidance).toContain("Do not change the action to descargar/download");
+  });
+
+  it("maps transport take/catch to tomar or abordar rather than coger", () => {
+    const guidance = buildLexicalAmbiguityGuidance(
+      "Take the bus to the office.",
+      "es-MX"
+    );
+
+    expect(guidance).toContain("[take-bus]");
+    expect(guidance).toContain("tomar/toma");
+    expect(guidance).toContain("abordar/aborda");
+    expect(guidance).toContain("guagua");
+  });
+
+  it("keeps Spain allowed to use coger while still disambiguating non-coger senses", () => {
+    const spain = buildSemanticTranslationContext({
+      text: "Take the bus and pick up the package.",
+      dialect: "es-ES",
+      documentKind: "plain",
+    });
+
+    expect(spain).toContain("coger is neutral in Spain");
+    expect(spain).toContain("[take-bus]");
+    expect(spain).not.toContain("[pickup-package]");
+  });
+
+  it("separates photo, medicine, and physical grab senses", () => {
+    expect(buildLexicalAmbiguityGuidance("Take a screenshot.", "es-MX")).toContain("[take-photo]");
+    expect(buildLexicalAmbiguityGuidance("Take the medicine after lunch.", "es-MX")).toContain("[take-medicine]");
+    expect(buildLexicalAmbiguityGuidance("Grab your backpack before leaving.", "es-MX")).toContain("[grab-bag]");
+  });
+});
+

--- a/packages/cli/src/lib/lexical-ambiguity.ts
+++ b/packages/cli/src/lib/lexical-ambiguity.ts
@@ -1,0 +1,75 @@
+import type { SpanishDialect } from "@espanol/types";
+
+export interface LexicalAmbiguityRule {
+  id: string;
+  dialects: readonly SpanishDialect[] | "all";
+  sourcePattern: RegExp;
+  guidance: string;
+}
+
+const TABOO_RISK_COGER_DIALECTS: readonly SpanishDialect[] = [
+  "es-MX", "es-AR", "es-CL", "es-CO", "es-VE",
+  "es-US", "es-PA", "es-PR", "es-DO", "es-CU",
+  "es-PE", "es-EC", "es-BO", "es-PY", "es-UY",
+  "es-GT", "es-HN", "es-SV", "es-NI", "es-CR",
+  "es-BZ",
+];
+
+export const LEXICAL_AMBIGUITY_RULES: readonly LexicalAmbiguityRule[] = [
+  {
+    id: "pickup-file",
+    dialects: TABOO_RISK_COGER_DIALECTS,
+    sourcePattern: /\b(pick up|grab|get|take)\b.{0,40}\b(file|files|document|documents|attachment|attachments)\b/i,
+    guidance: "For retrieving files/documents, use recoger/recoge/recuperar as appropriate. Do not use coger. Do not change the action to descargar/download unless the source explicitly says download.",
+  },
+  {
+    id: "pickup-package",
+    dialects: TABOO_RISK_COGER_DIALECTS,
+    sourcePattern: /\b(pick up|grab|get|take)\b.{0,40}\b(package|packages|parcel|order|badge|ticket)\b/i,
+    guidance: "For physical pickup of an item, use recoger/recoge or retirar/retira according to register. Agarrar can work in casual physical-grab contexts. Do not use coger in taboo-risk dialects.",
+  },
+  {
+    id: "take-bus",
+    dialects: "all",
+    sourcePattern: /\b(take|catch|ride|get on|board)\b.{0,30}\b(bus|train|metro|subway|taxi|cab|shuttle)\b/i,
+    guidance: "For taking transportation, use tomar/toma or abordar/aborda by register and dialect. Do not use coger outside Spain/Andorra. Preserve dialect-specific vehicle terms such as guagua where the dialect contract requires them.",
+  },
+  {
+    id: "take-photo",
+    dialects: "all",
+    sourcePattern: /\b(take|snap|capture)\b.{0,30}\b(photo|picture|screenshot|screen shot|image)\b/i,
+    guidance: "For taking a photo/screenshot, use tomar or sacar/capturar according to dialect and UI register. Never literalize this as coger.",
+  },
+  {
+    id: "take-medicine",
+    dialects: "all",
+    sourcePattern: /\b(take)\b.{0,30}\b(medicine|medication|pill|dose|tablet)\b/i,
+    guidance: "For taking medicine, use tomar. Do not use coger/agarrar/recoger.",
+  },
+  {
+    id: "grab-bag",
+    dialects: TABOO_RISK_COGER_DIALECTS,
+    sourcePattern: /\b(grab|take)\b.{0,30}\b(bag|keys|phone|laptop|backpack)\b/i,
+    guidance: "For physically grabbing a personal object, use agarrar/tomar depending on register. Do not use coger in taboo-risk dialects.",
+  },
+];
+
+function appliesToDialect(rule: LexicalAmbiguityRule, dialect: SpanishDialect): boolean {
+  return rule.dialects === "all" || rule.dialects.includes(dialect);
+}
+
+export function buildLexicalAmbiguityGuidance(text: string, dialect: SpanishDialect): string | undefined {
+  const matched = LEXICAL_AMBIGUITY_RULES.filter((rule) =>
+    appliesToDialect(rule, dialect) && rule.sourcePattern.test(text)
+  );
+
+  if (matched.length === 0) {
+    return undefined;
+  }
+
+  return [
+    "Lexical ambiguity constraints:",
+    ...matched.map((rule) => `[${rule.id}] ${rule.guidance}`),
+  ].join(" ");
+}
+

--- a/packages/cli/src/lib/semantic-context.ts
+++ b/packages/cli/src/lib/semantic-context.ts
@@ -1,6 +1,7 @@
 import type { SpanishDialect, FormalityLevel } from "@espanol/types";
 import { buildDialectQualityPrompt, getDialectGrammarProfile } from "@espanol/types";
 import { getDialectInfo } from "./dialect-info.js";
+import { buildLexicalAmbiguityGuidance } from "./lexical-ambiguity.js";
 
 export type SemanticDomain =
   | "technical"
@@ -134,6 +135,7 @@ export function buildSemanticTranslationContext(options: BuildSemanticContextOpt
   const grammarProfile = getDialectGrammarProfile(options.dialect);
   const qualityPrompt = buildDialectQualityPrompt(options.dialect);
   const outputConstraintPrompt = buildOutputConstraintPrompt(options.text, options.dialect);
+  const lexicalAmbiguityGuidance = buildLexicalAmbiguityGuidance(options.text, options.dialect);
   const dialectTerms = dialect
     ? [...dialect.formalTerms.slice(0, 4), ...dialect.slangTerms.slice(0, 4)].join(", ")
     : options.dialect;
@@ -157,6 +159,7 @@ export function buildSemanticTranslationContext(options: BuildSemanticContextOpt
     dialectTerms ? `Use regional vocabulary naturally where appropriate; examples/signals: ${dialectTerms}.` : undefined,
     grammarGuidance ? `Dialect grammar and style profile: ${grammarGuidance}` : undefined,
     qualityPrompt ? `Dialect quality contract: ${qualityPrompt}` : undefined,
+    lexicalAmbiguityGuidance,
     outputConstraintPrompt,
     "Preserve product names, code identifiers, URLs, placeholders, markdown structure, and glossary-locked terms.",
     "Prefer idiomatic Spanish for the target audience over one-to-one lexical substitution.",

--- a/scripts/dialect-certify.mjs
+++ b/scripts/dialect-certify.mjs
@@ -136,6 +136,15 @@ async function evaluate(sample, dialect, translate) {
     }
   }
 
+  if (output && sample.requiredOutputGroups?.length) {
+    for (const group of sample.requiredOutputGroups) {
+      const matched = group.some((term) => hasForbiddenTerm(output, term));
+      if (!matched) {
+        failures.push(`Missing required output group; expected one of: ${group.join(", ")}`);
+      }
+    }
+  }
+
   if (output && sample.preferredOutputAny?.length) {
     const matched = sample.preferredOutputAny.some((term) => hasForbiddenTerm(output, term));
     if (!matched) {

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -106,6 +106,15 @@ async function evaluate(sample, dialect, translate) {
     }
   }
 
+  if (output && sample.requiredOutputGroups?.length) {
+    for (const group of sample.requiredOutputGroups) {
+      const matched = group.some((term) => hasForbiddenTerm(output, term));
+      if (!matched) {
+        failures.push(`Missing required output group; expected one of: ${group.join(", ")}`);
+      }
+    }
+  }
+
   if (output && sample.preferredOutputAny?.length) {
     const matched = sample.preferredOutputAny.some((term) => hasForbiddenTerm(output, term));
     if (!matched) {


### PR DESCRIPTION
## Summary
- adds explicit lexical ambiguity rules for coger/tomar/agarrar/recoger-style senses
- injects matched ambiguity constraints into semantic translation prompts
- hardens es-MX fixtures around file pickup, package pickup, and transit take/catch
- adds `requiredOutputGroups` so certification can require multiple semantic traits, not just one token from a loose list
- verifies both qwen3.5-9b and qwen3.6-35b pass the new es-MX live ambiguity fixture set

## Why
The previous dialect profile had prose like "avoid literal coger," but that was too thin: it did not model which verb should be used for file pickup vs transit vs physical grab vs photo/medicine senses, and the fixture evaluator could pass when only one loose token matched. This change turns that dialect depth into executable constraints.

## Verification
- `pnpm --filter @espanol/cli exec vitest run src/__tests__/lexical-ambiguity.test.ts src/__tests__/semantic-context.test.ts src/__tests__/dialect-eval.test.ts src/__tests__/adversarial-dialect-fixtures.test.ts`
- `pnpm dialect:eval -- --dialects=es-MX --out=/tmp/dialectos-mx-ambiguity-eval`
- qwen3.5-9b live: `LLM_API_URL=http://127.0.0.1:1234/v1/chat/completions LLM_API_FORMAT=openai LLM_MODEL=qwen3.5-9b LLM_ALLOW_LOCAL=1 LLM_TIMEOUT_MS=180000 pnpm dialect:eval -- --live --provider=llm --fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial --dialects=es-MX --out=/tmp/dialectos-mx-ambiguity-live-qwen35`
- qwen3.6-35b live: `LLM_API_URL=http://127.0.0.1:1234/v1/chat/completions LLM_API_FORMAT=openai LLM_MODEL=qwen3.6-35b-a3b LLM_ALLOW_LOCAL=1 LLM_TIMEOUT_MS=240000 pnpm dialect:eval -- --live --provider=llm --fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial --dialects=es-MX --out=/tmp/dialectos-mx-ambiguity-live-qwen36`
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- `git diff --check`
- npm pack dry-run guard for all publishable packages
