### PR TITLE
Harden detection generated docs and launch gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-716%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-722%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 716 tests passing
+pnpm test        # 722 tests passing
 ```
 
 ---
@@ -233,14 +233,14 @@ pnpm test        # 716 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 305 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 307 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 716 tests across 7 packages plus the full-app docs and demo-server contracts**
+**Total: 722 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/docs/__tests__/demo-contract.test.mjs
+++ b/docs/__tests__/demo-contract.test.mjs
@@ -25,3 +25,9 @@ test("static docs engine has common three-word regional terms", () => {
   assert.match(engine, /\bguagua\b/);
   assert.match(engine, /\bbus\b/);
 });
+
+test("static docs engine does not guess a dialect on low-confidence text", () => {
+  assert.match(engine, /insufficient-dialect-markers/);
+  assert.match(engine, /isReliable/);
+  assert.match(engine, /dialect: isReliable \? best\.dialect\.code : null/);
+});

--- a/docs/dialectos-engine.js
+++ b/docs/dialectos-engine.js
@@ -523,12 +523,16 @@ function detectDialect(text, register = "any") {
   else if (best.score === 3) confidence = 0.7;
   else if (best.score >= 4) confidence = 0.9;
 
+  const isReliable = best.score > 0;
+
   return {
-    dialect: best.dialect.code,
-    confidence,
-    name: best.dialect.name,
+    dialect: isReliable ? best.dialect.code : null,
+    confidence: isReliable ? confidence : 0,
+    name: isReliable ? best.dialect.name : null,
     matchedKeywords: best.matchedKeywords,
     registerHint: best.registerHint,
+    isReliable,
+    reason: isReliable ? "matched-dialect-markers" : "insufficient-dialect-markers",
   };
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        716 tests passing · BSL 1.1 · Full-app demo
+        722 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">716</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">722</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">716</div>
+                    <div class="stat-value">722</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">716 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">722 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r build",
-    "test": "node --test docs/__tests__/*.test.mjs scripts/__tests__/*.test.mjs && pnpm -r test",
+    "test": "node scripts/build-demo.cjs --check && node --test docs/__tests__/*.test.mjs scripts/__tests__/*.test.mjs && pnpm -r test",
+    "check:generated": "node scripts/build-demo.cjs --check",
     "demo": "pnpm build && node scripts/demo-server.mjs",
     "test:coverage": "pnpm -r test:coverage",
     "clean": "pnpm -r clean",

--- a/packages/cli/src/__tests__/dialect-eval-script.test.ts
+++ b/packages/cli/src/__tests__/dialect-eval-script.test.ts
@@ -32,6 +32,29 @@ describe("dialect eval script", () => {
 
     rmSync(outDir, { recursive: true, force: true });
   });
+
+  it("can fail launch-style evals when warnings are present", () => {
+    const outDir = join(tmpdir(), `dialect-eval-warnings-${process.pid}`);
+    rmSync(outDir, { recursive: true, force: true });
+
+    expect(() => execFileSync("node", [
+      "scripts/dialect-eval.mjs",
+      `--out=${outDir}`,
+      "--fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial",
+      "--dialects=es-AD",
+      "--fail-on-warnings=true",
+    ], { cwd: join(import.meta.dirname, "../../../.."), stdio: "pipe" })).toThrow();
+
+    const results = JSON.parse(readFileSync(join(outDir, "results.json"), "utf-8")) as {
+      failed: number;
+      warnings: number;
+    };
+    expect(results.failed).toBe(0);
+    expect(results.warnings).toBeGreaterThan(0);
+
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
   it("reports a clear error when live mode has no configured provider", () => {
     const outDir = join(tmpdir(), `dialect-eval-live-${process.pid}`);
     rmSync(outDir, { recursive: true, force: true });

--- a/packages/cli/src/__tests__/dialects.test.ts
+++ b/packages/cli/src/__tests__/dialects.test.ts
@@ -154,14 +154,15 @@ describe("dialects command", () => {
       expect(output).toMatch(/formal|Register/);
     });
 
-    it("should return default dialect (es-ES) when no markers detected", async () => {
+    it("should return unknown when no markers are detected", async () => {
       const { executeDialectsDetect } = await import("../commands/dialects.js");
 
       await executeDialectsDetect("El texto es neutral y no tiene marcadores regionales obvios.");
 
       expect(writeOutput).toHaveBeenCalled();
       const output = vi.mocked(writeOutput).mock.calls[0][0];
-      expect(output).toContain("es-ES");
+      expect(output).toContain("unknown");
+      expect(output).toContain("not guessing a dialect");
     });
 
     it("should include confidence score in output", async () => {
@@ -186,7 +187,26 @@ describe("dialects command", () => {
       const parsed = JSON.parse(output);
       expect(parsed).toHaveProperty("dialect");
       expect(parsed).toHaveProperty("confidence");
+      expect(parsed).toHaveProperty("isReliable");
       expect(typeof parsed.confidence).toBe("number");
+      expect(typeof parsed.isReliable).toBe("boolean");
+    });
+
+
+
+    it("should format low-confidence detection as unknown JSON", async () => {
+      const { executeDialectsDetect } = await import("../commands/dialects.js");
+
+      await executeDialectsDetect("El texto es neutral y no tiene marcadores regionales obvios.", { format: "json" });
+
+      expect(writeOutput).toHaveBeenCalled();
+      const output = vi.mocked(writeOutput).mock.calls.at(-1)![0];
+      const parsed = JSON.parse(output);
+      expect(parsed.dialect).toBeNull();
+      expect(parsed.name).toBeNull();
+      expect(parsed.confidence).toBe(0);
+      expect(parsed.isReliable).toBe(false);
+      expect(parsed.reason).toBe("insufficient-dialect-markers");
     });
 
     it("should handle empty text gracefully", async () => {

--- a/packages/cli/src/lib/dialect-info.ts
+++ b/packages/cli/src/lib/dialect-info.ts
@@ -496,11 +496,13 @@ export type RegisterPreference = "any" | "formal" | "slang";
  * Detection result with register awareness
  */
 export interface DetectionResult {
-  dialect: SpanishDialect;
+  dialect: SpanishDialect | null;
   confidence: number;
-  name: string;
+  name: string | null;
   matchedKeywords: string[];
   registerHint: "formal" | "slang" | "neutral";
+  isReliable: boolean;
+  reason?: "matched-dialect-markers" | "insufficient-dialect-markers";
 }
 
 function getWordBoundaries(text: string): Set<string> {
@@ -576,12 +578,16 @@ export function detectDialect(text: string, register: RegisterPreference = "any"
   else if (best.score === 3) confidence = 0.7;
   else if (best.score >= 4) confidence = 0.9;
 
+  const isReliable = best.score > 0;
+
   return {
-    dialect: best.dialect.code,
-    confidence,
-    name: best.dialect.name,
+    dialect: isReliable ? best.dialect.code : null,
+    confidence: isReliable ? confidence : 0,
+    name: isReliable ? best.dialect.name : null,
     matchedKeywords: best.matchedKeywords,
     registerHint: best.registerHint,
+    isReliable,
+    reason: isReliable ? "matched-dialect-markers" : "insufficient-dialect-markers",
   };
 }
 
@@ -620,16 +626,27 @@ export function formatDetectionResult(result: DetectionResult, format: "text" | 
       confidence: result.confidence,
       name: result.name,
       registerHint: result.registerHint,
+      isReliable: result.isReliable,
+      reason: result.reason,
     }, null, 2);
   }
 
   const confidencePercent = Math.round(result.confidence * 100);
+  if (!result.isReliable) {
+    return [
+      "Detected Dialect: unknown (insufficient dialect markers)",
+      "Confidence: 0%",
+      "Register: neutral",
+      "No specific keywords detected; not guessing a dialect"
+    ].join("\n");
+  }
+
   return [
     `Detected Dialect: ${result.dialect} (${result.name})`,
     `Confidence: ${confidencePercent}%`,
     `Register: ${result.registerHint}`,
     result.matchedKeywords.length > 0
       ? `Matched Keywords: ${result.matchedKeywords.join(", ")}`
-      : "No specific keywords detected (default dialect)"
+      : "No specific keywords detected"
   ].join("\n");
 }

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -18,7 +18,7 @@ describe("Configuration System", () => {
   });
 
   afterEach(() => {
-    try { rmSync(tempDir, { recursive: true }); } catch {}
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   it("should return default config when no args or env", async () => {

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -4,7 +4,18 @@ import assert from "node:assert/strict";
 import { createDemoServer } from "../demo-server.mjs";
 
 async function startTestServer(services) {
-  const server = createDemoServer({ services });
+  const server = createDemoServer({ services, rateLimit: { maxRequests: 100, windowMs: 60000 } });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function startRateLimitedTestServer(services) {
+  const server = createDemoServer({ services, rateLimit: { maxRequests: 1, windowMs: 60000 } });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
   const address = server.address();
@@ -134,6 +145,88 @@ test("demo server exposes provider status for the browser UI", async () => {
     assert.equal(body.configured, true);
     assert.equal(body.ready, true);
     assert.deepEqual(body.providers, ["llm"]);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server rejects malformed JSON as a client error", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      throw new Error("should not be called");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{broken",
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /JSON|Unexpected|position|Expected/i);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server rate limits translation requests", async () => {
+  const { server, baseUrl } = await startRateLimitedTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async (request) => ({
+      translatedText: request.text,
+      dialect: request.dialect,
+      providerUsed: "llm",
+      fallbackCount: 0,
+      retryCount: 0,
+      sourceDetection: {
+        dialect: null,
+        confidence: 0,
+        name: null,
+        matchedKeywords: [],
+        registerHint: "neutral",
+        isReliable: false,
+      },
+      semanticPromptApplied: true,
+      providerStatus: {
+        configured: true,
+        ready: true,
+        providers: ["llm"],
+        semanticProviders: ["llm"],
+        message: "Semantic providers ready: llm",
+      },
+    }),
+  });
+
+  try {
+    const payload = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "hola", dialect: "es-MX" }),
+    };
+    const first = await fetch(`${baseUrl}/api/translate`, payload);
+    const second = await fetch(`${baseUrl}/api/translate`, payload);
+    const body = await second.json();
+
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 429);
+    assert.match(body.error, /Rate limit exceeded/);
   } finally {
     server.close();
   }

--- a/scripts/__tests__/static-hardening.test.mjs
+++ b/scripts/__tests__/static-hardening.test.mjs
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const ROOTS = ["packages", "scripts"];
+const SKIP = new Set(["dist", "node_modules", ".git"]);
+const SOURCE_EXTENSIONS = new Set([".ts", ".js", ".mjs", ".cjs"]);
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP.has(entry)) continue;
+    const absolute = join(dir, entry);
+    const stat = statSync(absolute);
+    if (stat.isDirectory()) {
+      walk(absolute, files);
+    } else if ([...SOURCE_EXTENSIONS].some((extension) => absolute.endsWith(extension))) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+test("source does not contain empty catch blocks that swallow failures", () => {
+  const offenders = [];
+  for (const root of ROOTS) {
+    for (const file of walk(root)) {
+      const source = readFileSync(file, "utf8");
+      if (/catch\s*(?:\([^)]*\))?\s*\{\s*\}/m.test(source)) {
+        offenders.push(file);
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});
+

--- a/scripts/build-demo.cjs
+++ b/scripts/build-demo.cjs
@@ -9,14 +9,63 @@ function getLines(file, start, end) {
   return fs.readFileSync(file, 'utf8').split('\n').slice(start - 1, end).join('\n');
 }
 
+function extractBalanced(source, startIndex, openChar, closeChar) {
+  const openIndex = source.indexOf(openChar, startIndex);
+  if (openIndex === -1) throw new Error(`Could not find ${openChar}`);
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === openChar) depth++;
+    else if (ch === closeChar) {
+      depth--;
+      if (depth === 0) return source.slice(openIndex, i + 1);
+    }
+  }
+  throw new Error(`Could not find matching ${closeChar}`);
+}
+
+function findBalancedEnd(source, startIndex, openChar, closeChar) {
+  const openIndex = source.indexOf(openChar, startIndex);
+  if (openIndex === -1) throw new Error(`Could not find ${openChar}`);
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === openChar) depth++;
+    else if (ch === closeChar) {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  throw new Error(`Could not find matching ${closeChar}`);
+}
+
+function extractConstArray(file, name) {
+  const source = fs.readFileSync(file, 'utf8');
+  const start = source.indexOf(`export const ${name}`);
+  if (start === -1) throw new Error(`Could not find ${name}`);
+  const assignment = source.indexOf('=', start);
+  if (assignment === -1) throw new Error(`Could not find assignment for ${name}`);
+  const array = extractBalanced(source, assignment, '[', ']');
+  return `${source.slice(start, assignment)}= ${array};`;
+}
+
+function extractFunction(file, name) {
+  const source = fs.readFileSync(file, 'utf8');
+  const exportStart = source.indexOf(`export function ${name}`);
+  const start = exportStart >= 0 ? exportStart : source.indexOf(`function ${name}`);
+  if (start === -1) throw new Error(`Could not find ${name}`);
+  return source.slice(start, findBalancedEnd(source, start, '{', '}'));
+}
+
 const d = path.join(__dirname, '../packages/cli/src/lib/dialect-info.ts');
 const m = path.join(__dirname, '../packages/cli/src/commands/i18n/manage-variants.ts');
 
-// Exact line ranges from source
+// Extract source-backed demo blocks by symbol name so generated docs do not
+// silently drift when implementation line numbers change.
 const blocks = [
-  getLines(d, 30, 481),    // DIALECT_METADATA
-  getLines(d, 506, 520),   // getWordBoundaries
-  getLines(d, 527, 586),   // detectDialect
+  extractConstArray(d, 'DIALECT_METADATA'),
+  extractFunction(d, 'getWordBoundaries'),
+  extractFunction(d, 'detectDialect'),
   getLines(m, 32, 35),     // VOSOTROS_ADAPTATION
   getLines(m, 38, 302),    // TECH_ADAPTATIONS
   getLines(m, 308, 337),   // DIALECT_ADAPTATIONS
@@ -29,10 +78,13 @@ function stripTS(code) {
     .replace(/:\s*Record<\n\s*SpanishDialect,\n\s*Array<\{[\s\S]*?\}>\n\s*>/g, '')
     .replace(/:\s*DialectMetadata\[\]/g, '')
     .replace(/:\s*DialectMetadata\s*\|\s*undefined/g, '')
+    .replace(/:\s*SpanishDialect\s*\|\s*null/g, '')
+    .replace(/:\s*string\s*\|\s*null/g, '')
     .replace(/:\s*SpanishDialect/g, '')
     .replace(/:\s*string\[\]/g, '')
     .replace(/:\s*string/g, '')
     .replace(/:\s*number/g, '')
+    .replace(/:\s*boolean/g, '')
     .replace(/:\s*Set<string>/g, '')
     .replace(/:\s*RegisterPreference/g, '')
     .replace(/:\s*DetectionResult/g, '')
@@ -66,8 +118,18 @@ if (typeof window !== 'undefined') {
 }
 `;
 
