### PR TITLE
Add git workspace hygiene and Epoch data tracking rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -33,6 +33,20 @@
 - Rebase, don't merge on feature branches
 - Never skip CI
 
+## Git Workspace Hygiene
+- Delete feature branches after merge — no stale branches
+- Remove worktrees when done — no orphaned worktrees
+- Prune stale remote references (`git remote prune origin`)
+- Clean working directory when task is done (`git status` clean)
+- Delete abandoned branches — don't leave dead work behind
+- Main branch is the only permanent artifact — everything else is temporary
+
+## Epoch Data Tracking
+- Use Epoch for time estimation before starting tasks (MCP, REST API, or CLI)
+- Record actual time after completing tasks (`record_actual`)
+- Every project feeds data to Epoch — it's how the system learns
+- Epoch only works if everyone contributes estimate-vs-actual data
+
 ## Local LLM
 - Use local inference at 100.66.225.85:1234 before cloud APIs
 - Check loaded models first, don't touch models you didn't load

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,20 @@
 - Rebase, don't merge on feature branches
 - Never skip CI
 
+## Git Workspace Hygiene
+- Delete feature branches after merge — no stale branches
+- Remove worktrees when done — no orphaned worktrees
+- Prune stale remote references (`git remote prune origin`)
+- Clean working directory when task is done (`git status` clean)
+- Delete abandoned branches — don't leave dead work behind
+- Main branch is the only permanent artifact — everything else is temporary
+
+## Epoch Data Tracking
+- Use Epoch for time estimation before starting tasks (MCP, REST API, or CLI)
+- Record actual time after completing tasks (`record_actual`)
+- Every project feeds data to Epoch — it's how the system learns
+- Epoch only works if everyone contributes estimate-vs-actual data
+
 ## Local LLM
 - Use local inference at 100.66.225.85:1234 before cloud APIs
 - Check loaded models first, don't touch models you didn't load

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -33,6 +33,20 @@
 - Rebase, don't merge on feature branches
 - Never skip CI
 
+## Git Workspace Hygiene
+- Delete feature branches after merge — no stale branches
+- Remove worktrees when done — no orphaned worktrees
+- Prune stale remote references (`git remote prune origin`)
+- Clean working directory when task is done (`git status` clean)
+- Delete abandoned branches — don't leave dead work behind
+- Main branch is the only permanent artifact — everything else is temporary
+
+## Epoch Data Tracking
+- Use Epoch for time estimation before starting tasks (MCP, REST API, or CLI)
+- Record actual time after completing tasks (`record_actual`)
+- Every project feeds data to Epoch — it's how the system learns
+- Epoch only works if everyone contributes estimate-vs-actual data
+
 ## Local LLM
 - Use local inference at 100.66.225.85:1234 before cloud APIs
 - Check loaded models first, don't touch models you didn't load

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,39 @@ All `main`/`master` branches in KyaniteLabs repos are protected:
 - **LICENSE**: MIT (org default)
 - **CONTRIBUTING.md**: Points to org contributing guide
 
+## Git Workspace Hygiene
+
+Agents must leave the repository in the same clean state they found it. No exceptions.
+
+- **Delete feature branches** after merge — whether you merged via PR or locally. A merged branch that still exists is a failure.
+- **Remove worktrees** when done. If you created a git worktree for isolated work, remove it when the work is complete or abandoned. No orphaned worktrees.
+- **Clean up stale references** — prune remote-tracking branches that no longer exist upstream (`git remote prune origin`).
+- **No abandoned work left behind** — if you started a branch, pushed it, and then the task was cancelled or superseded, delete the branch. Dead branches accumulate and confuse everyone.
+- **Local branches stay current** — regularly rebase local tracking branches against their upstream. If a local branch has diverged and is no longer needed, delete it.
+- **Worktree state matches intent** — if you're done with a task, the working directory should be clean (`git status` shows nothing). Staged changes, untracked files, and modified files from abandoned work are not acceptable.
+
+The rule is simple: finish your work, merge or discard it, clean up every artifact you created. The main branch is the only permanent artifact. Everything else is temporary and must be treated as such.
+
+## Epoch Data Tracking
+
+Every project must use Epoch (KyaniteLabs/Epoch) for time estimation and actively feed it data. Epoch only becomes useful when it has real estimate-vs-actual data from real projects.
+
+### What This Means
+- **Before starting a task**, get a time estimate from Epoch (via MCP, REST API at `localhost:3099`, or CLI)
+- **After completing a task**, record the actual time spent using `record_actual` or `POST /v1/feedback/record-actual`
+- **Include context** — task type, complexity, tools used, anything that helps the model learn
+- **Batch submissions are fine** — use `batch_record_actuals` for multiple estimates at once
+
+### Integration
+- MCP: add `@puenteworks/epoch` to your project's `.mcp.json`
+- REST API: `epoch serve --port 3099`
+- CLI: `npx @puenteworks/epoch pert-estimate ...`
+
+### Why This Is Non-Negotiable
+Epoch's accuracy improves with data. Without estimate-vs-actual feedback from real projects, it's just a calculator with uncalibrated assumptions. Every project that uses Epoch and reports back makes every other project's estimates better. This is a collective intelligence system — it only works if everyone contributes.
+
+The data stored in `~/.epoch/` (estimates.jsonl + feedback.jsonl) is the project's most valuable asset. Protect it, back it up, and keep feeding it.
+
 ## Agent Coordination
 
 When multiple agents work on the same repo:


### PR DESCRIPTION
Org-wide rules: git cleanup discipline and Epoch data tracking mandate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->