### PR TITLE
Modernize production demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-729%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-730%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 729 tests passing
+pnpm test        # 730 tests passing
 ```
 
 ---
@@ -240,7 +240,7 @@ pnpm test        # 729 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 729 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 730 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/docs/__tests__/demo-contract.test.mjs
+++ b/docs/__tests__/demo-contract.test.mjs
@@ -6,10 +6,10 @@ const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
 const engine = readFileSync(new URL("../dialectos-engine.js", import.meta.url), "utf8");
 
 test("docs demo is wired to the full app backend", () => {
-  assert.match(html, /Full-App Translator/);
+  assert.match(html, /Full-app translator/i);
   assert.match(html, /fetch\('\/api\/translate'/);
-  assert.match(html, /browser → local demo backend → provider registry → LLM semantic dialect prompt/);
-  assert.match(html, /Translate with Full App/);
+  assert.match(html, /browser to backend, backend to provider registry/);
+  assert.match(html, /Translate with full app/i);
 });
 
 test("docs demo never silently falls back to static rule substitutions", () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,354 +3,367 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DialectOS — Full-App Spanish Dialect Translation Demo</title>
-  <meta name="description" content="Run the full DialectOS translation stack from the browser through a local backend and configured LLM/provider.">
-  <script src="https://cdn.tailwindcss.com"></script>
+  <title>DialectOS — Spanish Dialect Translation QA</title>
+  <meta name="description" content="Test full-stack, provider-backed Spanish dialect translation across regional variants with quality gates and provider receipts.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230f172a'/%3E%3Cpath d='M14 40c10-22 26-22 36 0' fill='none' stroke='%2338bdf8' stroke-width='6' stroke-linecap='round'/%3E%3Ccircle cx='32' cy='32' r='8' fill='%23818cf8'/%3E%3C/svg%3E">
   <style>
-    body { font-family: 'Inter', sans-serif; background: #0f172a; color: #e2e8f0; }
-    .gradient-text { background: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-    .glass { background: rgba(30, 41, 59, 0.6); backdrop-filter: blur(12px); border: 1px solid rgba(148, 163, 184, 0.1); }
-    .glass-hover:hover { border-color: rgba(56, 189, 248, 0.3); }
-    .change { background: rgba(34, 197, 94, 0.15); color: #4ade80; padding: 0 3px; border-radius: 3px; font-weight: 500; }
-    .del { background: rgba(239, 68, 68, 0.15); color: #f87171; text-decoration: line-through; padding: 0 3px; border-radius: 3px; }
-    textarea:focus, select:focus { outline: none; box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2); }
-    .dialect-card { transition: all 0.2s; cursor: pointer; }
-    .dialect-card:hover { transform: translateY(-2px); border-color: rgba(56, 189, 248, 0.4); }
-    @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
-    .fade-in { animation: fadeIn 0.3s ease; }
-    .confidence-bar { transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1); }
+    :root {
+      color-scheme: dark;
+      --bg: #060914;
+      --panel: rgba(15, 23, 42, 0.78);
+      --panel-strong: rgba(15, 23, 42, 0.94);
+      --line: rgba(148, 163, 184, 0.18);
+      --muted: #94a3b8;
+      --text: #e5eefb;
+      --text-soft: #cbd5e1;
+      --sky: #38bdf8;
+      --violet: #8b5cf6;
+      --emerald: #34d399;
+      --amber: #f59e0b;
+      --rose: #fb7185;
+      --shadow: 0 24px 80px rgba(2, 6, 23, 0.55);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      min-height: 100vh;
+      margin: 0;
+      background:
+        radial-gradient(circle at 14% 8%, rgba(56, 189, 248, 0.22), transparent 32rem),
+        radial-gradient(circle at 86% 4%, rgba(139, 92, 246, 0.26), transparent 30rem),
+        linear-gradient(180deg, #070b18 0%, #0f172a 50%, #050814 100%);
+      color: var(--text);
+    }
+
+    a { color: inherit; }
+    button, select, textarea { font: inherit; }
+    button { cursor: pointer; }
+    code { color: #7dd3fc; }
+
+    .shell { width: min(1180px, calc(100% - 32px)); margin: 0 auto; }
+    .nav { display: flex; align-items: center; justify-content: space-between; padding: 24px 0; }
+    .brand { display: flex; gap: 12px; align-items: center; font-weight: 800; letter-spacing: -0.03em; }
+    .mark { width: 38px; height: 38px; border-radius: 13px; background: linear-gradient(135deg, var(--sky), var(--violet)); display: grid; place-items: center; box-shadow: 0 12px 36px rgba(56, 189, 248, .24); }
+    .mark::after { content: "D"; color: white; font-weight: 800; }
+    .navlinks { display: flex; gap: 10px; align-items: center; color: var(--muted); font-size: 14px; }
+    .navlinks a { text-decoration: none; padding: 9px 12px; border: 1px solid transparent; border-radius: 999px; }
+    .navlinks a:hover { border-color: var(--line); color: white; background: rgba(255,255,255,.04); }
+
+    .hero { padding: 52px 0 32px; display: grid; grid-template-columns: 1.05fr .95fr; gap: 34px; align-items: center; }
+    .eyebrow { display: inline-flex; align-items: center; gap: 8px; color: #bae6fd; border: 1px solid rgba(56, 189, 248, .28); background: rgba(14, 165, 233, .09); padding: 8px 12px; border-radius: 999px; font-size: 13px; font-weight: 700; }
+    .pulse { width: 8px; height: 8px; border-radius: 999px; background: var(--emerald); box-shadow: 0 0 0 6px rgba(52,211,153,.12); }
+    h1 { font-size: clamp(46px, 8vw, 86px); line-height: .9; letter-spacing: -0.08em; margin: 22px 0 20px; }
+    .gradient { background: linear-gradient(135deg, #e0f2fe 0%, #38bdf8 38%, #a78bfa 78%, #f0abfc 100%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .lede { color: var(--text-soft); font-size: clamp(17px, 2vw, 21px); line-height: 1.7; max-width: 720px; }
+    .ctaRow { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
+    .btn { border: 0; border-radius: 16px; padding: 13px 18px; font-weight: 800; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; gap: 8px; transition: transform .18s ease, background .18s ease, border-color .18s ease; }
+    .btn:hover { transform: translateY(-1px); }
+    .btn-primary { background: linear-gradient(135deg, #0284c7, #7c3aed); color: white; box-shadow: 0 16px 48px rgba(56, 189, 248, .2); }
+    .btn-ghost { background: rgba(15, 23, 42, .65); border: 1px solid var(--line); color: var(--text-soft); }
+
+    .hero-card { border: 1px solid var(--line); background: linear-gradient(180deg, rgba(15,23,42,.78), rgba(15,23,42,.5)); border-radius: 28px; padding: 20px; box-shadow: var(--shadow); backdrop-filter: blur(18px); }
+    .receipt { display: grid; gap: 12px; }
+    .receipt-row { display: flex; justify-content: space-between; align-items: center; padding: 15px; border-radius: 18px; background: rgba(2, 6, 23, .42); border: 1px solid rgba(148,163,184,.1); }
+    .receipt-label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+    .receipt-value { font-weight: 800; text-align: right; }
+    .ok { color: var(--emerald); } .warn { color: var(--amber); } .bad { color: var(--rose); }
+
+    .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin: 28px 0 44px; }
+    .stat { border: 1px solid var(--line); background: rgba(15, 23, 42, .56); border-radius: 22px; padding: 20px; text-align: center; }
+    .stat strong { display: block; font-size: 32px; letter-spacing: -0.04em; }
+    .stat span { color: var(--muted); font-size: 13px; }
+
+    .panel { border: 1px solid var(--line); background: var(--panel); border-radius: 30px; padding: clamp(18px, 3vw, 30px); box-shadow: var(--shadow); backdrop-filter: blur(18px); }
+    .status { border-radius: 20px; padding: 16px 18px; margin-bottom: 22px; border: 1px solid rgba(245,158,11,.28); background: rgba(245,158,11,.1); color: #fde68a; }
+    .status.ready { border-color: rgba(52,211,153,.3); background: rgba(52,211,153,.1); color: #bbf7d0; }
+    .status.error { border-color: rgba(251,113,133,.36); background: rgba(251,113,133,.1); color: #fecdd3; }
+
+    .toolbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; margin-bottom: 22px; }
+    .toolbar h2 { margin: 0 0 6px; font-size: 26px; letter-spacing: -0.04em; }
+    .toolbar p { margin: 0; color: var(--muted); }
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+    .chip { border: 1px solid var(--line); background: rgba(15, 23, 42, .78); color: var(--text-soft); border-radius: 999px; padding: 8px 11px; font-size: 12px; font-weight: 700; }
+    .chip:hover { border-color: rgba(56,189,248,.42); color: white; }
+
+    .translator-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
+    label { display: block; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .09em; font-weight: 800; margin: 0 0 9px; }
+    .field-head { display: flex; justify-content: space-between; gap: 10px; align-items: center; }
+    textarea, select { width: 100%; color: var(--text); background: rgba(2, 6, 23, .7); border: 1px solid rgba(148,163,184,.22); border-radius: 18px; outline: 0; }
+    textarea { min-height: 210px; padding: 16px; resize: vertical; line-height: 1.6; }
+    select { padding: 13px 14px; margin-bottom: 12px; }
+    textarea:focus, select:focus { border-color: rgba(56,189,248,.6); box-shadow: 0 0 0 4px rgba(56,189,248,.12); }
+    .translate-btn { width: 100%; margin-bottom: 12px; }
+    .output { min-height: 148px; white-space: pre-wrap; line-height: 1.65; color: #dbeafe; background: rgba(2, 6, 23, .54); border: 1px solid rgba(148,163,184,.18); border-radius: 18px; padding: 16px; }
+    .placeholder { color: #64748b; font-style: italic; }
+
+    .execution { margin-top: 18px; display: none; }
+    .execution.show { display: block; }
+    .receipt-pills { display: flex; flex-wrap: wrap; gap: 8px; }
+    .pill { border-radius: 999px; border: 1px solid rgba(56,189,248,.22); background: rgba(14,165,233,.08); color: #bae6fd; font-weight: 800; font-size: 12px; padding: 8px 10px; }
+
+    .detect { display: none; margin-top: 18px; border: 1px solid var(--line); background: rgba(2,6,23,.35); border-radius: 20px; padding: 16px; align-items: center; gap: 14px; }
+    .detect.show { display: flex; }
+    .flag { font-size: 34px; } .detect-code { font-weight: 900; } .detect-name { color: var(--muted); font-size: 13px; }
+
+    .vocab, .dialects { margin: 40px 0; }
+    .section-title { text-align: center; margin-bottom: 18px; }
+    .section-title h2 { margin: 0 0 8px; font-size: 30px; letter-spacing: -0.05em; }
+    .section-title p { margin: 0; color: var(--muted); }
+    .table-wrap { overflow-x: auto; border-radius: 24px; border: 1px solid var(--line); background: rgba(15,23,42,.58); }
+    table { width: 100%; border-collapse: collapse; min-width: 800px; }
+    th, td { padding: 13px 14px; border-bottom: 1px solid rgba(148,163,184,.1); text-align: left; }
+    th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+    td:first-child { color: #7dd3fc; font-weight: 900; }
+    .dialect-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .dialect-card { border: 1px solid var(--line); background: rgba(15,23,42,.52); border-radius: 20px; padding: 15px; text-align: center; cursor: pointer; transition: transform .18s ease, border-color .18s ease; }
+    .dialect-card:hover { transform: translateY(-2px); border-color: rgba(56,189,248,.5); }
+    .dialect-card .emoji { font-size: 26px; display: block; margin-bottom: 5px; }
+    .dialect-card strong { display: block; } .dialect-card small { color: var(--muted); }
+
+    footer { color: var(--muted); padding: 44px 0 60px; text-align: center; }
+    footer a { color: #7dd3fc; text-decoration: none; }
+
+    @media (max-width: 900px) {
+      .hero, .translator-grid { grid-template-columns: 1fr; }
+      .stats { grid-template-columns: repeat(2, 1fr); }
+      .toolbar { flex-direction: column; }
+      .chips { justify-content: flex-start; }
+      .dialect-grid { grid-template-columns: repeat(2, 1fr); }
+      .navlinks { display: none; }
+    }
   </style>
 </head>
-<body class="min-h-screen">
-  <!-- Hero -->
-  <header class="relative overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-b from-sky-900/20 to-transparent"></div>
-    <div class="relative max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
-      <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-sky-500/10 border border-sky-500/20 text-sky-400 text-sm font-medium mb-6">
-        <span class="w-2 h-2 rounded-full bg-sky-400 animate-pulse"></span>
-        729 tests passing · BSL 1.1 · Full-app demo
-      </div>
-      <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5">
-        <span class="gradient-text">DialectOS</span>
-      </h1>
-      <p class="text-lg text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-        This page now drives the <strong class="text-slate-200">full DialectOS app path</strong>:
-        browser → local demo backend → provider registry → LLM semantic dialect prompt.
-        Start it with <code class="text-sky-300">pnpm demo</code> or the Docker Compose demo, then test real translations without exposing model keys in the browser.
-      </p>
-      <div class="flex flex-wrap justify-center gap-3">
-        <a href="https://github.com/Pastorsimon1798/DialectOS" class="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-xl font-semibold text-sm transition-colors flex items-center gap-2">
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-          Star on GitHub
-        </a>
-        <a href="#translate" class="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 rounded-xl font-semibold text-sm text-white transition-colors">
-          Run Full Demo →
-        </a>
+<body>
+  <nav class="shell nav">
+    <div class="brand"><span class="mark"></span><span>DialectOS</span></div>
+    <div class="navlinks">
+      <a href="#translate">Demo</a>
+      <a href="https://github.com/Pastorsimon1798/DialectOS">GitHub</a>
+      <a href="docs/full-app-demo.md">Container guide</a>
+    </div>
+  </nav>
+
+  <header class="shell hero">
+    <div>
+      <div class="eyebrow"><span class="pulse"></span>729 tests · semantic provider demo · no static fallback</div>
+      <h1><span class="gradient">Spanish that knows where it is going.</span></h1>
+      <p class="lede">DialectOS routes your text through the real app path: browser to backend, backend to provider registry, provider to a semantic dialect prompt, and output through deterministic quality gates before anything reaches the page.</p>
+      <div class="ctaRow">
+        <a class="btn btn-primary" href="#translate">Test a dialect</a>
+        <a class="btn btn-ghost" href="https://github.com/Pastorsimon1798/DialectOS">View source</a>
       </div>
     </div>
+    <aside class="hero-card" aria-label="Runtime receipt">
+      <div class="receipt">
+        <div class="receipt-row"><span class="receipt-label">Inference</span><span class="receipt-value">Tailscale LM Studio</span></div>
+        <div class="receipt-row"><span class="receipt-label">Quality gate</span><span class="receipt-value ok">Output judge enabled</span></div>
+        <div class="receipt-row"><span class="receipt-label">Fallback policy</span><span class="receipt-value">No static fallback</span></div>
+        <div class="receipt-row"><span class="receipt-label">Demo status</span><span id="heroStatus" class="receipt-value warn">checking…</span></div>
+      </div>
+    </aside>
   </header>
 
-  <!-- Stats -->
-  <section class="max-w-4xl mx-auto px-6 mb-10">
-    <div class="glass rounded-2xl p-5 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-      <div><div class="text-3xl font-bold text-sky-400">25</div><div class="text-sm text-slate-500 mt-1">Dialects</div></div>
-      <div><div class="text-3xl font-bold text-violet-400">200+</div><div class="text-sm text-slate-500 mt-1">Vocabulary Rules</div></div>
-      <div><div class="text-3xl font-bold text-emerald-400">729</div><div class="text-sm text-slate-500 mt-1">Tests</div></div>
-      <div><div class="text-3xl font-bold text-amber-400">3</div><div class="text-sm text-slate-500 mt-1">Registers</div></div>
-    </div>
+  <section class="shell stats" aria-label="Project stats">
+    <div class="stat"><strong>25</strong><span>regional variants</span></div>
+    <div class="stat"><strong>728+</strong><span>repo tests</span></div>
+    <div class="stat"><strong>LLM</strong><span>semantic provider required</span></div>
+    <div class="stat"><strong>MQM</strong><span>launch-audit framing</span></div>
   </section>
 
-  <!-- Main Full-App Demo -->
-  <section id="translate" class="max-w-5xl mx-auto px-6 mb-14">
-    <div class="glass rounded-2xl p-6 md:p-8">
-      <div id="backendStatus" class="mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
-        <strong class="text-amber-200">Backend status:</strong>
-        checking <code>/api/status</code>… If you opened this on static GitHub Pages, start the full app locally with
-        <code class="text-sky-300">pnpm demo</code> or use the Docker Compose instructions.
-      </div>
+  <main class="shell">
+    <section id="translate" class="panel">
+      <div id="backendStatus" class="status"><strong>Backend status:</strong> checking /api/status…</div>
 
-      <!-- Toolbar -->
-      <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-5">
+      <div class="toolbar">
         <div>
-          <h2 class="text-xl font-semibold text-slate-200">Full-App Translator</h2>
-          <p class="text-sm text-slate-500 mt-0.5">Type text, pick a dialect, then call the backend that uses the real provider stack and semantic dialect prompts.</p>
+          <h2>Full-app translator</h2>
+          <p>Use short, adversarial inputs. If the provider output is weak, the judge rejects it visibly.</p>
         </div>
-        <div class="flex gap-2 flex-wrap">
-          <button onclick="loadPreset('es-mx')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇲🇽 → Mexico</button>
-          <button onclick="loadPreset('es-ar')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇦🇷 → Argentina</button>
-          <button onclick="loadPreset('es-co')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇨🇴 → Colombia</button>
-          <button onclick="loadPreset('es-cl')" class="px-3 py-1.5 text-xs rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors">🇨🇱 → Chile</button>
+        <div class="chips">
+          <button class="chip" data-preset="es-mx">Mexico stress</button>
+          <button class="chip" data-preset="es-pr">Puerto Rico pickup</button>
+          <button class="chip" data-preset="es-cl">Chile food</button>
+          <button class="chip" data-preset="es-ar">Argentina voseo</button>
         </div>
       </div>
 
-      <!-- Two-column layout -->
-      <div class="grid md:grid-cols-2 gap-5">
-        <!-- Source -->
+      <div class="translator-grid">
         <div>
-          <div class="flex items-center justify-between mb-2">
-            <label class="text-xs font-medium text-slate-400 uppercase tracking-wider">Source</label>
-            <span id="detectedSource" class="text-xs text-slate-500">—</span>
-          </div>
-          <textarea id="sourceText" rows="6" class="w-full bg-slate-900/80 border border-slate-700 rounded-xl p-4 text-slate-200 placeholder-slate-600 resize-none text-base leading-relaxed font-mono text-sm" placeholder="Escribe en español de España...&#10;&#10;Ejemplo: Vosotros lleváis el ordenador en el coche para ir al piso y comer patatas."></textarea>
+          <div class="field-head"><label for="sourceText">Source</label><span id="detectedSource" class="detect-name">—</span></div>
+          <textarea id="sourceText" placeholder="Try: Pick up the package from reception."></textarea>
         </div>
-
-        <!-- Target -->
         <div>
-          <div class="flex items-center justify-between mb-2">
-            <label class="text-xs font-medium text-slate-400 uppercase tracking-wider">Target Dialect</label>
-          </div>
-          <select id="targetDialect" class="w-full bg-slate-900/80 border border-slate-700 rounded-xl p-3 text-slate-200 text-sm mb-3 cursor-pointer">
-            <option value="es-MX">🇲🇽 Mexico (es-MX)</option>
-            <option value="es-AR">🇦🇷 Argentina (es-AR)</option>
-            <option value="es-CO">🇨🇴 Colombia (es-CO)</option>
-            <option value="es-CL">🇨🇱 Chile (es-CL)</option>
-            <option value="es-VE">🇻🇪 Venezuela (es-VE)</option>
-            <option value="es-PE">🇵🇪 Peru (es-PE)</option>
-            <option value="es-UY">🇺🇾 Uruguay (es-UY)</option>
-            <option value="es-PY">🇵🇾 Paraguay (es-PY)</option>
-            <option value="es-BO">🇧🇴 Bolivia (es-BO)</option>
-            <option value="es-EC">🇪🇨 Ecuador (es-EC)</option>
-            <option value="es-GT">🇬🇹 Guatemala (es-GT)</option>
-            <option value="es-HN">🇭🇳 Honduras (es-HN)</option>
-            <option value="es-SV">🇸🇻 El Salvador (es-SV)</option>
-            <option value="es-NI">🇳🇮 Nicaragua (es-NI)</option>
-            <option value="es-CR">🇨🇷 Costa Rica (es-CR)</option>
-            <option value="es-PA">🇵🇦 Panama (es-PA)</option>
-            <option value="es-CU">🇨🇺 Cuba (es-CU)</option>
-            <option value="es-DO">🇩🇴 Dominican Rep. (es-DO)</option>
-            <option value="es-PR">🇵🇷 Puerto Rico (es-PR)</option>
-            <option value="es-GQ">🇬🇶 Eq. Guinea (es-GQ)</option>
-            <option value="es-US">🇺🇸 U.S. Spanish (es-US)</option>
-            <option value="es-PH">🇵🇭 Philippines (es-PH)</option>
-            <option value="es-BZ">🇧🇿 Belize (es-BZ)</option>
-            <option value="es-AD">🇦🇩 Andorra (es-AD)</option>
-            <option value="es-ES">🇪🇸 Spain (es-ES)</option>
-          </select>
-          <button id="translateButton" onclick="translate()" class="w-full mb-3 px-4 py-3 bg-sky-600 hover:bg-sky-500 rounded-xl font-semibold text-sm text-white transition-colors">
-            Translate with Full App
-          </button>
-          <div id="outputBox" class="w-full bg-slate-900/50 border border-slate-700 rounded-xl p-4 text-slate-300 text-sm leading-relaxed min-h-[160px] font-mono">
-            <span class="text-slate-600 italic">Start the full app demo backend, type text, then click Translate with Full App...</span>
-          </div>
+          <label for="targetDialect">Target dialect</label>
+          <select id="targetDialect"></select>
+          <button id="translateButton" class="btn btn-primary translate-btn">Translate with full app</button>
+          <div id="outputBox" class="output"><span class="placeholder">Type text and run a provider-backed translation.</span></div>
         </div>
       </div>
 
-      <!-- Changes panel -->
-      <div id="changesPanel" class="mt-5 hidden">
-        <div class="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">Full-App Execution</div>
-        <div id="changesList" class="flex flex-wrap gap-2"></div>
+      <div id="changesPanel" class="execution">
+        <label>Execution receipt</label>
+        <div id="changesList" class="receipt-pills"></div>
       </div>
 
-      <!-- Detection mini-panel -->
-      <div id="detectPanel" class="mt-5 hidden fade-in">
-        <div class="glass rounded-xl p-4 flex flex-col md:flex-row items-start md:items-center gap-4">
-          <div class="flex items-center gap-3">
-            <span id="detectFlag" class="text-3xl">🇪🇸</span>
-            <div>
-              <div id="detectCode" class="text-lg font-bold text-slate-100">es-ES</div>
-              <div id="detectName" class="text-sm text-slate-400">Spain</div>
-            </div>
-          </div>
-          <div class="flex-1 w-full md:w-auto">
-            <div class="flex justify-between text-xs mb-1"><span class="text-slate-500">Detection confidence</span><span id="detectConf" class="text-slate-300">30%</span></div>
-            <div class="h-1.5 bg-slate-800 rounded-full overflow-hidden"><div id="detectBar" class="confidence-bar h-full rounded-full bg-slate-600" style="width:30%"></div></div>
-          </div>
-          <span id="detectReg" class="px-3 py-1 rounded-lg text-xs font-medium border bg-slate-500/20 text-slate-400 border-slate-500/30">NEUTRAL</span>
-        </div>
+      <div id="detectPanel" class="detect">
+        <span id="detectFlag" class="flag">🌐</span>
+        <div><div id="detectCode" class="detect-code">unknown</div><div id="detectName" class="detect-name">insufficient markers</div></div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Vocabulary Explorer -->
-  <section class="max-w-5xl mx-auto px-6 mb-14">
-    <h2 class="text-2xl font-bold text-center mb-6 text-slate-200">Same word, 25 different ways</h2>
-    <div class="glass rounded-2xl p-5 overflow-x-auto">
-      <table class="w-full text-sm">
-        <thead>
-          <tr class="text-slate-500 border-b border-slate-700">
-            <th class="text-left py-2.5 px-2 font-medium">Word</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇪🇸 Spain</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇲🇽 Mexico</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇦🇷 Argentina</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇨🇴 Colombia</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇨🇱 Chile</th>
-            <th class="text-left py-2.5 px-2 font-medium">🇻🇪 Venezuela</th>
-          </tr>
-        </thead>
-        <tbody class="text-slate-300">
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Computer</td><td class="py-2 px-2">ordenador</td><td class="py-2 px-2">computadora</td><td class="py-2 px-2">computadora</td><td class="py-2 px-2">computador</td><td class="py-2 px-2">computadora</td><td class="py-2 px-2">computadora</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Car</td><td class="py-2 px-2">coche</td><td class="py-2 px-2">carro</td><td class="py-2 px-2">auto</td><td class="py-2 px-2">carro</td><td class="py-2 px-2">auto</td><td class="py-2 px-2">carro</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Potato</td><td class="py-2 px-2">patata</td><td class="py-2 px-2">papa</td><td class="py-2 px-2">papa</td><td class="py-2 px-2">papa</td><td class="py-2 px-2">papa</td><td class="py-2 px-2">papa</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Juice</td><td class="py-2 px-2">zumo</td><td class="py-2 px-2">jugo</td><td class="py-2 px-2">jugo</td><td class="py-2 px-2">jugo</td><td class="py-2 px-2">jugo</td><td class="py-2 px-2">jugo</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Glasses</td><td class="py-2 px-2">gafas</td><td class="py-2 px-2">lentes</td><td class="py-2 px-2">anteojos</td><td class="py-2 px-2">lentes</td><td class="py-2 px-2">lentes</td><td class="py-2 px-2">lentes</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Pen</td><td class="py-2 px-2">bolígrafo</td><td class="py-2 px-2">pluma</td><td class="py-2 px-2">bolígrafo</td><td class="py-2 px-2">esfero</td><td class="py-2 px-2">bolígrafo</td><td class="py-2 px-2">lapicero</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Refrigerator</td><td class="py-2 px-2">frigorífico</td><td class="py-2 px-2">refrigerador</td><td class="py-2 px-2">heladera</td><td class="py-2 px-2">refrigerador</td><td class="py-2 px-2">refrigerador</td><td class="py-2 px-2">refrigerador</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Bean</td><td class="py-2 px-2">judía</td><td class="py-2 px-2">frijol</td><td class="py-2 px-2">poroto</td><td class="py-2 px-2">frijol</td><td class="py-2 px-2">poroto</td><td class="py-2 px-2">caraota</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Peanut</td><td class="py-2 px-2">cacahuete</td><td class="py-2 px-2">cacahuate</td><td class="py-2 px-2">maní</td><td class="py-2 px-2">maní</td><td class="py-2 px-2">maní</td><td class="py-2 px-2">maní</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Strawberry</td><td class="py-2 px-2">fresa</td><td class="py-2 px-2">fresa</td><td class="py-2 px-2">frutilla</td><td class="py-2 px-2">fresa</td><td class="py-2 px-2">frutilla</td><td class="py-2 px-2">fresa</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">Apartment</td><td class="py-2 px-2">piso</td><td class="py-2 px-2">departamento</td><td class="py-2 px-2">departamento</td><td class="py-2 px-2">apartamento</td><td class="py-2 px-2">departamento</td><td class="py-2 px-2">apartamento</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">T-shirt</td><td class="py-2 px-2">camiseta</td><td class="py-2 px-2">camiseta</td><td class="py-2 px-2">camiseta</td><td class="py-2 px-2">camiseta</td><td class="py-2 px-2">polera</td><td class="py-2 px-2">franela</td></tr>
-          <tr class="border-b border-slate-800/50"><td class="py-2 px-2 font-medium text-sky-400">2nd plural</td><td class="py-2 px-2">vosotros</td><td class="py-2 px-2">ustedes</td><td class="py-2 px-2">ustedes</td><td class="py-2 px-2">ustedes</td><td class="py-2 px-2">ustedes</td><td class="py-2 px-2">ustedes</td></tr>
-          <tr><td class="py-2 px-2 font-medium text-sky-400">Cool (slang)</td><td class="py-2 px-2">guay</td><td class="py-2 px-2">chido</td><td class="py-2 px-2">piola</td><td class="py-2 px-2">chévere</td><td class="py-2 px-2">bacán</td><td class="py-2 px-2">chevere</td></tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
+    <section class="vocab">
+      <div class="section-title"><h2>Same concept, different Spanish</h2><p>Examples are orientation aids; production output is provider-backed and judged.</p></div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Concept</th><th>Spain</th><th>Mexico</th><th>Argentina</th><th>Colombia</th><th>Chile</th><th>Puerto Rico</th></tr></thead>
+          <tbody>
+            <tr><td>Computer</td><td>ordenador</td><td>computadora</td><td>computadora</td><td>computador</td><td>computadora</td><td>computadora</td></tr>
+            <tr><td>Car</td><td>coche</td><td>carro</td><td>auto</td><td>carro</td><td>auto</td><td>carro</td></tr>
+            <tr><td>Bus</td><td>autobús</td><td>autobús/camión</td><td>colectivo</td><td>bus</td><td>micro</td><td>guagua</td></tr>
+            <tr><td>Pick up package</td><td>recoger/retirar</td><td>recoger</td><td>retirar</td><td>recoger</td><td>retirar</td><td>recoger</td></tr>
+            <tr><td>Tidy room</td><td>ordenar la habitación</td><td>ordenar el cuarto</td><td>ordenar la pieza</td><td>arreglar el cuarto</td><td>ordenar la pieza</td><td>recoger el cuarto</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-  <!-- All 25 Dialects -->
-  <section class="max-w-5xl mx-auto px-6 mb-16">
-    <h2 class="text-2xl font-bold text-center mb-6 text-slate-200">All 25 Dialects</h2>
-    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3" id="dialectGrid"></div>
-  </section>
+    <section class="dialects">
+      <div class="section-title"><h2>Covered dialects</h2><p>Click any dialect to set the target.</p></div>
+      <div id="dialectGrid" class="dialect-grid"></div>
+    </section>
+  </main>
 
-  <!-- Footer -->
-  <footer class="text-center py-10 text-slate-500 text-sm">
-    <p class="mb-1"><a href="https://github.com/Pastorsimon1798/DialectOS" class="text-sky-400 hover:text-sky-300">DialectOS</a> — BSL 1.1 (Apache-2.0 on 2030-04-20)</p>
-    <p>Made by <a href="https://github.com/Pastorsimon1798" class="text-slate-400 hover:text-slate-300">Pastorsimon1798</a></p>
+  <footer class="shell">
+    <p><a href="https://github.com/Pastorsimon1798/DialectOS">DialectOS</a> — BSL 1.1, Apache-2.0 on 2030-04-20</p>
   </footer>
 
-  <script src="dialectos-engine.js"></script>
   <script>
-    // UI logic only — engine loaded from dialectos-engine.js (actual TypeScript source)
-
     const DIALECT_INFO = {
       'es-ES': 'Spain', 'es-MX': 'Mexico', 'es-AR': 'Argentina', 'es-CO': 'Colombia', 'es-CU': 'Cuba',
       'es-PE': 'Peru', 'es-CL': 'Chile', 'es-VE': 'Venezuela', 'es-UY': 'Uruguay', 'es-PY': 'Paraguay',
       'es-BO': 'Bolivia', 'es-EC': 'Ecuador', 'es-GT': 'Guatemala', 'es-HN': 'Honduras', 'es-SV': 'El Salvador',
-      'es-NI': 'Nicaragua', 'es-CR': 'Costa Rica', 'es-PA': 'Panama', 'es-DO': 'Dominican Rep.', 'es-PR': 'Puerto Rico',
-      'es-GQ': 'Eq. Guinea', 'es-US': 'U.S. Spanish', 'es-PH': 'Philippines', 'es-BZ': 'Belize', 'es-AD': 'Andorra',
+      'es-NI': 'Nicaragua', 'es-CR': 'Costa Rica', 'es-PA': 'Panama', 'es-DO': 'Dominican Republic', 'es-PR': 'Puerto Rico',
+      'es-GQ': 'Equatorial Guinea', 'es-US': 'U.S. Spanish', 'es-PH': 'Philippines', 'es-BZ': 'Belize', 'es-AD': 'Andorra'
+    };
+    const FLAGS = { 'es-ES':'🇪🇸','es-MX':'🇲🇽','es-AR':'🇦🇷','es-CO':'🇨🇴','es-CU':'🇨🇺','es-PE':'🇵🇪','es-CL':'🇨🇱','es-VE':'🇻🇪','es-UY':'🇺🇾','es-PY':'🇵🇾','es-BO':'🇧🇴','es-EC':'🇪🇨','es-GT':'🇬🇹','es-HN':'🇭🇳','es-SV':'🇸🇻','es-NI':'🇳🇮','es-CR':'🇨🇷','es-PA':'🇵🇦','es-DO':'🇩🇴','es-PR':'🇵🇷','es-GQ':'🇬🇶','es-US':'🇺🇸','es-PH':'🇵🇭','es-BZ':'🇧🇿','es-AD':'🇦🇩' };
+    const PRESETS = {
+      'es-mx': { text: 'Pick up the file before deployment.', target: 'es-MX' },
+      'es-pr': { text: 'Pick up the package from reception.', target: 'es-PR' },
+      'es-cl': { text: 'Buy avocado for lunch.', target: 'es-CL' },
+      'es-ar': { text: 'You can update your account now.', target: 'es-AR' }
     };
 
-    const FLAGS = { 'es-ES':'🇪🇸','es-MX':'🇲🇽','es-AR':'🇦🇷','es-CO':'🇨🇴','es-CU':'🇨🇺','es-PE':'🇵🇪','es-CL':'🇨🇱','es-VE':'🇻🇪','es-UY':'🇺🇾','es-PY':'🇵🇾','es-BO':'🇧🇴','es-EC':'🇪🇨','es-GT':'🇬🇹','es-HN':'🇭🇳','es-SV':'🇸🇻','es-NI':'🇳🇮','es-CR':'🇨🇷','es-PA':'🇵🇦','es-DO':'🇩🇴','es-PR':'🇵🇷','es-GQ':'🇬🇶','es-US':'🇺🇸','es-PH':'🇵🇭','es-BZ':'🇧🇿','es-AD':'🇦🇩' };
-
-    function escapeHtml(s) {
-      return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-    }
-
     let translateRequestId = 0;
+    const $ = (id) => document.getElementById(id);
+    function escapeHtml(value) { return String(value).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
-    function renderDetection(result) {
-      const detectPanel = document.getElementById('detectPanel');
-      const best = result && result.dialect ? DIALECT_METADATA.find(d => d.code === result.dialect) : null;
-      const detectedLabel = best && result.confidence > 0.2
-        ? FLAGS[best.code] + ' ' + best.code + ' · ' + result.registerHint
-        : 'no high-confidence marker';
-      document.getElementById('detectedSource').textContent = detectedLabel;
-
-      if (best) {
-        document.getElementById('detectFlag').textContent = FLAGS[best.code];
-        document.getElementById('detectCode').textContent = best.code;
-        document.getElementById('detectName').textContent = best.name;
-        document.getElementById('detectConf').textContent = Math.round(result.confidence * 100) + '%';
-        document.getElementById('detectBar').style.width = (result.confidence * 100) + '%';
-        document.getElementById('detectBar').className = 'confidence-bar h-full rounded-full ' + (result.confidence >= 0.7 ? 'bg-emerald-500' : result.confidence >= 0.4 ? 'bg-amber-500' : 'bg-slate-600');
-        const regColors = { slang: 'bg-amber-500/20 text-amber-400 border-amber-500/30', formal: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30', neutral: 'bg-slate-500/20 text-slate-400 border-slate-500/30' };
-        const regEl = document.getElementById('detectReg');
-        regEl.textContent = result.registerHint.toUpperCase();
-        regEl.className = 'px-3 py-1 rounded-lg text-xs font-medium border ' + regColors[result.registerHint];
-        detectPanel.classList.remove('hidden');
-      } else {
-        detectPanel.classList.add('hidden');
-      }
+    function setStatus(status) {
+      const ready = Boolean(status.ready);
+      $('heroStatus').textContent = ready ? 'ready' : 'not ready';
+      $('heroStatus').className = 'receipt-value ' + (ready ? 'ok' : 'warn');
+      $('backendStatus').className = 'status ' + (ready ? 'ready' : 'error');
+      $('backendStatus').innerHTML = '<strong>Backend status:</strong> ' + escapeHtml(status.message || 'unknown') +
+        ' <span style="color:var(--muted)">Providers: ' + escapeHtml((status.providers || []).join(', ') || 'none') + '</span>';
     }
 
     async function refreshBackendStatus() {
-      const statusBox = document.getElementById('backendStatus');
       try {
         const response = await fetch('/api/status', { headers: { accept: 'application/json' } });
         if (!response.ok) throw new Error('status endpoint returned ' + response.status);
-        const status = await response.json();
-        const color = status.configured ? 'emerald' : 'amber';
-        statusBox.className = 'mb-5 rounded-xl border border-' + color + '-400/30 bg-' + color + '-500/10 p-4 text-sm text-' + color + '-100';
-        statusBox.innerHTML = '<strong class="text-' + color + '-200">Backend status:</strong> ' +
-          escapeHtml(status.message || 'connected') +
-          ' <span class="text-slate-400">Providers: ' + escapeHtml((status.providers || []).join(', ') || 'none') + '</span>';
+        setStatus(await response.json());
       } catch (error) {
-        statusBox.className = 'mb-5 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100';
-        statusBox.innerHTML = '<strong class="text-amber-200">Backend status:</strong> full-app backend is not reachable. Run <code class="text-sky-300">pnpm demo</code> and open the local URL. Static GitHub Pages cannot call your local model.';
+        setStatus({ ready: false, providers: [], message: 'full-app backend is not reachable' });
       }
     }
 
-    async function translate() {
-      const requestId = ++translateRequestId;
-      const text = document.getElementById('sourceText').value.trim();
-      const target = document.getElementById('targetDialect').value;
-      const outputBox = document.getElementById('outputBox');
-      const changesPanel = document.getElementById('changesPanel');
-      const changesList = document.getElementById('changesList');
-      const detectPanel = document.getElementById('detectPanel');
+    function renderDetection(result) {
+      if (result && result.isReliable && result.dialect) {
+        $('detectedSource').textContent = `${FLAGS[result.dialect] || '🌐'} ${result.dialect} · ${Math.round(result.confidence * 100)}%`;
+        $('detectFlag').textContent = FLAGS[result.dialect] || '🌐';
+        $('detectCode').textContent = result.dialect;
+        $('detectName').textContent = `${result.name || DIALECT_INFO[result.dialect]} · ${result.registerHint}`;
+        $('detectPanel').classList.add('show');
+      } else {
+        $('detectedSource').textContent = 'unknown · insufficient markers';
+        $('detectFlag').textContent = '🌐';
+        $('detectCode').textContent = 'unknown';
+        $('detectName').textContent = 'insufficient dialect markers';
+        $('detectPanel').classList.add('show');
+      }
+    }
 
+    async function runTranslation() {
+      const requestId = ++translateRequestId;
+      const text = $('sourceText').value.trim();
+      const dialect = $('targetDialect').value;
       if (!text) {
-        outputBox.innerHTML = '<span class="text-slate-600 italic">Start the full app demo backend, type text, then click Translate with Full App...</span>';
-        changesPanel.classList.add('hidden');
-        detectPanel.classList.add('hidden');
-        document.getElementById('detectedSource').textContent = '—';
+        $('outputBox').innerHTML = '<span class="placeholder">Type text and run a provider-backed translation.</span>';
         return;
       }
-
-      outputBox.innerHTML = '<span class="text-sky-300">Calling /api/translate through the full DialectOS backend…</span>';
-      changesPanel.classList.add('hidden');
-
+      $('translateButton').disabled = true;
+      $('translateButton').textContent = 'Judging provider output…';
+      $('outputBox').innerHTML = '<span class="placeholder">Calling /api/translate through the full DialectOS backend…</span>';
+      $('changesPanel').classList.remove('show');
       try {
         const response = await fetch('/api/translate', {
           method: 'POST',
           headers: { 'content-type': 'application/json', accept: 'application/json' },
-          body: JSON.stringify({ text, dialect: target, provider: 'auto', formality: 'auto' }),
+          body: JSON.stringify({ text, dialect, provider: 'auto', formality: 'auto' })
         });
         const result = await response.json().catch(() => ({}));
         if (requestId !== translateRequestId) return;
-        if (!response.ok || result.ok === false) {
-          throw new Error(result.error || ('backend returned ' + response.status));
-        }
-
-        outputBox.innerHTML = escapeHtml(result.translatedText || '');
-        changesPanel.classList.remove('hidden');
-        changesList.innerHTML = [
-          '<span class="px-2.5 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 text-xs font-medium border border-emerald-500/20">provider: ' + escapeHtml(result.providerUsed || 'unknown') + '</span>',
-          '<span class="px-2.5 py-1 rounded-lg bg-sky-500/10 text-sky-300 text-xs font-medium border border-sky-500/20">target: ' + escapeHtml(target) + '</span>',
-          '<span class="px-2.5 py-1 rounded-lg bg-violet-500/10 text-violet-300 text-xs font-medium border border-violet-500/20">fallbacks: ' + escapeHtml(String(result.fallbackCount || 0)) + '</span>',
-        ].join('');
+        if (!response.ok || result.ok === false) throw new Error(result.error || `backend returned ${response.status}`);
+        $('outputBox').innerHTML = escapeHtml(result.translatedText || '');
+        $('changesList').innerHTML = [
+          ['provider', result.providerUsed || 'unknown'],
+          ['target', dialect],
+          ['fallbacks', String(result.fallbackCount || 0)],
+          ['quality', 'judge passed']
+        ].map(([k,v]) => `<span class="pill">${escapeHtml(k)}: ${escapeHtml(v)}</span>`).join('');
+        $('changesPanel').classList.add('show');
         renderDetection(result.sourceDetection);
         refreshBackendStatus();
       } catch (error) {
-        if (requestId !== translateRequestId) return;
-        outputBox.innerHTML = '<span class="text-amber-300">Full-app backend error:</span> ' +
-          escapeHtml(error.message || String(error)) +
-          '<br><br><span class="text-slate-500">Start a provider-backed backend with <code>pnpm demo</code>. No static translation fallback was used.</span>';
-        changesPanel.classList.add('hidden');
-        detectPanel.classList.add('hidden');
+        $('outputBox').innerHTML = '<span class="bad">Full-app backend error:</span> ' + escapeHtml(error.message || String(error)) +
+          '<br><br><span class="placeholder">No static translation fallback was used. Fix the provider/model or source text and retry.</span>';
+      } finally {
+        if (requestId === translateRequestId) {
+          $('translateButton').disabled = false;
+          $('translateButton').textContent = 'Translate with full app';
+        }
       }
     }
-
-    const PRESETS = {
-      'es-mx': { text: 'Vosotros lleváis el ordenador en el coche para ir al piso y comer patatas.', target: 'es-MX' },
-      'es-ar': { text: 'Vosotros lleváis gafas y escribís con bolígrafo en el piso. Después compráis fresas y cacahuetes.', target: 'es-AR' },
-      'es-co': { text: 'Vosotros lleváis el ordenador en el coche para ir al piso y comer judías.', target: 'es-CO' },
-      'es-cl': { text: 'Vosotros usáis la camiseta y coméis fresas con cacahuetes.', target: 'es-CL' },
-    };
 
     function loadPreset(key) {
-      const p = PRESETS[key];
-      document.getElementById('sourceText').value = p.text;
-      document.getElementById('targetDialect').value = p.target;
+      const preset = PRESETS[key];
+      $('sourceText').value = preset.text;
+      $('targetDialect').value = preset.target;
     }
 
-    function renderGrid() {
-      const grid = document.getElementById('dialectGrid');
+    function renderDialects() {
+      const select = $('targetDialect');
+      const grid = $('dialectGrid');
       for (const [code, name] of Object.entries(DIALECT_INFO)) {
-        const div = document.createElement('div');
-        div.className = 'glass rounded-xl p-3 text-center dialect-card';
-        div.innerHTML = '<div class="text-2xl mb-1">' + FLAGS[code] + '</div><div class="text-sm font-medium text-slate-300">' + code + '</div><div class="text-xs text-slate-500">' + name + '</div>';
-        div.onclick = () => { document.getElementById('targetDialect').value = code; };
-        grid.appendChild(div);
+        select.insertAdjacentHTML('beforeend', `<option value="${code}">${FLAGS[code] || '🌐'} ${name} (${code})</option>`);
+        const card = document.createElement('button');
+        card.className = 'dialect-card';
+        card.innerHTML = `<span class="emoji">${FLAGS[code] || '🌐'}</span><strong>${code}</strong><small>${escapeHtml(name)}</small>`;
+        card.addEventListener('click', () => { select.value = code; });
+        grid.appendChild(card);
       }
     }
 
-    renderGrid();
-    loadPreset('es-mx');
-    refreshBackendStatus();
+    document.addEventListener('DOMContentLoaded', () => {
+      renderDialects();
+      loadPreset('es-mx');
+      $('translateButton').addEventListener('click', runTranslation);
+      document.querySelectorAll('[data-preset]').forEach((button) => button.addEventListener('click', () => loadPreset(button.dataset.preset)));
+      refreshBackendStatus();
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">729</div>
+                    <div class="stat-value">730</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">729 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">730 tests • 7 packages • 16 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -150,6 +150,28 @@ test("demo server exposes provider status for the browser UI", async () => {
   }
 });
 
+test("demo server handles favicon without a noisy 404", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      throw new Error("not used");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/favicon.ico`);
+    assert.equal(response.status, 204);
+  } finally {
+    server.close();
+  }
+});
+
 test("demo server rejects malformed JSON as a client error", async () => {
   const { server, baseUrl } = await startTestServer({
     status: () => ({

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -125,6 +125,12 @@ export function createDemoServer(options = {}) {
       const method = req.method || "GET";
       const url = new URL(req.url || "/", "http://127.0.0.1");
 
+      if (method === "GET" && url.pathname === "/favicon.ico") {
+        res.writeHead(204, { "cache-control": "public, max-age=86400" });
+        res.end();
+        return;
+      }
+
       if (method === "GET" && url.pathname === "/api/status") {
         const services = await servicesPromise;
         sendJson(res, 200, { ok: true, ...(await services.status()) });


### PR DESCRIPTION
## Summary
- replaces the production demo page with self-contained CSS and no Tailwind CDN
- removes the obsolete `dialectos-engine.js` browser script dependency
- replaces inline `onclick="translate()"` globals with event listeners and `runTranslation`
- adds a data-URI favicon and `/favicon.ico` 204 handler to avoid noisy browser 404s
- refreshes the visual hierarchy, provider receipts, quality-gate messaging, and mobile layout

## Verification
- `node --test docs/__tests__/demo-contract.test.mjs scripts/__tests__/demo-server.test.mjs`
- `pnpm build`
- `pnpm test`
- `git diff --check`
- npm pack dry-run guard
