### PR TITLE
Generalize semantic ambiguity gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-711%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-713%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 711 tests passing
+pnpm test        # 713 tests passing
 ```
 
 ---
@@ -233,14 +233,14 @@ pnpm test        # 711 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 300 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 302 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 711 tests across 7 packages plus the full-app docs and demo-server contracts**
+**Total: 713 tests across 7 packages plus the full-app docs and demo-server contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        711 tests passing · BSL 1.1 · Full-app demo
+        713 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">711</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">713</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">711</div>
+                    <div class="stat-value">713</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">711 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">713 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -85,11 +85,11 @@ describe("dialect eval script", () => {
     };
     const events = readFileSync(join(outDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { event: string });
 
-    expect(results.total).toBe(4);
+    expect(results.total).toBeGreaterThanOrEqual(4);
     expect(results.failed).toBe(0);
-    expect(results.passed).toBe(4);
+    expect(results.passed).toBe(results.total);
     expect(results.results.every((result) => typeof result.elapsedMs === "number")).toBe(true);
-    expect(progress.completed).toBe(4);
+    expect(progress.completed).toBe(results.total);
     expect(progress.failed).toBe(0);
     expect(events.some((event) => event.event === "sample_started")).toBe(true);
     expect(events.some((event) => event.event === "sample_completed")).toBe(true);

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-MX.json
@@ -135,7 +135,7 @@
     "requiredContext": [
       "Mexican Spanish",
       "Lexical ambiguity constraints",
-      "Do not use coger"
+      "Avoid coger in taboo-risk dialects"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [
@@ -184,7 +184,7 @@
     "requiredContext": [
       "Mexican Spanish",
       "Lexical ambiguity constraints",
-      "Do not use coger"
+      "Avoid coger in taboo-risk dialects"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [

--- a/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-adversarial/es-PR.json
@@ -161,5 +161,50 @@
       "recepción"
     ],
     "notes": "Pick up package should preserve pickup/package intent and not become download."
+  },
+  {
+    "id": "pr-tidy-room",
+    "category": "intent-ambiguity",
+    "severity": "critical",
+    "tags": [
+      "pick-up",
+      "room",
+      "household",
+      "semantic-ambiguity"
+    ],
+    "source": "Pick up the room before guests arrive.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Puerto Rican Spanish",
+      "Lexical ambiguity constraints",
+      "recoger el cuarto"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "coger",
+      "levantar"
+    ],
+    "requiredOutputGroups": [
+      [
+        "cuarto",
+        "habitación"
+      ],
+      [
+        "recoge",
+        "recoger",
+        "ordena",
+        "ordenar",
+        "arregla",
+        "arreglar"
+      ]
+    ],
+    "preferredOutputAny": [
+      "recoge",
+      "recoger",
+      "cuarto"
+    ],
+    "notes": "Puerto Rican pick up the room means tidy the room; recoger el cuarto is acceptable and should not be treated as package/file pickup."
   }
 ]

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-MX.json
@@ -11,7 +11,7 @@
       "prefer-neutral-alternative",
       "Localize grammar",
       "Lexical ambiguity constraints",
-      "Do not use coger"
+      "Avoid coger in taboo-risk dialects"
     ],
     "forbiddenContext": [],
     "forbiddenOutputTerms": [

--- a/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
+++ b/packages/cli/src/__tests__/fixtures/dialect-eval/es-PR.json
@@ -52,5 +52,50 @@
       "asistencia",
       "atención al cliente"
     ]
+  },
+  {
+    "id": "pr-tidy-room",
+    "category": "intent-ambiguity",
+    "severity": "critical",
+    "tags": [
+      "pick-up",
+      "room",
+      "household",
+      "semantic-ambiguity"
+    ],
+    "source": "Pick up the room before guests arrive.",
+    "domain": "general",
+    "register": "auto",
+    "documentKind": "plain",
+    "requiredContext": [
+      "Puerto Rican Spanish",
+      "Lexical ambiguity constraints",
+      "recoger el cuarto"
+    ],
+    "forbiddenContext": [],
+    "forbiddenOutputTerms": [
+      "coger",
+      "levantar"
+    ],
+    "requiredOutputGroups": [
+      [
+        "cuarto",
+        "habitación"
+      ],
+      [
+        "recoge",
+        "recoger",
+        "ordena",
+        "ordenar",
+        "arregla",
+        "arreglar"
+      ]
+    ],
+    "preferredOutputAny": [
+      "recoge",
+      "recoger",
+      "cuarto"
+    ],
+    "notes": "Puerto Rican pick up the room means tidy the room; recoger el cuarto is acceptable and should not be treated as package/file pickup."
   }
 ]

--- a/packages/cli/src/__tests__/lexical-ambiguity.test.ts
+++ b/packages/cli/src/__tests__/lexical-ambiguity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildLexicalAmbiguityGuidance } from "../lib/lexical-ambiguity.js";
+import { ALL_SPANISH_DIALECTS } from "@espanol/types";
+import {
+  buildLexicalAmbiguityExpectations,
+  buildLexicalAmbiguityGuidance
+} from "../lib/lexical-ambiguity.js";
 import { buildSemanticTranslationContext } from "../lib/semantic-context.js";
 
 describe("lexical ambiguity constraints", () => {
@@ -10,8 +14,8 @@ describe("lexical ambiguity constraints", () => {
     );
 
     expect(guidance).toContain("[pickup-file]");
-    expect(guidance).toContain("recoger/recoge/recuperar");
-    expect(guidance).toContain("Do not use coger");
+    expect(guidance).toContain("recoger/recoge, recuperar/recupera");
+    expect(guidance).toContain("Avoid coger in taboo-risk dialects");
     expect(guidance).toContain("Do not change the action to descargar/download");
   });
 
@@ -36,7 +40,7 @@ describe("lexical ambiguity constraints", () => {
 
     expect(spain).toContain("coger is neutral in Spain");
     expect(spain).toContain("[take-bus]");
-    expect(spain).not.toContain("[pickup-package]");
+    expect(spain).toContain("[pickup-package]");
   });
 
   it("separates photo, medicine, and physical grab senses", () => {
@@ -44,5 +48,28 @@ describe("lexical ambiguity constraints", () => {
     expect(buildLexicalAmbiguityGuidance("Take the medicine after lunch.", "es-MX")).toContain("[take-medicine]");
     expect(buildLexicalAmbiguityGuidance("Grab your backpack before leaving.", "es-MX")).toContain("[grab-bag]");
   });
-});
 
+  it("models Puerto Rican recoger el cuarto as tidying the room", () => {
+    const guidance = buildLexicalAmbiguityGuidance("Pick up the room before guests arrive.", "es-PR");
+    const expectations = buildLexicalAmbiguityExpectations("Pick up the room before guests arrive.", "es-PR");
+
+    expect(guidance).toContain("[tidy-room]");
+    expect(guidance).toContain("In Puerto Rican Spanish, recoger el cuarto is natural");
+    expect(expectations.requiredOutputGroups).toEqual(expect.arrayContaining([
+      expect.arrayContaining(["cuarto", "habitación"]),
+      expect.arrayContaining(["recoge", "recoger", "ordena", "ordenar", "arregla", "arreglar"]),
+    ]));
+    expect(expectations.forbiddenOutputTerms).toEqual(expect.arrayContaining(["coge", "coger", "levanta", "levantar"]));
+  });
+
+  it("builds category expectations for every dialect instead of one-off examples", () => {
+    for (const dialect of ALL_SPANISH_DIALECTS) {
+      expect(buildLexicalAmbiguityExpectations("Pick up the file before deployment.", dialect).matchedRuleIds).toContain("pickup-file");
+      expect(buildLexicalAmbiguityExpectations("Pick up the package from reception.", dialect).matchedRuleIds).toContain("pickup-package");
+      expect(buildLexicalAmbiguityExpectations("Take the bus to the office.", dialect).matchedRuleIds).toContain("take-bus");
+      expect(buildLexicalAmbiguityExpectations("Take a screenshot.", dialect).matchedRuleIds).toContain("take-photo");
+      expect(buildLexicalAmbiguityExpectations("Take the medicine after lunch.", dialect).matchedRuleIds).toContain("take-medicine");
+      expect(buildLexicalAmbiguityExpectations("Pick up the room before guests arrive.", dialect).matchedRuleIds).toContain("tidy-room");
+    }
+  });
+});

--- a/packages/cli/src/lib/lexical-ambiguity.ts
+++ b/packages/cli/src/lib/lexical-ambiguity.ts
@@ -5,6 +5,19 @@ export interface LexicalAmbiguityRule {
   dialects: readonly SpanishDialect[] | "all";
   sourcePattern: RegExp;
   guidance: string;
+  expectations?: {
+    requiredOutputGroups?: readonly (readonly string[])[];
+    forbiddenOutputTerms?: readonly string[];
+  } | ((dialect: SpanishDialect) => {
+    requiredOutputGroups?: readonly (readonly string[])[];
+    forbiddenOutputTerms?: readonly string[];
+  });
+}
+
+export interface LexicalAmbiguityExpectations {
+  matchedRuleIds: string[];
+  requiredOutputGroups: string[][];
+  forbiddenOutputTerms: string[];
 }
 
 const TABOO_RISK_COGER_DIALECTS: readonly SpanishDialect[] = [
@@ -18,39 +31,113 @@ const TABOO_RISK_COGER_DIALECTS: readonly SpanishDialect[] = [
 export const LEXICAL_AMBIGUITY_RULES: readonly LexicalAmbiguityRule[] = [
   {
     id: "pickup-file",
-    dialects: TABOO_RISK_COGER_DIALECTS,
+    dialects: "all",
     sourcePattern: /\b(pick up|grab|get|take)\b.{0,40}\b(file|files|document|documents|attachment|attachments)\b/i,
-    guidance: "For retrieving files/documents, use recoger/recoge/recuperar as appropriate. Do not use coger. Do not change the action to descargar/download unless the source explicitly says download.",
+    guidance: "For retrieving files/documents, use recoger/recoge, recuperar/recupera, obtener/obtén, or buscar/busca according to context. Do not change the action to descargar/download unless the source explicitly says download. Avoid coger in taboo-risk dialects.",
+    expectations: (dialect) => ({
+      requiredOutputGroups: [
+        ["archivo", "archivos", "documento", "documentos", "adjunto", "adjuntos"],
+        ["recoge", "recoger", "recupera", "recuperar", "obtén", "obtener", "busca", "buscar"],
+      ],
+      forbiddenOutputTerms: [
+        "descarga",
+        "descargar",
+        "bajar",
+        ...(TABOO_RISK_COGER_DIALECTS.includes(dialect) ? ["coge", "coger"] : []),
+      ],
+    }),
   },
   {
     id: "pickup-package",
-    dialects: TABOO_RISK_COGER_DIALECTS,
+    dialects: "all",
     sourcePattern: /\b(pick up|grab|get|take)\b.{0,40}\b(package|packages|parcel|order|badge|ticket)\b/i,
-    guidance: "For physical pickup of an item, use recoger/recoge or retirar/retira according to register. Agarrar can work in casual physical-grab contexts. Do not use coger in taboo-risk dialects.",
+    guidance: "For physical pickup of an item, use recoger/recoge or retirar/retira according to register. Agarrar can work only in casual physical-grab contexts. Do not change pickup into download. Avoid coger in taboo-risk dialects.",
+    expectations: (dialect) => ({
+      requiredOutputGroups: [
+        ["paquete", "paquetes", "pedido", "boleto", "ticket", "credencial"],
+        ["recoge", "recoger", "retira", "retirar"],
+      ],
+      forbiddenOutputTerms: [
+        "descarga",
+        "descargar",
+        ...(TABOO_RISK_COGER_DIALECTS.includes(dialect) ? ["coge", "coger"] : []),
+      ],
+    }),
   },
   {
     id: "take-bus",
     dialects: "all",
     sourcePattern: /\b(take|catch|ride|get on|board)\b.{0,30}\b(bus|train|metro|subway|taxi|cab|shuttle)\b/i,
     guidance: "For taking transportation, use tomar/toma or abordar/aborda by register and dialect. Do not use coger outside Spain/Andorra. Preserve dialect-specific vehicle terms such as guagua where the dialect contract requires them.",
+    expectations: (dialect) => ({
+      requiredOutputGroups: [
+        dialect === "es-CU" || dialect === "es-DO" || dialect === "es-PR"
+          ? ["guagua", "autobús", "bus"]
+          : dialect === "es-MX"
+            ? ["bus", "autobús", "camión"]
+            : ["bus", "autobús", "ómnibus", "colectivo", "guagua", "camión"],
+        dialect === "es-ES" || dialect === "es-AD"
+          ? ["coge", "coger", "toma", "tomar", "aborda", "abordar"]
+          : ["toma", "tomar", "aborda", "abordar"],
+      ],
+      forbiddenOutputTerms: dialect === "es-ES" || dialect === "es-AD"
+        ? []
+        : ["coge", "coger", "agarra", "agarrar"],
+    }),
   },
   {
     id: "take-photo",
     dialects: "all",
     sourcePattern: /\b(take|snap|capture)\b.{0,30}\b(photo|picture|screenshot|screen shot|image)\b/i,
     guidance: "For taking a photo/screenshot, use tomar or sacar/capturar according to dialect and UI register. Never literalize this as coger.",
+    expectations: {
+      requiredOutputGroups: [
+        ["foto", "fotografía", "captura", "imagen", "pantalla"],
+        ["toma", "tomar", "saca", "sacar", "captura", "capturar", "haz", "hacer"],
+      ],
+      forbiddenOutputTerms: ["coge", "coger", "agarra", "agarrar", "recoge", "recoger"],
+    },
   },
   {
     id: "take-medicine",
     dialects: "all",
     sourcePattern: /\b(take)\b.{0,30}\b(medicine|medication|pill|dose|tablet)\b/i,
     guidance: "For taking medicine, use tomar. Do not use coger/agarrar/recoger.",
+    expectations: {
+      requiredOutputGroups: [
+        ["medicina", "medicamento", "pastilla", "dosis", "tableta"],
+        ["toma", "tomar", "tómate", "tomarse"],
+      ],
+      forbiddenOutputTerms: ["coge", "coger", "agarra", "agarrar", "recoge", "recoger"],
+    },
   },
   {
     id: "grab-bag",
     dialects: TABOO_RISK_COGER_DIALECTS,
     sourcePattern: /\b(grab|take)\b.{0,30}\b(bag|keys|phone|laptop|backpack)\b/i,
     guidance: "For physically grabbing a personal object, use agarrar/tomar depending on register. Do not use coger in taboo-risk dialects.",
+    expectations: {
+      requiredOutputGroups: [
+        ["bolsa", "llaves", "teléfono", "celular", "laptop", "mochila"],
+        ["agarra", "agarrar", "toma", "tomar"],
+      ],
+      forbiddenOutputTerms: ["coge", "coger", "recoge", "recoger"],
+    },
+  },
+  {
+    id: "tidy-room",
+    dialects: "all",
+    sourcePattern: /\b(pick up|clean up|tidy up|straighten up)\b.{0,40}\b(room|bedroom)\b/i,
+    guidance: "For tidying a room, translate the household-cleanup sense, not physical pickup. In Puerto Rican Spanish, recoger el cuarto is natural for tidying the room. Elsewhere, ordenar/arreglar/recoger la habitación/el cuarto may fit by dialect and register.",
+    expectations: (dialect) => ({
+      requiredOutputGroups: [
+        dialect === "es-PR" ? ["cuarto", "habitación"] : ["cuarto", "habitación", "pieza", "recámara"],
+        dialect === "es-PR"
+          ? ["recoge", "recoger", "ordena", "ordenar", "arregla", "arreglar"]
+          : ["ordena", "ordenar", "arregla", "arreglar", "recoge", "recoger"],
+      ],
+      forbiddenOutputTerms: ["coge", "coger", "levanta", "levantar"],
+    }),
   },
 ];
 
@@ -59,9 +146,7 @@ function appliesToDialect(rule: LexicalAmbiguityRule, dialect: SpanishDialect): 
 }
 
 export function buildLexicalAmbiguityGuidance(text: string, dialect: SpanishDialect): string | undefined {
-  const matched = LEXICAL_AMBIGUITY_RULES.filter((rule) =>
-    appliesToDialect(rule, dialect) && rule.sourcePattern.test(text)
-  );
+  const matched = findMatchedLexicalAmbiguityRules(text, dialect);
 
   if (matched.length === 0) {
     return undefined;
@@ -73,3 +158,38 @@ export function buildLexicalAmbiguityGuidance(text: string, dialect: SpanishDial
   ].join(" ");
 }
 
+export function findMatchedLexicalAmbiguityRules(
+  text: string,
+  dialect: SpanishDialect
+): readonly LexicalAmbiguityRule[] {
+  return LEXICAL_AMBIGUITY_RULES.filter((rule) =>
+    appliesToDialect(rule, dialect) && rule.sourcePattern.test(text)
+  );
+}
+
+export function buildLexicalAmbiguityExpectations(
+  text: string,
+  dialect: SpanishDialect
+): LexicalAmbiguityExpectations {
+  const matched = findMatchedLexicalAmbiguityRules(text, dialect);
+  const requiredOutputGroups: string[][] = [];
+  const forbiddenOutputTerms = new Set<string>();
+
+  for (const rule of matched) {
+    const expectations = typeof rule.expectations === "function"
+      ? rule.expectations(dialect)
+      : rule.expectations;
+    for (const group of expectations?.requiredOutputGroups || []) {
+      requiredOutputGroups.push([...group]);
+    }
+    for (const term of expectations?.forbiddenOutputTerms || []) {
+      forbiddenOutputTerms.add(term);
+    }
+  }
+
+  return {
+    matchedRuleIds: matched.map((rule) => rule.id),
+    requiredOutputGroups,
+    forbiddenOutputTerms: [...forbiddenOutputTerms],
+  };
+}

--- a/scripts/dialect-certify.mjs
+++ b/scripts/dialect-certify.mjs
@@ -23,6 +23,10 @@ const VOSEO_DIALECTS = new Set(["es-AR", "es-UY", "es-PY", "es-GT", "es-HN", "es
 const VOSOTROS_DIALECTS = new Set(["es-ES", "es-AD"]);
 const GUAGUA_BUS_DIALECTS = new Set(["es-CU", "es-DO", "es-PR"]);
 
+const { buildLexicalAmbiguityExpectations } = await import(
+  pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/lexical-ambiguity.js`).href
+);
+
 function parsePositiveInt(value, fallback) {
   const parsed = parseInt(value || "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -69,6 +73,7 @@ function mockTranslate(source, dialect, sample = {}) {
     .replace(/\bPlease update your contraseña before continuing\./i, formalSupport ? "Por favor, actualice su contraseña antes de continuar." : "Actualiza tu contraseña antes de continuar.")
     .replace(/\bContact support\b/i, formalSupport ? "Comuníquese con soporte" : "Contacta a soporte")
     .replace(/\bpayment fails\b/i, "pago falla")
+    .replace(/\bPick up the room before guests arrive\./i, dialect === "es-PR" ? "Recoge el cuarto antes de que lleguen los invitados." : "Ordena la habitación antes de que lleguen los invitados.")
     .replace(/\bPick up\b/i, "Recoge")
     .replace(/\bfiles\b/i, "archivos")
     .replace(/\bfile\b/i, "archivo")
@@ -123,7 +128,9 @@ async function evaluate(sample, dialect, translate) {
     failures.push(`Provider error: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  for (const term of sample.forbiddenOutputTerms || []) {
+  const lexicalExpectations = buildLexicalAmbiguityExpectations(sample.source, dialect);
+
+  for (const term of [...(sample.forbiddenOutputTerms || []), ...lexicalExpectations.forbiddenOutputTerms]) {
     if (output && hasForbiddenTerm(output, term)) {
       failures.push(`Forbidden output term present: ${term}`);
     }
@@ -136,8 +143,12 @@ async function evaluate(sample, dialect, translate) {
     }
   }
 
-  if (output && sample.requiredOutputGroups?.length) {
-    for (const group of sample.requiredOutputGroups) {
+  const requiredOutputGroups = [
+    ...(sample.requiredOutputGroups || []),
+    ...lexicalExpectations.requiredOutputGroups,
+  ];
+  if (output && requiredOutputGroups.length) {
+    for (const group of requiredOutputGroups) {
       const matched = group.some((term) => hasForbiddenTerm(output, term));
       if (!matched) {
         failures.push(`Missing required output group; expected one of: ${group.join(", ")}`);

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -20,6 +20,10 @@ const VOSEO_DIALECTS = new Set(["es-AR", "es-UY", "es-PY", "es-GT", "es-HN", "es
 const VOSOTROS_DIALECTS = new Set(["es-ES", "es-AD"]);
 const GUAGUA_BUS_DIALECTS = new Set(["es-CU", "es-DO", "es-PR"]);
 
+const { buildLexicalAmbiguityExpectations } = await import(
+  pathToFileURL(`${process.cwd()}/packages/cli/dist/lib/lexical-ambiguity.js`).href
+);
+
 function mockTranslate(source, dialect, sample = {}) {
   const formalSupport = sample.register === "formal" && /\b(password|support|payment)\b/i.test(source);
 
@@ -31,6 +35,7 @@ function mockTranslate(source, dialect, sample = {}) {
     .replace(/\bBuy hot sauce for lunch\./i, dialect === "es-BO" ? "Compre llajwa para el almuerzo." : "Compre salsa picante para el almuerzo.")
     .replace(/\bBuy avocado for lunch\./i, dialect === "es-CL" ? "Compra palta para el almuerzo." : "Compra aguacate para el almuerzo.")
     .replace(/\bUse the computer to open the file\./i, ["es-CO", "es-EC"].includes(dialect) ? "Usa el computador para abrir el archivo." : "Usa la computadora para abrir el archivo.")
+    .replace(/\b(Catch|Ride|Get on)\b/i, "Toma")
     .replace(/\bTake\b/i, "Toma")
     .replace(/\bbus\b/i, GUAGUA_BUS_DIALECTS.has(dialect) ? "guagua" : "bus")
     .replace(/\boffice\b/i, "oficina")
@@ -39,7 +44,10 @@ function mockTranslate(source, dialect, sample = {}) {
     .replace(/\bPlease update your contraseña before continuing\./i, formalSupport ? "Por favor, actualice su contraseña antes de continuar." : "Actualiza tu contraseña antes de continuar.")
     .replace(/\bContact support\b/i, formalSupport ? "Comuníquese con soporte" : "Contacta a soporte")
     .replace(/\bpayment fails\b/i, "pago falla")
+    .replace(/\bPick up the room before guests arrive\./i, dialect === "es-PR" ? "Recoge el cuarto antes de que lleguen los invitados." : "Ordena la habitación antes de que lleguen los invitados.")
     .replace(/\bPick up\b/i, "Recoge")
+    .replace(/\bpackage\b/i, "paquete")
+    .replace(/\breception\b/i, "recepción")
     .replace(/\bfile\b/i, "archivo")
     .replace(/\bdeployment\b/i, "despliegue")
     .replace(/\bYou can update\b/i, VOSEO_DIALECTS.has(dialect) ? "Vos podés actualizar" : "Puedes actualizar")
@@ -93,7 +101,9 @@ async function evaluate(sample, dialect, translate) {
     failures.push(`Provider error: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  for (const term of sample.forbiddenOutputTerms || []) {
+  const lexicalExpectations = buildLexicalAmbiguityExpectations(sample.source, dialect);
+
+  for (const term of [...(sample.forbiddenOutputTerms || []), ...lexicalExpectations.forbiddenOutputTerms]) {
     if (output && hasForbiddenTerm(output, term)) {
       failures.push(`Forbidden output term present: ${term}`);
     }
@@ -106,8 +116,12 @@ async function evaluate(sample, dialect, translate) {
     }
   }
 
-  if (output && sample.requiredOutputGroups?.length) {
-    for (const group of sample.requiredOutputGroups) {
+  const requiredOutputGroups = [
+    ...(sample.requiredOutputGroups || []),
+    ...lexicalExpectations.requiredOutputGroups,
+  ];
+  if (output && requiredOutputGroups.length) {
+    for (const group of requiredOutputGroups) {
       const matched = group.some((term) => hasForbiddenTerm(output, term));
       if (!matched) {
         failures.push(`Missing required output group; expected one of: ${group.join(", ")}`);


### PR DESCRIPTION
## Summary
- generalizes lexical ambiguity gates so matching eval/certification samples inherit rule expectations across dialects
- adds dialect-aware required output groups and forbidden terms for pickup, transit, photo/screenshot, medicine, physical grab, and room-tidying senses
- models Puerto Rican `recoger el cuarto` as tidying the room, not package/file pickup
- adds PR eval/adversarial fixtures and broad category tests across all dialects
- keeps certification from accepting one-token lucky matches by applying output groups from the ambiguity rule engine

## Why
The previous fix was still too close to a one-off. The real failure mode is object/sense/dialect ambiguity: `coger`, `tomar`, `agarrar`, `recoger`, `retirar`, etc. cannot be handled as simple replacements. This patch makes ambiguity an executable category with prompt guidance and scoring gates.

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- `pnpm dialect:eval -- --out=/tmp/dialectos-ambiguity-matrix-eval`
- `pnpm dialect:eval -- --fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial --out=/tmp/dialectos-ambiguity-matrix-adversarial`
- qwen3.5-9b live PR ambiguity eval: `LLM_API_URL=http://127.0.0.1:1234/v1/chat/completions LLM_API_FORMAT=openai LLM_MODEL=qwen3.5-9b LLM_ALLOW_LOCAL=1 LLM_TIMEOUT_MS=180000 pnpm dialect:eval -- --live --provider=llm --fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial --dialects=es-PR --out=/tmp/dialectos-pr-ambiguity-live-qwen35-final`
- `git diff --check`
- npm pack dry-run guard for all publishable packages
