### PR TITLE
Run workflows on Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       matrix:
         node-version: [22, 24]
@@ -49,7 +49,7 @@ jobs:
       - run: pnpm test
 
   adversarial-ci:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build-and-test
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Verify npm package contents
         run: |
           for pkg in packages/*; do
+            [ -f "$pkg/package.json" ] || continue
             (cd "$pkg" && npm pack --dry-run) >/tmp/"$(basename "$pkg")"-pack.txt 2>&1
             if grep -E 'src/__tests__|src/.*\.test\.ts|fixtures/' /tmp/"$(basename "$pkg")"-pack.txt; then
               echo "Unexpected test/source fixture content in package $pkg"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - name: Setup Pages

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   validate:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       matrix:
         dialect:


### PR DESCRIPTION
## Summary
- move repo-local workflow jobs off mixed self-hosted/GitHub-hosted runners
- use `blacksmith-2vcpu-ubuntu-2404` for the changed workflow jobs
- keep workflow and job names intact so required check contexts remain stable

## Changed workflows
- `.github/workflows/validate-pr.yml`
- `.github/workflows/pages.yml`
- `.github/workflows/ci.yml`

## Verification
- parsed changed workflow YAML locally

## Context
This repo was in a mixed Kyanite state: Blacksmith was present, but some repo-local workflows still targeted non-Blacksmith runners and could queue/block PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->