### PR TITLE
Address Codex review on demo dialect validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 739 tests passing
+pnpm test        # 742 tests passing
 ```
 
 ---
@@ -241,7 +241,7 @@ pnpm test        # 739 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 739 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 742 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@
 
   <header class="shell hero">
     <div>
-      <div class="eyebrow"><span class="pulse"></span>739 tests · semantic provider demo · no static fallback</div>
+      <div class="eyebrow"><span class="pulse"></span>742 tests · semantic provider demo · no static fallback</div>
       <h1><span class="gradient">Spanish that knows where it is going.</span></h1>
       <p class="lede">DialectOS routes your text through the real app path: browser to backend, backend to provider registry, provider to a semantic dialect prompt, and output through deterministic quality gates before anything reaches the page.</p>
       <div class="ctaRow">

--- a/index.html
+++ b/index.html
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">739 tests • 7 packages • 17 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">742 tests • 7 packages • 17 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -150,6 +150,125 @@ test("demo server accepts targetLocale alias instead of silently defaulting to e
   }
 });
 
+test("demo server ignores blank earlier dialect aliases and uses the first non-blank target", async () => {
+  const calls = [];
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async (request) => {
+      calls.push(request);
+      return {
+        translatedText: "El jugo de china ya está listo.",
+        dialect: request.dialect,
+        providerUsed: "llm",
+        fallbackCount: 0,
+        retryCount: 0,
+        sourceDetection: {
+          dialect: null,
+          confidence: 0,
+          name: null,
+          matchedKeywords: [],
+          registerHint: "neutral",
+          isReliable: false,
+        },
+        semanticPromptApplied: true,
+        providerStatus: {
+          configured: true,
+          ready: true,
+          providers: ["llm"],
+          semanticProviders: ["llm"],
+          message: "Semantic providers ready: llm",
+        },
+      };
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: "Orange juice is ready.",
+        dialect: " ",
+        targetLocale: "es-PR",
+        provider: "auto",
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.dialect, "es-PR");
+    assert.deepEqual(calls.map((call) => call.dialect), ["es-PR"]);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server short-circuits dialect aliases before malformed trailing values", async () => {
+  const calls = [];
+  const malformedTrailingLocale = { toString: "not-callable" };
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async (request) => {
+      calls.push(request);
+      return {
+        translatedText: "El jugo de china ya está listo.",
+        dialect: request.dialect,
+        providerUsed: "llm",
+        fallbackCount: 0,
+        retryCount: 0,
+        sourceDetection: {
+          dialect: null,
+          confidence: 0,
+          name: null,
+          matchedKeywords: [],
+          registerHint: "neutral",
+          isReliable: false,
+        },
+        semanticPromptApplied: true,
+        providerStatus: {
+          configured: true,
+          ready: true,
+          providers: ["llm"],
+          semanticProviders: ["llm"],
+          message: "Semantic providers ready: llm",
+        },
+      };
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: "Orange juice is ready.",
+        targetLocale: "es-PR",
+        locale: malformedTrailingLocale,
+        provider: "auto",
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.dialect, "es-PR");
+    assert.deepEqual(calls.map((call) => call.dialect), ["es-PR"]);
+  } finally {
+    server.close();
+  }
+});
+
 test("demo server rejects requests with no target dialect instead of silently using es-MX", async () => {
   let called = false;
   const { server, baseUrl } = await startTestServer({
@@ -178,6 +297,40 @@ test("demo server rejects requests with no target dialect instead of silently us
     assert.equal(body.ok, false);
     assert.match(body.error, /Target dialect is required/);
     assert.equal(called, false);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server does not classify quality-judge required-trait failures as client input errors", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      throw new Error("Provider output failed quality judge: semantic/critical: Missing required semantic trait for es-PR; expected one of: china");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: "Orange juice is ready.",
+        targetLocale: "es-PR",
+        provider: "auto",
+      }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 500);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /Missing required semantic trait/);
   } finally {
     server.close();
   }

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -54,12 +54,16 @@ function safeError(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+class ClientInputError extends Error {}
+
 function readDialect(body) {
-  const candidate = body?.dialect ?? body?.targetDialect ?? body?.targetLocale ?? body?.locale;
-  if (candidate === undefined || candidate === null || String(candidate).trim() === "") {
-    throw new Error("Target dialect is required. Send dialect, targetDialect, or targetLocale, for example es-PR.");
+  for (const value of [body?.dialect, body?.targetDialect, body?.targetLocale, body?.locale]) {
+    if (value === undefined || value === null) continue;
+    if (typeof value !== "string") continue;
+    const candidate = value.trim();
+    if (candidate) return candidate;
   }
-  return String(candidate).trim();
+  throw new ClientInputError("Target dialect is required. Send dialect, targetDialect, or targetLocale, for example es-PR.");
 }
 
 async function readJson(req) {
@@ -175,7 +179,7 @@ export function createDemoServer(options = {}) {
           const message = safeError(error);
           const status = /No provider configured|No translation providers|Provider not available/i.test(message)
             ? 503
-            : /Invalid|No input|required|too large/i.test(message)
+            : error instanceof ClientInputError || /Invalid|No input|too large/i.test(message)
               ? 400
               : 500;
           sendJson(res, status, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Fixes the Codex PR #65 finding where blank `dialect` blocked fallback to `targetLocale` / `targetDialect` / `locale`.
- Replaces broad `/required/` HTTP status matching with an explicit `ClientInputError` for missing target dialects.
- Adds regression tests for both Codex findings.
- Updates visible test count to 741.

## Codex findings addressed
1. `readDialect` used nullish coalescing, so `{ "dialect": "", "targetLocale": "es-PR" }` failed instead of using the alias.
2. `/required/` in the status mapper could classify quality-judge errors such as `Missing required semantic trait...` as HTTP 400.

## Verification
- `node --test scripts/__tests__/demo-server.test.mjs`
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
