### PR TITLE
Judge web demo provider output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-728%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-729%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 728 tests passing
+pnpm test        # 729 tests passing
 ```
 
 ---
@@ -233,14 +233,14 @@ pnpm test        # 728 tests passing
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
 | [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 313 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 314 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 728 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 729 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
         <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        728 tests passing · BSL 1.1 · Full-app demo
+        729 tests passing · BSL 1.1 · Full-app demo
       </div>
       <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
         <span class="gradient-text">DialectOS</span>
@@ -57,7 +57,7 @@
     <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
       <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
       <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">728</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
+      <div><div class="text-3xl font-bold text-emerald-400">729</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
       <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">728</div>
+                    <div class="stat-value">729</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">728 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">729 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/packages/cli/src/__tests__/web-demo-service.test.ts
+++ b/packages/cli/src/__tests__/web-demo-service.test.ts
@@ -14,7 +14,7 @@ function makeProvider(
   return {
     name,
     translate: vi.fn(async (text: string, sourceLang: string, targetLang: string, options) => ({
-      translatedText: `[${options?.dialect}] ${text}`,
+      translatedText: options?.dialect === "es-MX" && text.includes("file") ? "Recoge el archivo antes del despliegue." : `[${options?.dialect}] ${text}`,
       sourceLang,
       targetLang,
       provider: name as never,
@@ -47,7 +47,7 @@ describe("web demo service", () => {
       provider: "auto",
     }, registry);
 
-    expect(result.translatedText).toBe("[es-MX] Pick up the file before you park the car.");
+    expect(result.translatedText).toBe("Recoge el archivo antes del despliegue.");
     expect(result.providerUsed).toBe("llm");
     expect(result.semanticPromptApplied).toBe(true);
     expect(result.providerStatus.semanticProviders).toEqual(["llm"]);
@@ -115,6 +115,21 @@ describe("web demo service", () => {
       dialect: "es-MX",
     }, registry)).rejects.toThrow(/All semantic demo providers failed/);
     expect(generic.translate).not.toHaveBeenCalled();
+  });
+
+  it("rejects provider output that fails the quality judge", async () => {
+    const registry = new ProviderRegistry();
+    const provider = makeProvider("llm");
+    vi.mocked(provider.translate).mockResolvedValue({
+      translatedText: "Recoger the file before deploying.",
+      provider: "llm" as never,
+    });
+    registry.register(provider);
+
+    await expect(translateForWebDemo({
+      text: "Pick up the file before deployment.",
+      dialect: "es-MX",
+    }, registry)).rejects.toThrow(/Provider output failed quality judge/);
   });
 
   it("reports missing providers instead of falling back to static rule substitutions", async () => {

--- a/packages/cli/src/lib/web-demo-service.ts
+++ b/packages/cli/src/lib/web-demo-service.ts
@@ -3,6 +3,8 @@ import type { FormalityLevel, SpanishDialect } from "@espanol/types";
 import { ALL_SPANISH_DIALECTS } from "@espanol/types";
 import { validateContentLength } from "@espanol/security";
 import { detectDialect } from "./dialect-info.js";
+import { buildLexicalAmbiguityExpectations } from "./lexical-ambiguity.js";
+import { judgeTranslationOutput } from "./output-judge.js";
 import { createProviderRegistry } from "./provider-factory.js";
 import { buildSemanticTranslationContext } from "./semantic-context.js";
 
@@ -113,6 +115,21 @@ export async function translateForWebDemo(
       context: semanticContext,
     },
   );
+  const lexicalExpectations = buildLexicalAmbiguityExpectations(text, dialect);
+  const judge = judgeTranslationOutput({
+    source: text,
+    register: formality,
+    documentKind: "plain",
+    requiredOutputGroups: lexicalExpectations.requiredOutputGroups,
+    forbiddenOutputTerms: lexicalExpectations.forbiddenOutputTerms,
+  }, dialect, translated.translatedText);
+  if (judge.blockingIssues.length > 0) {
+    throw new Error(
+      `Provider output failed quality judge: ${
+        judge.blockingIssues.map((issue) => `${issue.category}/${issue.severity}: ${issue.message}`).join("; ")
+      }`
+    );
+  }
 
   return {
     translatedText: translated.translatedText,


### PR DESCRIPTION
## Summary
- applies the deterministic output judge to the full-app web demo path
- passes lexical ambiguity required groups/forbidden terms into the judge
- rejects low-quality provider output before it reaches the browser
- adds regression coverage for mixed English/Spanish output from the demo service
- updates test count to 729

## Why
The first VPS smoke proved the route worked but exposed a weak output (`Recoger the file before deploying.`). Model choice matters, but the product surface also needs a quality gate so bad provider output is visible as an error, not presented as a valid translation.

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- focused `web-demo-service` tests
- npm pack dry-run guard
