### PR TITLE
Prevent demo requests from silently targeting Mexico

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 737 tests passing
+pnpm test        # 739 tests passing
 ```
 
 ---
@@ -216,7 +216,7 @@ pnpm test        # 737 tests passing
 | `check_formality` | Check tú vs usted consistency |
 | `apply_gender_neutral` | Apply gender-neutral language |
 
-### Translation (6 tools)
+### Translation (7 tools)
 | Tool | Description |
 |------|-------------|
 | `translate_text` | Translate with semantic context, grammar profiles, and quality contracts |
@@ -226,7 +226,6 @@ pnpm test        # 737 tests passing
 | `search_glossary` | Search 300+ source-attributed glossary terms |
 | `list_dialects` | List all 25 supported dialects |
 | `research_regional_term` | Research source-backed regional lexeme proposals without mutating runtime data |
-| `research_regional_term` | Research source-backed regional lexeme proposals without mutating runtime data |
 
 ---
 
@@ -234,15 +233,15 @@ pnpm test        # 737 tests passing
 
 | Package | Version | Description | Tests |
 |---------|---------|-------------|-------|
-| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 17 MCP tools (stdio server) | 85 |
-| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 317 |
+| [`@espanol/mcp`](packages/mcp) | `0.1.0` | 17 MCP tools (stdio server) | 86 |
+| [`@espanol/cli`](packages/cli) | `0.1.0` | CLI commands for semantic translation workflows | 320 |
 | [`@espanol/providers`](packages/providers) | `0.1.0` | LLM, DeepL, LibreTranslate, MyMemory with circuit breaker | 71 |
 | [`@espanol/security`](packages/security) | `0.1.0` | Rate limiting, SSRF protection, sanitization | 66 |
 | [`@espanol/types`](packages/types) | `0.1.0` | Shared TypeScript types + glossary, profile, certification, and quality data | 54 |
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 737 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 739 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 
@@ -295,7 +294,7 @@ See [`SECURITY.md`](SECURITY.md) for details.
                        │ stdio
 ┌──────────────────────▼──────────────────────────────────────┐
 │                   @espanol/mcp                               │
-│              16 tools • JSON-RPC over stdio                  │
+│              17 tools • JSON-RPC over stdio                  │
 └──────────────────────┬──────────────────────────────────────┘
                        │
 ┌──────────────────────▼──────────────────────────────────────┐

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@
 
   <header class="shell hero">
     <div>
-      <div class="eyebrow"><span class="pulse"></span>737 tests · semantic provider demo · no static fallback</div>
+      <div class="eyebrow"><span class="pulse"></span>739 tests · semantic provider demo · no static fallback</div>
       <h1><span class="gradient">Spanish that knows where it is going.</span></h1>
       <p class="lede">DialectOS routes your text through the real app path: browser to backend, backend to provider registry, provider to a semantic dialect prompt, and output through deterministic quality gates before anything reaches the page.</p>
       <div class="ctaRow">

--- a/index.html
+++ b/index.html
@@ -287,22 +287,22 @@
             <div class="packages-grid">
                 <div class="package-card">
                     <div class="package-name">@espanol/types</div>
-                    <div class="package-tests">41 tests</div>
-                    <div class="package-desc">Shared type definitions and Zod schemas for dialects, entries, and results</div>
+                    <div class="package-tests">54 tests</div>
+                    <div class="package-desc">Shared type definitions, dialect profiles, certification, and glossary data</div>
                 </div>
                 <div class="package-card">
                     <div class="package-name">@espanol/security</div>
-                    <div class="package-tests">65 tests</div>
+                    <div class="package-tests">66 tests</div>
                     <div class="package-desc">Path validation, sanitization, rate limiting, and input safety</div>
                 </div>
                 <div class="package-card">
                     <div class="package-name">@espanol/providers</div>
-                    <div class="package-tests">35 tests</div>
-                    <div class="package-desc">Translation providers (DeepL, LibreTranslate, MyMemory) with circuit breaker</div>
+                    <div class="package-tests">71 tests</div>
+                    <div class="package-desc">LLM, DeepL, LibreTranslate, MyMemory with circuit breaker</div>
                 </div>
                 <div class="package-card">
                     <div class="package-name">@espanol/markdown-parser</div>
-                    <div class="package-tests">73 tests</div>
+                    <div class="package-tests">74 tests</div>
                     <div class="package-desc">Safe markdown parsing with marked-based, ReDoS-safe implementation</div>
                 </div>
                 <div class="package-card">
@@ -312,13 +312,13 @@
                 </div>
                 <div class="package-card">
                     <div class="package-name">@espanol/cli</div>
-                    <div class="package-tests">158 tests</div>
-                    <div class="package-desc">CLI tool with 16 commands for translation and i18n management</div>
+                    <div class="package-tests">320 tests</div>
+                    <div class="package-desc">CLI commands for semantic translation, research, certification, and i18n workflows</div>
                 </div>
                 <div class="package-card">
                     <div class="package-name">@espanol/mcp</div>
-                    <div class="package-tests">80 tests</div>
-                    <div class="package-desc">MCP adapter with 16 tools for AI assistants (Claude, Cursor, Windsurf)</div>
+                    <div class="package-tests">86 tests</div>
+                    <div class="package-desc">MCP adapter with 17 tools for AI assistants (Claude, Cursor, Windsurf)</div>
                 </div>
             </div>
         </section>
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">737 tests • 7 packages • 17 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">739 tests • 7 packages • 17 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @espanol/mcp
 
-Model Context Protocol server providing 16 tools for Spanish dialect translation across 25 regional variants.
+Model Context Protocol server providing 17 tools for Spanish dialect translation across 25 regional variants.
 
 ## Usage
 
@@ -44,6 +44,7 @@ Add to your MCP client configuration:
 - `translate_readme` — Full README translation pipeline
 - `search_glossary` — Search 300+ source-attributed glossary terms
 - `list_dialects` — List all 25 supported dialects
+- `research_regional_term` — Research source-backed regional lexeme proposals without mutating runtime data
 
 ## Security
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -45,7 +45,7 @@ function createServer(config: MCPConfig = loadConfig()): McpServer {
     config.rateLimit.windowMs
   );
 
-  // Register all tool categories (16 tools total)
+  // Register all tool categories (17 tools total)
   registerDocsTools(server, { registry, rateLimiter });
   registerI18nTools(server, { registry, rateLimiter });
   registerTranslatorTools(server, { registry, rateLimiter });

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -91,6 +91,98 @@ test("demo server translates through injected full-app service", async () => {
   }
 });
 
+test("demo server accepts targetLocale alias instead of silently defaulting to es-MX", async () => {
+  const calls = [];
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async (request) => {
+      calls.push(request);
+      return {
+        translatedText: "El jugo de china ya está listo.",
+        dialect: request.dialect,
+        providerUsed: "llm",
+        fallbackCount: 0,
+        retryCount: 0,
+        sourceDetection: {
+          dialect: null,
+          confidence: 0,
+          name: null,
+          matchedKeywords: [],
+          registerHint: "neutral",
+          isReliable: false,
+        },
+        semanticPromptApplied: true,
+        providerStatus: {
+          configured: true,
+          ready: true,
+          providers: ["llm"],
+          semanticProviders: ["llm"],
+          message: "Semantic providers ready: llm",
+        },
+      };
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: "Orange juice is ready.",
+        targetLocale: "es-PR",
+        provider: "auto",
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.dialect, "es-PR");
+    assert.equal(body.translatedText, "El jugo de china ya está listo.");
+    assert.deepEqual(calls.map((call) => call.dialect), ["es-PR"]);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server rejects requests with no target dialect instead of silently using es-MX", async () => {
+  let called = false;
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      called = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "Orange juice is ready.", provider: "auto" }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /Target dialect is required/);
+    assert.equal(called, false);
+  } finally {
+    server.close();
+  }
+});
+
 test("demo server returns provider errors instead of static fallback output", async () => {
   const { server, baseUrl } = await startTestServer({
     status: () => ({

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -54,6 +54,14 @@ function safeError(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function readDialect(body) {
+  const candidate = body?.dialect ?? body?.targetDialect ?? body?.targetLocale ?? body?.locale;
+  if (candidate === undefined || candidate === null || String(candidate).trim() === "") {
+    throw new Error("Target dialect is required. Send dialect, targetDialect, or targetLocale, for example es-PR.");
+  }
+  return String(candidate).trim();
+}
+
 async function readJson(req) {
   const chunks = [];
   let size = 0;
@@ -158,7 +166,7 @@ export function createDemoServer(options = {}) {
         try {
           const result = await services.translate({
             text: String(body.text || ""),
-            dialect: String(body.dialect || "es-MX"),
+            dialect: readDialect(body),
             provider: body.provider ? String(body.provider) : "auto",
             formality: body.formality ? String(body.formality) : "auto",
           });
@@ -167,7 +175,7 @@ export function createDemoServer(options = {}) {
           const message = safeError(error);
           const status = /No provider configured|No translation providers|Provider not available/i.test(message)
             ? 503
-            : /Invalid|No input|too large/i.test(message)
+            : /Invalid|No input|required|too large/i.test(message)
               ? 400
               : 500;
           sendJson(res, status, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Fix `/api/translate` so missing `dialect` no longer silently defaults to `es-MX`.
- Accept common target aliases: `dialect`, `targetDialect`, `targetLocale`, `locale`.
- Return a 400 client error for missing target dialect before calling providers.
- Refresh stale 16-tool / 737-test / package-count docs after the research MCP release.

## Root cause
Live/browser testing with `dialect: "es-PR"` works for Puerto Rico examples, but API-style requests using `targetLocale: "es-PR"` were ignored and silently routed as `es-MX`. That made the system look like it was failing regional semantics when the real bug was an unsafe endpoint default.

## Verification
- `node --test scripts/__tests__/demo-server.test.mjs`
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
