### PR TITLE
Add complementary Blacksmith probe

### DIFF
--- a/.github/workflows/blacksmith-probe.yml
+++ b/.github/workflows/blacksmith-probe.yml
@@ -1,0 +1,17 @@
+name: Blacksmith Probe
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/blacksmith-probe.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    uses: KyaniteLabs/.github/.github/workflows/blacksmith-probe.yml@main
+    with:
+      probe_label: complementary-runner-probe


### PR DESCRIPTION
## Summary
- Adds a thin workflow calling the centralized `KyaniteLabs/.github` Blacksmith probe.
- Does not replace or weaken existing CI.

## Why
Blacksmith is complementary runner capacity for KyaniteLabs org repos. GitHub remains the repo/PR/control plane and existing repo workflows remain authoritative.

## Verification
The PR check itself verifies Blacksmith runner availability for this repository.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->