### PR TITLE
Keep full-app demo on semantic providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-713%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-716%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 713 tests passing
+pnpm test        # 716 tests passing
 ```
 
 ---
@@ -233,14 +233,14 @@ pnpm test        # 713 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 302 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 305 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 713 tests across 7 packages plus the full-app docs and demo-server contracts**
+**Total: 716 tests across 7 packages plus the full-app docs and demo-server contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        713 tests passing · BSL 1.1 · Full-app demo
+        716 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">713</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">716</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">713</div>
+                    <div class="stat-value">716</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">713 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">716 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/packages/cli/src/__tests__/web-demo-service.test.ts
+++ b/packages/cli/src/__tests__/web-demo-service.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { ProviderRegistry } from "@espanol/providers";
-import type { TranslationProvider } from "@espanol/types";
+import type { ProviderCapability, TranslationProvider } from "@espanol/types";
 import {
   getWebDemoProviderStatus,
   translateForWebDemo,
   validateWebDemoDialect,
 } from "../lib/web-demo-service.js";
 
-function makeProvider(name = "llm"): TranslationProvider {
+function makeProvider(
+  name = "llm",
+  capabilityOverrides: Partial<ProviderCapability> = {}
+): TranslationProvider {
   return {
     name,
     translate: vi.fn(async (text: string, sourceLang: string, targetLang: string, options) => ({
@@ -27,6 +30,7 @@ function makeProvider(name = "llm"): TranslationProvider {
       supportedTargetLangs: ["es"],
       maxPayloadChars: 100000,
       dialectHandling: "semantic",
+      ...capabilityOverrides,
     }),
   };
 }
@@ -45,9 +49,9 @@ describe("web demo service", () => {
 
     expect(result.translatedText).toBe("[es-MX] Pick up the file before you park the car.");
     expect(result.providerUsed).toBe("llm");
+    expect(result.semanticPromptApplied).toBe(true);
     expect(result.providerStatus.semanticProviders).toEqual(["llm"]);
-    expect(result.semanticContext).toContain("Target dialect: Mexican Spanish");
-    expect(result.semanticContext).toContain("do not translate literally word-by-word");
+    expect(result).not.toHaveProperty("semanticContext");
     expect(provider.translate).toHaveBeenCalledWith(
       "Pick up the file before you park the car.",
       "auto",
@@ -57,6 +61,60 @@ describe("web demo service", () => {
         context: expect.stringContaining("Dialect quality contract"),
       })
     );
+  });
+
+  it("does not expose internal prompt context in public demo results", async () => {
+    const registry = new ProviderRegistry();
+    registry.register(makeProvider());
+
+    const result = await translateForWebDemo({
+      text: "Pick up the file before deployment.",
+      dialect: "es-MX",
+    }, registry);
+
+    expect(JSON.stringify(result)).not.toContain("Dialect quality contract");
+    expect(JSON.stringify(result)).not.toContain("Lexical ambiguity constraints");
+    expect(result.semanticPromptApplied).toBe(true);
+  });
+
+  it("refuses generic non-semantic providers for the full-app demo", async () => {
+    const registry = new ProviderRegistry();
+    registry.register(makeProvider("libretranslate", {
+      displayName: "Mock generic MT",
+      supportsContext: false,
+      supportsDialect: false,
+      dialectHandling: "none",
+    }));
+
+    const status = getWebDemoProviderStatus(registry);
+    expect(status.configured).toBe(true);
+    expect(status.ready).toBe(false);
+    expect(status.semanticProviders).toEqual([]);
+
+    await expect(translateForWebDemo({
+      text: "Pick up the file before deployment.",
+      dialect: "es-MX",
+    }, registry)).rejects.toThrow(/not semantic enough/);
+  });
+
+  it("does not fall back from semantic providers to generic providers", async () => {
+    const registry = new ProviderRegistry();
+    const failingSemantic = makeProvider("llm");
+    vi.mocked(failingSemantic.translate).mockRejectedValue(new Error("semantic down"));
+    const generic = makeProvider("libretranslate", {
+      displayName: "Mock generic MT",
+      supportsContext: false,
+      supportsDialect: false,
+      dialectHandling: "none",
+    });
+    registry.register(failingSemantic);
+    registry.register(generic);
+
+    await expect(translateForWebDemo({
+      text: "Pick up the file before deployment.",
+      dialect: "es-MX",
+    }, registry)).rejects.toThrow(/All semantic demo providers failed/);
+    expect(generic.translate).not.toHaveBeenCalled();
   });
 
   it("reports missing providers instead of falling back to static rule substitutions", async () => {
@@ -73,4 +131,3 @@ describe("web demo service", () => {
     expect(getWebDemoProviderStatus(new ProviderRegistry()).configured).toBe(false);
   });
 });
-

--- a/packages/cli/src/lib/web-demo-service.ts
+++ b/packages/cli/src/lib/web-demo-service.ts
@@ -4,7 +4,6 @@ import { ALL_SPANISH_DIALECTS } from "@espanol/types";
 import { validateContentLength } from "@espanol/security";
 import { detectDialect } from "./dialect-info.js";
 import { createProviderRegistry } from "./provider-factory.js";
-import { translateWithFallback } from "./resilient-translation.js";
 import { buildSemanticTranslationContext } from "./semantic-context.js";
 
 export interface WebDemoTranslateRequest {
@@ -16,6 +15,7 @@ export interface WebDemoTranslateRequest {
 
 export interface WebDemoProviderStatus {
   configured: boolean;
+  ready: boolean;
   providers: string[];
   semanticProviders: string[];
   message: string;
@@ -28,7 +28,7 @@ export interface WebDemoTranslateResult {
   fallbackCount: number;
   retryCount: number;
   sourceDetection: ReturnType<typeof detectDialect>;
-  semanticContext: string;
+  semanticPromptApplied: boolean;
   providerStatus: WebDemoProviderStatus;
 }
 
@@ -59,11 +59,14 @@ export function getWebDemoProviderStatus(
 
   return {
     configured: providers.length > 0,
+    ready: semanticProviders.length > 0,
     providers,
     semanticProviders,
-    message: providers.length > 0
-      ? `Configured providers: ${providers.join(", ")}`
-      : "No provider configured. Start a local OpenAI-compatible model or set LLM_API_URL + LLM_MODEL.",
+    message: semanticProviders.length > 0
+      ? `Semantic providers ready: ${semanticProviders.join(", ")}`
+      : providers.length > 0
+        ? `Configured providers are not semantic enough for the full-app demo: ${providers.join(", ")}. Start an LLM provider with LLM_API_URL + LLM_MODEL.`
+        : "No provider configured. Start a local OpenAI-compatible model or set LLM_API_URL + LLM_MODEL.",
   };
 }
 
@@ -84,6 +87,12 @@ export async function translateForWebDemo(
   if (!providerStatus.configured) {
     throw new Error(providerStatus.message);
   }
+  if (!providerStatus.ready) {
+    throw new Error(providerStatus.message);
+  }
+  if (provider && !providerStatus.semanticProviders.includes(provider)) {
+    throw new Error(`Provider ${provider} is not semantic enough for the full-app demo. Use one of: ${providerStatus.semanticProviders.join(", ")}`);
+  }
 
   const semanticContext = buildSemanticTranslationContext({
     text,
@@ -92,9 +101,9 @@ export async function translateForWebDemo(
     documentKind: "plain",
   });
 
-  const translated = await translateWithFallback(
+  const translated = await translateWithSemanticDemoProviders(
     registry,
-    provider,
+    provider ? [provider] : providerStatus.semanticProviders,
     text,
     "auto",
     "es",
@@ -103,7 +112,6 @@ export async function translateForWebDemo(
       formality,
       context: semanticContext,
     },
-    { delayMs: 0 }
   );
 
   return {
@@ -113,8 +121,51 @@ export async function translateForWebDemo(
     fallbackCount: translated.fallbackCount,
     retryCount: translated.retryCount,
     sourceDetection: detectDialect(text),
-    semanticContext,
+    semanticPromptApplied: true,
     providerStatus,
   };
 }
 
+async function translateWithSemanticDemoProviders(
+  registry: ProviderRegistry,
+  providers: string[],
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  options: {
+    dialect: SpanishDialect;
+    formality: FormalityLevel;
+    context: string;
+  }
+): Promise<{
+  translatedText: string;
+  providerUsed: string;
+  fallbackCount: number;
+  retryCount: number;
+}> {
+  const errors: string[] = [];
+  for (const [attemptIndex, name] of providers.entries()) {
+    try {
+      const provider = registry.get(name);
+      const prepared = registry.prepareRequest(name, text, sourceLang, targetLang, options);
+      const result = await provider.translate(
+        text,
+        prepared.sourceLang,
+        prepared.targetLang,
+        prepared.options
+      );
+      registry.recordSuccess(name);
+      return {
+        translatedText: result.translatedText,
+        providerUsed: provider.name,
+        fallbackCount: attemptIndex,
+        retryCount: 0,
+      };
+    } catch (error) {
+      registry.recordFailure(name);
+      errors.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  throw new Error(`All semantic demo providers failed (${providers.join(" -> ")}): ${errors.join(" | ")}`);
+}

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -38,12 +38,13 @@ test("demo server translates through injected full-app service", async () => {
           matchedKeywords: [],
           registerHint: "neutral",
         },
-        semanticContext: "Translate by preserving meaning",
+        semanticPromptApplied: true,
         providerStatus: {
           configured: true,
+          ready: true,
           providers: ["llm"],
           semanticProviders: ["llm"],
-          message: "Configured providers: llm",
+          message: "Semantic providers ready: llm",
         },
       };
     },
@@ -65,6 +66,9 @@ test("demo server translates through injected full-app service", async () => {
     assert.equal(body.ok, true);
     assert.equal(body.translatedText, "Recoge el archivo antes de estacionar el carro.");
     assert.equal(body.providerUsed, "llm");
+    assert.equal(body.semanticPromptApplied, true);
+    assert.equal(body.semanticContext, undefined);
+    assert.equal(JSON.stringify(body).includes("Dialect quality contract"), false);
     assert.deepEqual(calls, [{
       text: "Pick up the file before you park the car.",
       dialect: "es-MX",
@@ -80,6 +84,7 @@ test("demo server returns provider errors instead of static fallback output", as
   const { server, baseUrl } = await startTestServer({
     status: () => ({
       configured: false,
+      ready: false,
       providers: [],
       semanticProviders: [],
       message: "No provider configured",
@@ -110,9 +115,10 @@ test("demo server exposes provider status for the browser UI", async () => {
   const { server, baseUrl } = await startTestServer({
     status: () => ({
       configured: true,
+      ready: true,
       providers: ["llm"],
       semanticProviders: ["llm"],
-      message: "Configured providers: llm",
+      message: "Semantic providers ready: llm",
     }),
     translate: async () => {
       throw new Error("not used");
@@ -126,9 +132,9 @@ test("demo server exposes provider status for the browser UI", async () => {
     assert.equal(response.status, 200);
     assert.equal(body.ok, true);
     assert.equal(body.configured, true);
+    assert.equal(body.ready, true);
     assert.deepEqual(body.providers, ["llm"]);
   } finally {
     server.close();
   }
 });
-


### PR DESCRIPTION
## Summary
- prevents the full-app browser demo from exposing internal semantic prompt/context text
- requires at least one semantic provider for the demo path instead of treating generic MT providers as demo-ready
- prevents fallback from a failed semantic provider to generic providers in the demo path
- adds regression tests for prompt leakage, non-semantic providers, and generic fallback refusal
- updates test counts to 716

## Why
Based on recent failures, the highest-probability next class of bugs is product-surface misrepresentation: the UI/API looks like it works while either leaking implementation details or silently using a weaker provider. The demo is supposed to prove semantic dialect behavior, so it must require semantic providers and keep internal prompts server-side.

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- focused `web-demo-service` tests
- focused `demo-server` tests
- `git diff --check`
- npm pack dry-run guard for publishable packages
