### PR TITLE
Add research remediation runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Translate, detect, and adapt content across **25 regional Spanish variants** while preserving markdown structure, code comments, and locale file formatting.
 
 [![CI](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/Pastorsimon1798/DialectOS/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-733%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
+[![Tests](https://img.shields.io/badge/tests-737%20passing-brightgreen)](https://github.com/Pastorsimon1798/DialectOS/actions)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
@@ -41,7 +41,7 @@ DialectOS is available as a paid Spanish localization launch audit. We certify y
 | Feature | Google Translate | DeepL API | **DialectOS** |
 |---------|-----------------|-----------|---------------|
 | Spanish dialect awareness | ❌ Generic "Spanish" | ⚠️ Limited variants | ✅ **25 regional variants** |
-| MCP native integration | ❌ | ❌ | ✅ **16 MCP tools** |
+| MCP native integration | ❌ | ❌ | ✅ **17 MCP tools** |
 | Markdown structure preservation | ❌ | ❌ | ✅ **Tables, code blocks, links intact** |
 | i18n locale file support | ❌ | ❌ | ✅ **JSON locale diff & merge** |
 | Gender-neutral language | ❌ | ❌ | ✅ **elles / latine / -x** |
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 733 tests passing
+pnpm test        # 737 tests passing
 ```
 
 ---
@@ -225,6 +225,8 @@ pnpm test        # 733 tests passing
 | `translate_readme` | Full README translation pipeline |
 | `search_glossary` | Search 300+ source-attributed glossary terms |
 | `list_dialects` | List all 25 supported dialects |
+| `research_regional_term` | Research source-backed regional lexeme proposals without mutating runtime data |
+| `research_regional_term` | Research source-backed regional lexeme proposals without mutating runtime data |
 
 ---
 
@@ -232,7 +234,7 @@ pnpm test        # 733 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 16 MCP tools (stdio server) | 85 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 17 MCP tools (stdio server) | 85 |
 | [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 317 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
@@ -240,7 +242,7 @@ pnpm test        # 733 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 733 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 737 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@
 
   <header class="shell hero">
     <div>
-      <div class="eyebrow"><span class="pulse"></span>733 tests · semantic provider demo · no static fallback</div>
+      <div class="eyebrow"><span class="pulse"></span>737 tests · semantic provider demo · no static fallback</div>
       <h1><span class="gradient">Spanish that knows where it is going.</span></h1>
       <p class="lede">DialectOS routes your text through the real app path: browser to backend, backend to provider registry, provider to a semantic dialect prompt, and output through deterministic quality gates before anything reaches the page.</p>
       <div class="ctaRow">
@@ -169,7 +169,7 @@
 
   <section class="shell stats" aria-label="Project stats">
     <div class="stat"><strong>25</strong><span>regional variants</span></div>
-    <div class="stat"><strong>733</strong><span>repo tests</span></div>
+    <div class="stat"><strong>737</strong><span>repo tests</span></div>
     <div class="stat"><strong>LLM</strong><span>semantic provider required</span></div>
     <div class="stat"><strong>MQM</strong><span>launch-audit framing</span></div>
   </section>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <div class="stat-label">Packages</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-value">733</div>
+                    <div class="stat-value">737</div>
                     <div class="stat-label">Tests</div>
                 </div>
                 <div class="stat">
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">733 tests • 7 packages • 16 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">737 tests • 7 packages • 17 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dialect:certify": "node scripts/dialect-certify.mjs",
     "dialect:certify:adversarial": "node scripts/dialect-certify-adversarial.mjs",
     "dialect:certify:documents": "node scripts/dialect-certify-documents.mjs",
-    "dialect:report": "node scripts/dialect-report.mjs"
+    "dialect:report": "node scripts/dialect-report.mjs",
+    "dialect:research": "node packages/cli/dist/index.js research-regional-term"
   },
   "keywords": [
     "spanish",

--- a/packages/cli/src/__tests__/regional-research.test.ts
+++ b/packages/cli/src/__tests__/regional-research.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseDialectList, researchRegionalTerm } from "../lib/regional-research.js";
+
+const sources = [
+  { title: "Puerto Rican food glossary", link: "https://example.com/pr", snippet: "jugo de china means orange juice" },
+];
+
+describe("regional research runtime", () => {
+  it("creates source-backed proposals without mutating runtime data", async () => {
+    const result = await researchRegionalTerm({
+      concept: "orange juice",
+      dialects: ["es-PR", "es-MX"],
+      semanticField: "food-drink",
+      search: async () => sources,
+    });
+
+    expect(result.mode).toBe("research-proposal");
+    expect(result.mutationPolicy).toBe("never-mutates-runtime-data");
+    expect(result.proposals.find((proposal) => proposal.dialect === "es-PR")?.preferred).toContain("jugo de china");
+    expect(result.proposals.find((proposal) => proposal.dialect === "es-MX")?.preferred).toContain("jugo de naranja");
+    expect(result.proposals.every((proposal) => proposal.sources.length > 0)).toBe(true);
+    expect(result.suggestedFixtures.length).toBe(2);
+  });
+
+  it("works without search as an explicit low-evidence proposal", async () => {
+    const result = await researchRegionalTerm({
+      concept: "unknown concept",
+      dialects: ["es-PR"],
+    });
+
+    expect(result.warnings).toContain("No search adapter configured; using built-in priors only.");
+    expect(result.proposals[0].confidence).toBe("low");
+  });
+
+  it("validates dialect lists", () => {
+    expect(parseDialectList("es-PR,es-MX")).toEqual(["es-PR", "es-MX"]);
+    expect(() => parseDialectList("es-XX")).toThrow(/Invalid dialect/);
+  });
+});

--- a/packages/cli/src/commands/research.ts
+++ b/packages/cli/src/commands/research.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { writeOutput } from "../lib/output.js";
+import { parseDialectList, researchRegionalTerm, type RegionalResearchSource } from "../lib/regional-research.js";
+
+export interface ResearchCommandOptions {
+  concept: string;
+  dialects: string;
+  semanticField?: string;
+  out?: string;
+}
+
+async function serperSearch(query: string): Promise<RegionalResearchSource[]> {
+  const apiKey = process.env.SERPER_API_KEY;
+  if (!apiKey) return [];
+  const response = await fetch("https://google.serper.dev/search", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ q: query, num: 5 }),
+  });
+  if (!response.ok) throw new Error(`Serper search failed: ${response.status}`);
+  const data = await response.json() as { organic?: Array<{ title?: string; link?: string; snippet?: string }> };
+  return (data.organic || []).filter((item) => item.title && item.link).map((item) => ({
+    title: item.title!,
+    link: item.link!,
+    snippet: item.snippet,
+  }));
+}
+
+export async function executeResearchRegionalTerm(options: ResearchCommandOptions): Promise<void> {
+  const dialects = parseDialectList(options.dialects);
+  const result = await researchRegionalTerm({
+    concept: options.concept,
+    dialects,
+    semanticField: options.semanticField,
+    search: process.env.SERPER_API_KEY ? serperSearch : undefined,
+  });
+
+  const out = options.out || `audits/research/${new Date().toISOString().slice(0, 10)}-${result.concept.replace(/[^a-z0-9]+/g, "-")}.json`;
+  mkdirSync(out.split("/").slice(0, -1).join("/") || ".", { recursive: true });
+  writeFileSync(out, `${JSON.stringify(result, null, 2)}\n`);
+  writeOutput(JSON.stringify({ out, concept: result.concept, proposals: result.proposals.length, warnings: result.warnings }, null, 2));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { executeBatchTranslate } from "./commands/i18n/batch-translate.js";
 import { executeManageVariants } from "./commands/i18n/manage-variants.js";
 import { executeCheckFormality } from "./commands/i18n/check-formality.js";
 import { executeApplyGenderNeutral } from "./commands/i18n/apply-gender-neutral.js";
+import { executeResearchRegionalTerm } from "./commands/research.js";
 import { getDefaultProviderRegistry } from "./lib/provider-factory.js";
 import { writeError, writeOutput } from "./lib/output.js";
 import { SecurityError, createSafeError } from "@espanol/security";
@@ -144,6 +145,29 @@ program
       };
 
       await executeTranslateApiDocs(input, mergedOptions.dialect!, mergedOptions, () => registry);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeError(message);
+      process.exit(1);
+    }
+  });
+
+// research command
+program
+  .command("research-regional-term")
+  .description("Research a regional term as a source-backed proposal; never mutates runtime translation data")
+  .requiredOption("--concept <concept>", "Concept or phrase to research")
+  .requiredOption("--dialects <dialects>", "Comma-separated dialect codes, e.g. es-PR,es-MX")
+  .option("--semantic-field <field>", "Semantic field, e.g. food-drink", "general")
+  .option("--out <path>", "Output JSON artifact path")
+  .action(async (options) => {
+    try {
+      await executeResearchRegionalTerm({
+        concept: options.concept,
+        dialects: options.dialects,
+        semanticField: options.semanticField,
+        out: options.out,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       writeError(message);

--- a/packages/cli/src/lib/regional-research.ts
+++ b/packages/cli/src/lib/regional-research.ts
@@ -1,0 +1,141 @@
+import type { SpanishDialect } from "@espanol/types";
+import { ALL_SPANISH_DIALECTS } from "@espanol/types";
+
+export type ResearchConfidence = "low" | "medium" | "high";
+
+export interface RegionalResearchSource {
+  title: string;
+  link: string;
+  snippet?: string;
+}
+
+export interface RegionalLexemeProposal {
+  dialect: SpanishDialect;
+  preferred: string[];
+  accepted: string[];
+  forbidden: string[];
+  confidence: ResearchConfidence;
+  rationale: string;
+  sources: RegionalResearchSource[];
+}
+
+export interface RegionalResearchResult {
+  concept: string;
+  semanticField: string;
+  dialects: SpanishDialect[];
+  generatedAt: string;
+  mode: "research-proposal";
+  mutationPolicy: "never-mutates-runtime-data";
+  proposals: RegionalLexemeProposal[];
+  suggestedFixtures: Array<{
+    dialect: SpanishDialect;
+    source: string;
+    requiredOutputGroups: string[][];
+    forbiddenOutputTerms: string[];
+  }>;
+  warnings: string[];
+}
+
+export interface RegionalResearchOptions {
+  concept: string;
+  dialects: SpanishDialect[];
+  semanticField?: string;
+  search?: (query: string) => Promise<RegionalResearchSource[]>;
+  maxSourcesPerDialect?: number;
+}
+
+const ORANGE_JUICE_PRIORS: Record<string, Omit<RegionalLexemeProposal, "sources">> = {
+  "es-PR": {
+    dialect: "es-PR",
+    preferred: ["jugo de china"],
+    accepted: ["jugo de naranja"],
+    forbidden: [],
+    confidence: "high",
+    rationale: "Puerto Rican citrus usage commonly maps china to sweet orange, so orange juice is jugo de china.",
+  },
+  "es-DO": {
+    dialect: "es-DO",
+    preferred: ["jugo de china", "jugo de naranja"],
+    accepted: ["jugo de naranja"],
+    forbidden: [],
+    confidence: "medium",
+    rationale: "Dominican usage may also use china for orange, but jugo de naranja remains broadly accepted.",
+  },
+  "default": {
+    dialect: "es-MX",
+    preferred: ["jugo de naranja"],
+    accepted: ["zumo de naranja"],
+    forbidden: ["jugo de china"],
+    confidence: "medium",
+    rationale: "Outside Puerto Rican/Dominican citrus contexts, naranja is the safer default for orange.",
+  },
+};
+
+function validateDialect(dialect: string): SpanishDialect {
+  if (!ALL_SPANISH_DIALECTS.includes(dialect as SpanishDialect)) {
+    throw new Error(`Invalid dialect: ${dialect}`);
+  }
+  return dialect as SpanishDialect;
+}
+
+function normalizeConcept(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function builtInPrior(concept: string, dialect: SpanishDialect): Omit<RegionalLexemeProposal, "sources"> {
+  if (/orange juice|jugo de china|jugo de naranja/i.test(concept)) {
+    const prior = ORANGE_JUICE_PRIORS[dialect] || ORANGE_JUICE_PRIORS.default;
+    return { ...prior, dialect };
+  }
+  return {
+    dialect,
+    preferred: [],
+    accepted: [],
+    forbidden: [],
+    confidence: "low",
+    rationale: "No built-in prior for this concept yet; use gathered sources for review before promoting data.",
+  };
+}
+
+export function parseDialectList(value: string): SpanishDialect[] {
+  return value.split(",").map((item) => validateDialect(item.trim())).filter(Boolean);
+}
+
+export async function researchRegionalTerm(options: RegionalResearchOptions): Promise<RegionalResearchResult> {
+  const concept = normalizeConcept(options.concept);
+  if (!concept) throw new Error("concept is required");
+  if (options.dialects.length === 0) throw new Error("at least one dialect is required");
+
+  const warnings: string[] = [];
+  const proposals: RegionalLexemeProposal[] = [];
+  const maxSources = options.maxSourcesPerDialect ?? 4;
+
+  for (const dialect of options.dialects) {
+    const prior = builtInPrior(concept, dialect);
+    const query = `${options.concept} ${dialect} regional Spanish term`;
+    let sources: RegionalResearchSource[] = [];
+    if (options.search) {
+      sources = (await options.search(query)).slice(0, maxSources);
+    } else {
+      warnings.push("No search adapter configured; using built-in priors only.");
+    }
+    proposals.push({ ...prior, sources });
+  }
+
+  return {
+    concept,
+    semanticField: options.semanticField || "general",
+    dialects: options.dialects,
+    generatedAt: new Date().toISOString(),
+    mode: "research-proposal",
+    mutationPolicy: "never-mutates-runtime-data",
+    proposals,
+    suggestedFixtures: proposals.map((proposal) => ({
+      dialect: proposal.dialect,
+      source: options.concept,
+      requiredOutputGroups: proposal.preferred.length > 0 ? [proposal.preferred] : [],
+      forbiddenOutputTerms: proposal.forbidden,
+    })),
+    warnings: [...new Set(warnings)],
+  };
+}

--- a/packages/mcp/src/__tests__/security.test.ts
+++ b/packages/mcp/src/__tests__/security.test.ts
@@ -632,7 +632,7 @@ describe("MCP Security Tests", () => {
       const mockServer = { tool: vi.fn() };
       registerTranslatorTools(mockServer as any, { registry: mockRegistry });
 
-      expect(mockServer.tool).toHaveBeenCalledTimes(6);
+      expect(mockServer.tool).toHaveBeenCalledTimes(7);
       const toolNames = vi.mocked(mockServer.tool).mock.calls.map(
         (call) => call[0]
       );
@@ -642,11 +642,12 @@ describe("MCP Security Tests", () => {
         "translate_code_comment",
         "translate_readme",
         "search_glossary",
+        "research_regional_term",
         "list_dialects",
       ]);
     });
 
-    it("should register all 16 tools total", async () => {
+    it("should register all 17 tools total", async () => {
       const { registerDocsTools } = await import("../tools/docs.js");
       const { registerI18nTools } = await import("../tools/i18n.js");
       const { registerTranslatorTools } = await import(
@@ -659,7 +660,7 @@ describe("MCP Security Tests", () => {
       registerI18nTools(mockServer as any, { registry: mockRegistry });
       registerTranslatorTools(mockServer as any, { registry: mockRegistry });
 
-      expect(mockServer.tool).toHaveBeenCalledTimes(16);
+      expect(mockServer.tool).toHaveBeenCalledTimes(17);
     });
   });
 

--- a/packages/mcp/src/__tests__/translator.test.ts
+++ b/packages/mcp/src/__tests__/translator.test.ts
@@ -161,7 +161,7 @@ describe("MCP Translator Tools", () => {
   });
 
   describe("Tool Registration", () => {
-    it("should register all 6 translator tools", async () => {
+    it("should register all 7 translator tools", async () => {
       const { registerTranslatorTools } = await import("../tools/translator.js");
       const mockServer = {
         tool: vi.fn(),
@@ -169,7 +169,7 @@ describe("MCP Translator Tools", () => {
 
       registerTranslatorTools(mockServer as any, { registry: mockRegistry });
 
-      expect(mockServer.tool).toHaveBeenCalledTimes(6);
+      expect(mockServer.tool).toHaveBeenCalledTimes(7);
       const toolNames = vi.mocked(mockServer.tool).mock.calls.map((call) => call[0]);
       expect(toolNames).toContain("translate_text");
       expect(toolNames).toContain("detect_dialect");
@@ -177,6 +177,7 @@ describe("MCP Translator Tools", () => {
       expect(toolNames).toContain("translate_readme");
       expect(toolNames).toContain("search_glossary");
       expect(toolNames).toContain("list_dialects");
+      expect(toolNames).toContain("research_regional_term");
     });
   });
 
@@ -521,6 +522,24 @@ describe("MCP Translator Tools", () => {
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.results).toEqual([]);
       expect(parsedResult.count).toBe(0);
+    });
+  });
+
+
+  describe("research_regional_term tool", () => {
+    it("should produce a non-mutating regional research proposal", async () => {
+      const { registerTranslatorTools } = await import("../tools/translator.js");
+      const mockServer = { tool: vi.fn() };
+      registerTranslatorTools(mockServer as any, { registry: mockRegistry, rateLimiter: mockRateLimiter });
+      const researchCall = vi.mocked(mockServer.tool).mock.calls.find((call) => call[0] === "research_regional_term");
+      expect(researchCall).toBeDefined();
+      const handler = researchCall![3];
+
+      const result = await handler({ concept: "orange juice", dialects: "es-PR,es-MX", semanticField: "food-drink" });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.mutationPolicy).toBe("never-mutates-runtime-data");
+      expect(parsed.proposals.some((proposal: any) => proposal.preferred.includes("jugo de china"))).toBe(true);
+      expect(parsed.proposals.some((proposal: any) => proposal.preferred.includes("jugo de naranja"))).toBe(true);
     });
   });
 

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -1,20 +1,20 @@
 /**
  * MCP Tools for Translation
  *
- * Provides 6 MCP tools:
+ * Provides 7 MCP tools:
  * - translate_text: Translate text to Spanish dialect
  * - detect_dialect: Detect Spanish dialect from text
  * - translate_code_comment: Translate code comments (basic, text extraction)
  * - translate_readme: Translate a README markdown file
  * - search_glossary: Search the built-in glossary
  * - list_dialects: List all Spanish dialects with metadata
+ * - research_regional_term: Create source-backed lexeme proposals without mutating runtime data
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 import type {
-  SpanishDialect,
   ProviderName,
 } from "@espanol/types";
 import { searchGlossary } from "@espanol/types";
@@ -36,6 +36,7 @@ import {
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "../lib/provider-factory.js";
 import { prepareProviderRequest } from "../lib/provider-request.js";
+import { ALL_SPANISH_DIALECTS, type SpanishDialect } from "@espanol/types";
 
 // ============================================================================
 // Types
@@ -72,6 +73,30 @@ interface SearchGlossaryParams {
 }
 
 interface ListDialectsParams {}
+
+interface ResearchRegionalTermParams {
+  concept: string;
+  dialects: string;
+  semanticField?: string;
+}
+
+interface McpRegionalResearchSource {
+  title: string;
+  link: string;
+  snippet?: string;
+}
+
+type McpResearchConfidence = "low" | "medium" | "high";
+
+interface McpRegionalLexemeProposal {
+  dialect: SpanishDialect;
+  preferred: string[];
+  accepted: string[];
+  forbidden: string[];
+  confidence: McpResearchConfidence;
+  rationale: string;
+  sources: McpRegionalResearchSource[];
+}
 
 // ============================================================================
 // Dialect Metadata
@@ -891,6 +916,101 @@ async function handleSearchGlossary(
   }
 }
 
+
+
+function parseMcpDialectList(value: string): SpanishDialect[] {
+  return value.split(",").map((item) => item.trim()).filter(Boolean).map((item) => {
+    if (!ALL_SPANISH_DIALECTS.includes(item as SpanishDialect)) {
+      throw new SecurityError(`Invalid dialect: ${item}`, ErrorCode.INVALID_INPUT);
+    }
+    return item as SpanishDialect;
+  });
+}
+
+function mcpBuiltInResearchPrior(concept: string, dialect: SpanishDialect): Omit<McpRegionalLexemeProposal, "sources"> {
+  if (/orange juice|jugo de china|jugo de naranja/i.test(concept)) {
+    if (dialect === "es-PR") {
+      return { dialect, preferred: ["jugo de china"], accepted: ["jugo de naranja"], forbidden: [], confidence: "high", rationale: "Puerto Rican citrus usage maps china to sweet orange, so orange juice is jugo de china." };
+    }
+    if (dialect === "es-DO") {
+      return { dialect, preferred: ["jugo de china", "jugo de naranja"], accepted: ["jugo de naranja"], forbidden: [], confidence: "medium", rationale: "Dominican usage may use china for orange, while jugo de naranja remains broadly accepted." };
+    }
+    return { dialect, preferred: ["jugo de naranja"], accepted: ["zumo de naranja"], forbidden: ["jugo de china"], confidence: "medium", rationale: "Outside PR/DO citrus contexts, naranja is the safer default for orange." };
+  }
+  return { dialect, preferred: [], accepted: [], forbidden: [], confidence: "low", rationale: "No built-in prior for this concept yet; use gathered sources for review before promoting data." };
+}
+
+async function researchRegionalTermMcp(params: ResearchRegionalTermParams, search?: (query: string) => Promise<McpRegionalResearchSource[]>) {
+  const concept = params.concept.trim();
+  if (!concept) throw new SecurityError("Concept cannot be empty", ErrorCode.INVALID_INPUT);
+  const dialects = parseMcpDialectList(params.dialects);
+  const warnings: string[] = [];
+  const proposals: McpRegionalLexemeProposal[] = [];
+  for (const dialect of dialects) {
+    const prior = mcpBuiltInResearchPrior(concept, dialect);
+    const sources = search ? await search(`${concept} ${dialect} regional Spanish term`) : [];
+    if (!search) warnings.push("No search adapter configured; using built-in priors only.");
+    proposals.push({ ...prior, sources: sources.slice(0, 4) });
+  }
+  return {
+    concept: concept.toLowerCase(),
+    semanticField: params.semanticField || "general",
+    dialects,
+    generatedAt: new Date().toISOString(),
+    mode: "research-proposal",
+    mutationPolicy: "never-mutates-runtime-data",
+    proposals,
+    suggestedFixtures: proposals.map((proposal) => ({
+      dialect: proposal.dialect,
+      source: concept,
+      requiredOutputGroups: proposal.preferred.length ? [proposal.preferred] : [],
+      forbiddenOutputTerms: proposal.forbidden,
+    })),
+    warnings: [...new Set(warnings)],
+  };
+}
+
+async function serperSearch(query: string): Promise<McpRegionalResearchSource[]> {
+  const apiKey = process.env.SERPER_API_KEY;
+  if (!apiKey) return [];
+  const response = await fetch("https://google.serper.dev/search", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ q: query, num: 5 }),
+  });
+  if (!response.ok) throw new Error(`Serper search failed: ${response.status}`);
+  const data = await response.json() as { organic?: Array<{ title?: string; link?: string; snippet?: string }> };
+  return (data.organic || []).filter((item) => item.title && item.link).map((item) => ({
+    title: item.title!,
+    link: item.link!,
+    snippet: item.snippet,
+  }));
+}
+
+async function handleResearchRegionalTerm(
+  params: ResearchRegionalTermParams,
+  _registry: ProviderRegistry,
+  rateLimiter: RateLimiter
+): Promise<ToolResult> {
+  try {
+    await rateLimiter.acquire();
+    validateContentLength(params.concept);
+    const result = await researchRegionalTermMcp(params, process.env.SERPER_API_KEY ? serperSearch : undefined);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+    };
+  } catch (error) {
+    const safeError = createSafeError(error);
+    return {
+      content: [{ type: "text", text: JSON.stringify({ error: safeError.code, message: safeError.error }) }],
+      isError: true,
+    };
+  }
+}
+
 /**
  * Handle list_dialects tool
  */
@@ -1021,6 +1141,20 @@ export function registerTranslatorTools(
     },
     async (params) => {
       return handleSearchGlossary(params as SearchGlossaryParams, registry, rateLimiter);
+    }
+  );
+
+  // Register research_regional_term tool
+  server.tool(
+    "research_regional_term",
+    "Research a regional term as a source-backed proposal; does not mutate runtime translation data",
+    {
+      concept: z.string().describe("Concept or phrase to research, e.g. orange juice"),
+      dialects: z.string().describe("Comma-separated dialect codes, e.g. es-PR,es-MX"),
+      semanticField: z.string().optional().describe("Semantic field, e.g. food-drink"),
+    },
+    async (params) => {
+      return handleResearchRegionalTerm(params as ResearchRegionalTermParams, registry, rateLimiter);
     }
   );
 


### PR DESCRIPTION
## Summary
- adds CLI `research-regional-term` for source-backed regional lexeme proposals
- adds root `pnpm dialect:research` wrapper
- adds MCP `research_regional_term` tool
- keeps the research path proposal-only with `mutationPolicy=never-mutates-runtime-data`
- supports Serper search when `SERPER_API_KEY` is configured, otherwise emits explicit built-in-prior-only warnings
- adds tests for proposal generation, dialect validation, and MCP registration/handler behavior

## Boundary
This does **not** put web search into normal translation. Translation remains deterministic/provider-backed using approved matrices and judges. Research produces artifacts/proposals/fixtures for reviewed remediation.

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- focused CLI regional-research tests
- focused MCP translator/security tests
- npm pack dry-run guard
