### PR TITLE
Close public demo edge-case leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ git clone https://github.com/Pastorsimon1798/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
-pnpm test        # 742 tests passing
+pnpm test        # 746 tests passing
 ```
 
 ---
@@ -241,7 +241,7 @@ pnpm test        # 742 tests passing
 | [`@espanol/locale-utils`](packages/locale-utils) | `0.1.0` | Locale file diff/merge utilities | 55 |
 | [`@espanol/markdown-parser`](packages/markdown-parser) | `0.1.0` | Structure-preserving markdown parser | 74 |
 
-**Total: 742 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
+**Total: 746 tests across 7 packages plus the full-app docs, demo-server, and static-hardening contracts**
 
 ---
 

--- a/audits/2026-04-23-demo-adversarial-hardening.md
+++ b/audits/2026-04-23-demo-adversarial-hardening.md
@@ -1,0 +1,23 @@
+# Demo/API adversarial hardening — 2026-04-23
+
+## Scope
+Public demo server and landing-page integration for `dialectos.kyanitelabs.tech`.
+
+## Failure modes found and addressed
+
+| Class | Finding | Fix | Regression evidence |
+| --- | --- | --- | --- |
+| Public source exposure | The demo server would serve repo files such as `/package.json`, `/scripts/demo-server.mjs`, `/packages/cli/src/lib/web-demo-service.ts`, and traversal variants like `/docs/../package.json`. | Replaced repo-root static serving with a public-file allowlist. | `demo server does not expose repo implementation files as public assets` |
+| Malformed URL path | Bad percent-encoded static paths surfaced as HTTP 500. | Malformed static paths now return HTTP 400 with a client error. | `demo server treats malformed encoded static paths as bad requests` |
+| Dirty JSON body | `null` JSON could produce server errors instead of a client error. | Translation body must be a JSON object before service execution. | `demo server rejects non-object JSON bodies before translation` |
+| Non-string field coercion | Object/array values in `text`, `provider`, or `formality` could reach translation services or cause misleading 500s. | Required/optional string fields are validated before service execution. | `demo server rejects non-string translation fields before translation` |
+| Local hardening headers | Static/JSON responses relied on upstream headers in production but not local/demo-server behavior. | Added baseline `x-content-type-options: nosniff` and `referrer-policy` headers to JSON/static responses. | Covered by server response tests and manual probes |
+
+## Explicitly retained
+- `/docs/full-app-demo.md` remains public for the container guide.
+- `/docs/index.html`, `/index.html`, `/`, and `/docs/dialectos-engine.js` remain public where needed.
+- `/api/status` and `/api/translate` behavior remains provider-backed; no static translation fallback was introduced.
+
+## Remaining watchlist
+- The live Traefik layer still owns production security headers such as HSTS and noindex.
+- The server intentionally returns provider/quality errors visibly; future work can introduce stable error codes without hiding failures.

--- a/docs/index.html
+++ b/docs/index.html
@@ -291,7 +291,7 @@
 
   <header id="top" class="shell hero">
     <div>
-      <div class="kicker"><span class="live-dot"></span><span>742 tests</span><span>·</span><span>provider-backed</span><span>·</span><span>no static fallback</span></div>
+      <div class="kicker"><span class="live-dot"></span><span>746 tests</span><span>·</span><span>provider-backed</span><span>·</span><span>no static fallback</span></div>
       <h1>Spanish that can defend where it came from.</h1>
       <p class="lede">DialectOS is a full-stack dialect translation surface for Spanish regional meaning: Puerto Rican <em>jugo de china</em>, Caribbean <em>guagua</em>, voseo, taboo verbs, and semantic traps that generic translation demos flatten.</p>
       <div class="subproof" aria-label="Product proof points">
@@ -316,7 +316,7 @@
 
   <section class="shell metrics" aria-label="Project metrics">
     <div class="metric"><strong>25</strong><span>Spanish regional variants covered by the app surface</span></div>
-    <div class="metric"><strong>742</strong><span>tests across runtime, docs, dialect fixtures, and safety checks</span></div>
+    <div class="metric"><strong>746</strong><span>tests across runtime, docs, dialect fixtures, and safety checks</span></div>
     <div class="metric"><strong>17</strong><span>MCP tools for translation, glossary, and research workflows</span></div>
     <div class="metric"><strong>0</strong><span>silent static fallback paths in the public demo</span></div>
   </section>
@@ -419,7 +419,7 @@
   <footer class="shell">
     <div class="footer-inner">
       <p><a href="https://github.com/Pastorsimon1798/DialectOS">DialectOS</a> — BSL 1.1, Apache-2.0 on 2030-04-20</p>
-      <p class="mono">742 tests · 17 MCP tools · 25 dialects</p>
+      <p class="mono">746 tests · 17 MCP tools · 25 dialects</p>
     </div>
   </footer>
 

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -21,7 +21,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 - i18n operations: detect missing keys, batch translate, check formality
 - LLM-first provider routing with DeepL/LibreTranslate/MyMemory as fallback utilities
 
-**Tech stack:** TypeScript, pnpm monorepo, 700 tests, Vitest
+**Tech stack:** TypeScript, pnpm monorepo, 746 tests, Vitest
 
 **Repo:** https://github.com/Pastorsimon1798/DialectOS
 
@@ -65,7 +65,7 @@ Security matters when you're piping content through translation APIs.
 - 18 CVEs resolved, zero current vulnerabilities
 
 **Tweet 5:**
-700 tests. 7 packages. pnpm monorepo. TypeScript.
+746 tests. 7 packages. pnpm monorepo. TypeScript.
 
 Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
@@ -91,7 +91,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 - i18n utilities (detect missing keys, batch translate, formality check)
 - Security hardened (SSRF protection, circuit breakers, rate limiting)
 
-**Tech:** TypeScript, pnpm monorepo, 700 tests
+**Tech:** TypeScript, pnpm monorepo, 746 tests
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
@@ -113,7 +113,7 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, 700 tests passing.
+Source available, BSL 1.1 licensed, 746 tests passing.
 
 https://github.com/Pastorsimon1798/DialectOS
 
@@ -136,7 +136,7 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 - LLM-first provider routing plus fallback utilities
 - Security hardened with SSRF protection and circuit breakers
 
-**Tech stack:** TypeScript, pnpm monorepo, 700 tests
+**Tech stack:** TypeScript, pnpm monorepo, 746 tests
 
 **License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
 

--- a/index.html
+++ b/index.html
@@ -501,7 +501,7 @@
 
         <footer>
             <p>DialectOS — Spanish Dialect Translation Server • BSL 1.1</p>
-            <p style="margin-top: 0.5rem;">742 tests • 7 packages • 17 MCP tools • 25 dialects</p>
+            <p style="margin-top: 0.5rem;">746 tests • 7 packages • 17 MCP tools • 25 dialects</p>
         </footer>
     </div>
 </body>

--- a/scripts/__tests__/demo-server.test.mjs
+++ b/scripts/__tests__/demo-server.test.mjs
@@ -417,6 +417,68 @@ test("demo server handles favicon without a noisy 404", async () => {
   }
 });
 
+test("demo server does not expose repo implementation files as public assets", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      throw new Error("not used");
+    },
+  });
+
+  try {
+    for (const path of [
+      "/package.json",
+      "/scripts/demo-server.mjs",
+      "/packages/cli/src/lib/web-demo-service.ts",
+      "/docs/../package.json",
+      "/%2e%2e/package.json",
+    ]) {
+      const response = await fetch(`${baseUrl}${path}`);
+      const body = await response.text();
+      assert.equal(response.status, 404, `${path} should not be public`);
+      assert.doesNotMatch(body, /@espanol|createDemoServer|ProviderRegistry|DialectOS full-app demo/);
+    }
+
+    const guide = await fetch(`${baseUrl}/docs/full-app-demo.md`);
+    assert.equal(guide.status, 200);
+    assert.match(await guide.text(), /DialectOS full-app demo/);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server treats malformed encoded static paths as bad requests", async () => {
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      throw new Error("not used");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/%E0%A4%A`);
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /Malformed URL path/);
+  } finally {
+    server.close();
+  }
+});
+
 test("demo server rejects malformed JSON as a client error", async () => {
   const { server, baseUrl } = await startTestServer({
     status: () => ({
@@ -442,6 +504,78 @@ test("demo server rejects malformed JSON as a client error", async () => {
     assert.equal(response.status, 400);
     assert.equal(body.ok, false);
     assert.match(body.error, /JSON|Unexpected|position|Expected/i);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server rejects non-object JSON bodies before translation", async () => {
+  let called = false;
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      called = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/translate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "null",
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.ok, false);
+    assert.match(body.error, /JSON body must be an object/);
+    assert.equal(called, false);
+  } finally {
+    server.close();
+  }
+});
+
+test("demo server rejects non-string translation fields before translation", async () => {
+  let called = false;
+  const { server, baseUrl } = await startTestServer({
+    status: () => ({
+      configured: true,
+      ready: true,
+      providers: ["llm"],
+      semanticProviders: ["llm"],
+      message: "Semantic providers ready: llm",
+    }),
+    translate: async () => {
+      called = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  try {
+    for (const payload of [
+      { text: { value: "Orange juice is ready." }, targetLocale: "es-PR" },
+      { text: "Orange juice is ready.", targetLocale: "es-PR", provider: { name: "auto" } },
+      { text: "Orange juice is ready.", targetLocale: "es-PR", formality: ["auto"] },
+    ]) {
+      const response = await fetch(`${baseUrl}/api/translate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(body.ok, false);
+      assert.match(body.error, /must be a string/);
+    }
+    assert.equal(called, false);
   } finally {
     server.close();
   }

--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -18,6 +18,19 @@ const CONTENT_TYPES = {
   ".svg": "image/svg+xml",
 };
 
+const COMMON_HEADERS = {
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "strict-origin-when-cross-origin",
+};
+
+const PUBLIC_STATIC_FILES = new Map([
+  ["/", "docs/index.html"],
+  ["/index.html", "docs/index.html"],
+  ["/docs/index.html", "docs/index.html"],
+  ["/docs/full-app-demo.md", "docs/full-app-demo.md"],
+  ["/docs/dialectos-engine.js", "docs/dialectos-engine.js"],
+]);
+
 function createRateLimiter(options = {}) {
   const maxRequests = Number(options.maxRequests || process.env.DIALECTOS_DEMO_RATE_LIMIT || 60);
   const windowMs = Number(options.windowMs || process.env.DIALECTOS_DEMO_RATE_WINDOW_MS || 60000);
@@ -46,6 +59,7 @@ function sendJson(res, status, payload) {
   res.writeHead(status, {
     "content-type": "application/json; charset=utf-8",
     "cache-control": "no-store",
+    ...COMMON_HEADERS,
   });
   res.end(body);
 }
@@ -56,6 +70,12 @@ function safeError(error) {
 
 class ClientInputError extends Error {}
 
+function assertRequestObject(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ClientInputError("JSON body must be an object.");
+  }
+}
+
 function readDialect(body) {
   for (const value of [body?.dialect, body?.targetDialect, body?.targetLocale, body?.locale]) {
     if (value === undefined || value === null) continue;
@@ -64,6 +84,40 @@ function readDialect(body) {
     if (candidate) return candidate;
   }
   throw new ClientInputError("Target dialect is required. Send dialect, targetDialect, or targetLocale, for example es-PR.");
+}
+
+function readRequiredString(body, key, label) {
+  const value = body?.[key];
+  if (typeof value !== "string") {
+    throw new ClientInputError(`${label} must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ClientInputError(`${label} must be a non-empty string.`);
+  }
+  return trimmed;
+}
+
+function readOptionalString(body, key, label, fallback) {
+  const value = body?.[key];
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+  if (typeof value !== "string") {
+    throw new ClientInputError(`${label} must be a string.`);
+  }
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function readTranslateRequest(body) {
+  assertRequestObject(body);
+  return {
+    text: readRequiredString(body, "text", "Text"),
+    dialect: readDialect(body),
+    provider: readOptionalString(body, "provider", "Provider", "auto"),
+    formality: readOptionalString(body, "formality", "Formality", "auto"),
+  };
 }
 
 async function readJson(req) {
@@ -81,10 +135,16 @@ async function readJson(req) {
 }
 
 function staticPathFor(urlPath, rootDir) {
-  const pathname = decodeURIComponent(urlPath.split("?")[0] || "/");
-  const relative = pathname === "/"
-    ? "docs/index.html"
-    : pathname.replace(/^\/+/, "");
+  let pathname;
+  try {
+    pathname = decodeURIComponent(urlPath.split("?")[0] || "/");
+  } catch {
+    throw new ClientInputError("Malformed URL path.");
+  }
+  const relative = PUBLIC_STATIC_FILES.get(pathname);
+  if (!relative) {
+    return undefined;
+  }
   const absolute = path.resolve(rootDir, relative);
   if (!absolute.startsWith(rootDir + path.sep) && absolute !== rootDir) {
     return undefined;
@@ -93,26 +153,40 @@ function staticPathFor(urlPath, rootDir) {
 }
 
 async function serveStatic(req, res, rootDir) {
-  const absolute = staticPathFor(req.url || "/", rootDir);
+  let absolute;
+  try {
+    absolute = staticPathFor(req.url || "/", rootDir);
+  } catch (error) {
+    if (error instanceof ClientInputError) {
+      sendJson(res, 400, { ok: false, error: error.message });
+      return;
+    }
+    throw error;
+  }
   if (!absolute) {
-    sendJson(res, 403, { error: "Forbidden" });
+    sendJson(res, 404, { ok: false, error: "Not found" });
     return;
   }
 
   try {
     const info = await stat(absolute);
     if (!info.isFile()) {
-      sendJson(res, 404, { error: "Not found" });
+      sendJson(res, 404, { ok: false, error: "Not found" });
       return;
     }
     const ext = path.extname(absolute);
     res.writeHead(200, {
       "content-type": CONTENT_TYPES[ext] || "application/octet-stream",
       "cache-control": "no-store",
+      ...COMMON_HEADERS,
     });
+    if ((req.method || "GET") === "HEAD") {
+      res.end();
+      return;
+    }
     createReadStream(absolute).pipe(res);
   } catch {
-    sendJson(res, 404, { error: "Not found" });
+    sendJson(res, 404, { ok: false, error: "Not found" });
   }
 }
 
@@ -159,7 +233,6 @@ export function createDemoServer(options = {}) {
           });
           return;
         }
-        const services = await servicesPromise;
         let body;
         try {
           body = await readJson(req);
@@ -168,12 +241,9 @@ export function createDemoServer(options = {}) {
           return;
         }
         try {
-          const result = await services.translate({
-            text: String(body.text || ""),
-            dialect: readDialect(body),
-            provider: body.provider ? String(body.provider) : "auto",
-            formality: body.formality ? String(body.formality) : "auto",
-          });
+          const request = readTranslateRequest(body);
+          const services = await servicesPromise;
+          const result = await services.translate(request);
           sendJson(res, 200, { ok: true, ...result });
         } catch (error) {
           const message = safeError(error);


### PR DESCRIPTION
## Summary
- Replaces repo-root static serving with an explicit public-file allowlist.
- Blocks public access to implementation files like `/package.json`, `/scripts/demo-server.mjs`, and `/packages/...`.
- Converts malformed encoded static paths to HTTP 400 instead of 500.
- Validates translation JSON body shape and string fields before provider/service execution.
- Adds baseline `x-content-type-options: nosniff` and `referrer-policy` headers to demo server responses.
- Updates public test-count copy to 746 and records the hardening audit.

## Failure modes addressed
See `audits/2026-04-23-demo-adversarial-hardening.md`.

## Verification
- `node --test scripts/__tests__/demo-server.test.mjs`
- `pnpm build`
- `pnpm test`
- `pnpm audit --audit-level low`
- package dry-run guard
- local curl probes for public allowlist, source leak blocking, malformed paths, and response headers