-fs.writeFileSync(path.join(__dirname, '../docs/dialectos-engine.js'), output);
-console.log('Generated docs/dialectos-engine.js (' + output.length + ' chars)');
+const outputPath = path.join(__dirname, '../docs/dialectos-engine.js');
+if (process.argv.includes('--check')) {
+  const current = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : '';
+  if (current !== output) {
+    console.error('docs/dialectos-engine.js is stale. Run: node scripts/build-demo.cjs');
+    process.exit(1);
+  }
+  console.log('Generated docs/dialectos-engine.js is current');
+} else {
+  fs.writeFileSync(outputPath, output);
+  console.log('Generated docs/dialectos-engine.js (' + output.length + ' chars)');
+}
 
 try {
   require('child_process').execSync('node --check docs/dialectos-engine.js', { cwd: path.join(__dirname, '..') });

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -18,6 +18,29 @@ const CONTENT_TYPES = {
   ".svg": "image/svg+xml",
 };
 
+function createRateLimiter(options = {}) {
+  const maxRequests = Number(options.maxRequests || process.env.DIALECTOS_DEMO_RATE_LIMIT || 60);
+  const windowMs = Number(options.windowMs || process.env.DIALECTOS_DEMO_RATE_WINDOW_MS || 60000);
+  const buckets = new Map();
+
+  return {
+    check(key) {
+      const now = Date.now();
+      const current = buckets.get(key);
+      if (!current || now >= current.resetAt) {
+        buckets.set(key, { count: 1, resetAt: now + windowMs });
+        return { allowed: true, remaining: Math.max(maxRequests - 1, 0), resetMs: windowMs };
+      }
+      current.count += 1;
+      return {
+        allowed: current.count <= maxRequests,
+        remaining: Math.max(maxRequests - current.count, 0),
+        resetMs: Math.max(current.resetAt - now, 0),
+      };
+    },
+  };
+}
+
 function sendJson(res, status, payload) {
   const body = JSON.stringify(payload, null, 2);
   res.writeHead(status, {
@@ -92,6 +115,7 @@ async function loadDefaultServices(rootDir) {
 
 export function createDemoServer(options = {}) {
   const rootDir = path.resolve(options.rootDir || DEFAULT_ROOT);
+  const rateLimiter = createRateLimiter(options.rateLimit);
   const servicesPromise = options.services
     ? Promise.resolve(options.services)
     : loadDefaultServices(rootDir);
@@ -108,8 +132,23 @@ export function createDemoServer(options = {}) {
       }
 
       if (method === "POST" && url.pathname === "/api/translate") {
+        const key = req.socket.remoteAddress || "unknown";
+        const rate = rateLimiter.check(key);
+        if (!rate.allowed) {
+          sendJson(res, 429, {
+            ok: false,
+            error: `Rate limit exceeded. Try again in ${Math.ceil(rate.resetMs / 1000)}s.`,
+          });
+          return;
+        }
         const services = await servicesPromise;
-        const body = await readJson(req);
+        let body;
+        try {
+          body = await readJson(req);
+        } catch (error) {
+          sendJson(res, 400, { ok: false, error: safeError(error) });
+          return;
+        }
         try {
           const result = await services.translate({
             text: String(body.text || ""),
@@ -166,4 +205,3 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
     process.exit(1);
   });
 }
-

--- a/scripts/dialect-certify.mjs
+++ b/scripts/dialect-certify.mjs
@@ -15,6 +15,7 @@ const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/
 const outDir = args.get("out") || `audits/dialect-certify-${new Date().toISOString().slice(0, 10)}`;
 const providerName = args.get("provider") || "mock-semantic";
 const live = args.get("live") === "true";
+const failOnWarnings = args.get("fail-on-warnings") === "true";
 const sampleTimeoutMs = parsePositiveInt(args.get("sample-timeout-ms"), 300000);
 const sampleRetries = parseNonNegativeInt(args.get("sample-retries"), 1);
 const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
@@ -395,7 +396,7 @@ async function runParentMode() {
 
   const finalSummary = summarize(results, startedAt);
   console.log(JSON.stringify({ outDir: absoluteOutDir, total: finalSummary.total, passed: finalSummary.passed, failed: finalSummary.failed, warnings: finalSummary.warnings, live }, null, 2));
-  if (finalSummary.failed > 0) {
+  if (finalSummary.failed > 0 || (failOnWarnings && finalSummary.warnings > 0)) {
     process.exit(1);
   }
 }

--- a/scripts/dialect-eval.mjs
+++ b/scripts/dialect-eval.mjs
@@ -14,6 +14,7 @@ const fixtureDir = args.get("fixtures") || "packages/cli/src/__tests__/fixtures/
 const outDir = args.get("out") || `audits/dialect-eval-${new Date().toISOString().slice(0, 10)}`;
 const providerName = args.get("provider") || "mock-semantic";
 const live = args.get("live") === "true";
+const failOnWarnings = args.get("fail-on-warnings") === "true";
 const dialectFilter = new Set((args.get("dialects") || "").split(",").map((d) => d.trim()).filter(Boolean));
 
 const VOSEO_DIALECTS = new Set(["es-AR", "es-UY", "es-PY", "es-GT", "es-HN", "es-SV", "es-NI"]);
@@ -187,6 +188,6 @@ mkdirSync(outDir, { recursive: true });
 writeFileSync(join(outDir, "results.json"), `${JSON.stringify(summary, null, 2)}\n`);
 console.log(JSON.stringify({ outDir, total: summary.total, passed: summary.passed, failed: summary.failed, warnings: summary.warnings, live }, null, 2));
 
-if (summary.failed > 0) {
+if (summary.failed > 0 || (failOnWarnings && summary.warnings > 0)) {
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- makes low-confidence dialect detection explicit instead of defaulting neutral text to es-ES
- adds `isReliable` / `reason` to detection output and renders unknown for insufficient markers
- makes generated browser demo asset extraction symbol-based and adds `node scripts/build-demo.cjs --check` to root tests
- adds static hardening against empty catch blocks and removes one swallowed cleanup failure in MCP tests
- adds demo API malformed-JSON handling and in-memory rate limiting
- adds `--fail-on-warnings=true` gate to eval/certification scripts for launch-style runs

## Probabilistic failure categories addressed
- short-input/low-confidence detection overclaiming
- generated `docs/dialectos-engine.js` drifting from source after edits
- warning-only quality problems passing launch gates
- swallowed errors / empty catch blocks
- demo API abuse or malformed requests surfacing as server errors

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- `pnpm dialect:eval -- --out=/tmp/dialectos-detection-drift-eval`
- `pnpm dialect:eval -- --fixtures=packages/cli/src/__tests__/fixtures/dialect-adversarial --out=/tmp/dialectos-detection-drift-adversarial`
- `node scripts/build-demo.cjs --check`
- `git diff --check`
- npm pack dry-run guard for all publishable packages
