### PR TITLE
fix(ci): skip non-package directories in verification loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Verify npm package contents
         run: |
           for pkg in packages/*; do
+            [ -f "$pkg/package.json" ] || continue
             (cd "$pkg" && npm pack --dry-run) >/tmp/"$(basename "$pkg")"-pack.txt 2>&1
             if grep -E 'src/__tests__|src/.*\.test\.ts|fixtures/' /tmp/"$(basename "$pkg")"-pack.txt; then
               echo "Unexpected test/source fixture content in package $pkg"


### PR DESCRIPTION
## Summary
- Add `[ -f "$pkg/package.json" ] || continue` guard to the package verification loop in CI
- The `benchmarks/` directory under `packages/` has no `package.json`, causing `npm pack --dry-run` to fail
- This is the root cause of the CI failure on main

Closes #87

## Test plan
- [x] Verified `packages/benchmarks/` has no `package.json`
- [x] All other 7 package dirs have valid `package.json`
- [ ] CI should pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->