### PR TITLE
Refresh DialectOS discovery links after username rename

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [Pastorsimon1798]
+github: [simongonzalezdc]
 ko_fi: kyanitelabs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/.llm
+++ b/.llm
@@ -66,7 +66,7 @@ translation, glossary enforcement, adversarial quality gates, and standalone val
 BSL 1.1 (free for most use). Becomes Apache-2.0 on 2030-04-20.
 
 ## Links
-- Repository: https://github.com/Pastorsimon1798/DialectOS
-- Documentation: https://pastorsimon1798.github.io/DialectOS
-- Issues: https://github.com/Pastorsimon1798/DialectOS/issues
-- GitHub Action: https://github.com/Pastorsimon1798/DialectOS/blob/main/action.yml
+- Repository: https://github.com/KyaniteLabs/DialectOS
+- Documentation: https://kyanitelabs.github.io/DialectOS
+- Issues: https://github.com/KyaniteLabs/DialectOS/issues
+- GitHub Action: https://github.com/KyaniteLabs/DialectOS/blob/main/action.yml

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured JSON error handling
 - Graceful shutdown on SIGINT/SIGTERM
 
-[0.3.0]: https://github.com/Pastorsimon1798/DialectOS/releases/tag/v0.3.0
-[0.2.0]: https://github.com/Pastorsimon1798/DialectOS/releases/tag/v0.2.0
-[0.1.0]: https://github.com/Pastorsimon1798/DialectOS/releases/tag/v0.1.0
+[0.3.0]: https://github.com/KyaniteLabs/DialectOS/releases/tag/v0.3.0
+[0.2.0]: https://github.com/KyaniteLabs/DialectOS/releases/tag/v0.2.0
+[0.1.0]: https://github.com/KyaniteLabs/DialectOS/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ abstract: "The first Model Context Protocol server built specifically for Spanis
 authors:
   - family-names: "Gonzalez"
     given-names: "Simon"
-repository-code: "https://github.com/Pastorsimon1798/DialectOS"
+repository-code: "https://github.com/KyaniteLabs/DialectOS"
 license: BSL-1.1
 version: 0.3.0
 date-released: 2026-04-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ External contributor opens issue
   → Auto-triage promotes to: agent-ready label
   → Pipeline picks up → creates fix PR
 
-Owner/member (Pastorsimon1798) opens issue
+Owner/member (simongonzalezdc) opens issue
   → Auto-triage detects member author
   → Promotes directly to agent-ready (skips triage)
   → Pipeline picks up → creates fix PR

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at [the issue tracker](https://github.com/Pastorsimon1798/DialectOS/issues). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at [the issue tracker](https://github.com/KyaniteLabs/DialectOS/issues). All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing! DialectOS is a community-driven pro
 ### Setup
 
 ```bash
-git clone https://github.com/Pastorsimon1798/DialectOS.git
+git clone https://github.com/KyaniteLabs/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
@@ -106,7 +106,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ## ❓ Questions?
 
-- Open a [GitHub Discussion](https://github.com/Pastorsimon1798/DialectOS/discussions)
+- Open a [GitHub Discussion](https://github.com/KyaniteLabs/DialectOS/discussions)
 - Or reach out via the issue tracker
 
 Thank you for making DialectOS better! 🌎

--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,9 @@ Business Source License 1.1
 
 Parameters
 
-Licensor:             Pastorsimon1798
+Licensor:             Simon Gonzalez De Cruz
 Licensed Work:        DialectOS
-                      The Licensed Work is (c) 2026 Pastorsimon1798
+                      The Licensed Work is (c) 2026 Simon Gonzalez De Cruz
 Change Date:          2030-04-20
 Change License:       Apache License, Version 2.0
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 **Please do not open public issues for security vulnerabilities.**
 
-Instead, report security concerns via [GitHub Security Advisories](https://github.com/Pastorsimon1798/DialectOS/security/advisories/new) or email the maintainer directly.
+Instead, report security concerns via [GitHub Security Advisories](https://github.com/KyaniteLabs/DialectOS/security/advisories/new) or email the maintainer directly.
 
 We will:
 1. Acknowledge receipt within 48 hours

--- a/audits/adversarial-2026-04-01/corpus/README.es.q.md
+++ b/audits/adversarial-2026-04-01/corpus/README.es.q.md
@@ -67,7 +67,7 @@ Añada a su configuración del cliente MCP (por ejemplo, Claude Desktop `  claud
 ### De la Fuente
 
 ```bash
-git clone https://github.com/Pastorsimon1798/DialectOS.git
+git clone https://github.com/KyaniteLabs/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build

--- a/audits/adversarial-2026-04-01/corpus/synthetic-adversarial-pack.md
+++ b/audits/adversarial-2026-04-01/corpus/synthetic-adversarial-pack.md
@@ -14,9 +14,9 @@ Paragraph with `inline_code()`, [link text](https://example.com/path?q=abc), and
 export const API_URL = "https://api.example.com/v1";
 ```
 
-- Bullet one with HANDLE @pastorsimon1798
+- Bullet one with HANDLE @simongonzalezdc
 - Bullet two with DOMAIN kyanitelabs.tech
-- Bullet three with owner/repo pastorsimon1798/DialectOS
+- Bullet three with owner/repo KyaniteLabs/DialectOS
 
 ## Injection-like content
 

--- a/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.final.md
+++ b/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.final.md
@@ -2,4 +2,4 @@
 
  Kyanite Labs    construye   Liminal  . Siga   @kyanitelabs      kyanitelabs.tech   .
 
-No mutar:   Puente Works   ,   Cerafica   ,   pastorsimon1798/DialectOS   .
+No mutar:   Puente Works   ,   Cerafica   ,   KyaniteLabs/DialectOS   .

--- a/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.md
+++ b/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.md
@@ -2,4 +2,4 @@
 
  Kyanite Labs    construye   Liminal  . Siga   @kyanitelabs      kyanitelabs.tech   .
 
-No mutar:   Puente Works   ,   Cerafica   ,   pastorsimon1798/DialectOS   .
+No mutar:   Puente Works   ,   Cerafica   ,   KyaniteLabs/DialectOS   .

--- a/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.q.md
+++ b/audits/adversarial-2026-04-01/corpus/token-lock-stress.es.q.md
@@ -2,4 +2,4 @@
 
  Kyanite Labs    construye   Liminal  . Siga   @kyanitelabs      kyanitelabs.tech   .
 
-No mutar:   Puente Works   ,   Cerafica   ,   pastorsimon1798/DialectOS   .
+No mutar:   Puente Works   ,   Cerafica   ,   KyaniteLabs/DialectOS   .

--- a/audits/adversarial-2026-04-01/corpus/token-lock-stress.md
+++ b/audits/adversarial-2026-04-01/corpus/token-lock-stress.md
@@ -2,4 +2,4 @@
 
 Kyanite Labs builds Liminal. Follow @kyanitelabs at kyanitelabs.tech.
 
-Do not mutate: Puente Works, Cerafica, pastorsimon1798/DialectOS.
+Do not mutate: Puente Works, Cerafica, KyaniteLabs/DialectOS.

--- a/docs/SEO-AI-SEO-MASTERPLAN.md
+++ b/docs/SEO-AI-SEO-MASTERPLAN.md
@@ -65,7 +65,7 @@
 # Change: "20 regional variants" → "25 regional variants"
 
 # 2. Fix FUNDING.yml — remove placeholder comment, add real options
-github: [Pastorsimon1798]
+github: [simongonzalezdc]
 # Add: ko_fi, patreon, or buy_me_a_coffee when ready
 
 # 3. Add 10 more GitHub topics via repo settings page
@@ -94,18 +94,18 @@ Add to `docs/index.html` `<head>`:
 <!-- Open Graph -->
 <meta property="og:title" content="DialectOS — Spanish Dialect Translation Server (MCP + CLI)">
 <meta property="og:description" content="Translate across 25 Spanish regional variants with structure preservation, quality gates, and MCP native integration. 1034 tests. 17 MCP tools.">
-<meta property="og:image" content="https://pastorsimon1798.github.io/DialectOS/assets/og-image.png">
-<meta property="og:url" content="https://pastorsimon1798.github.io/DialectOS">
+<meta property="og:image" content="https://kyanitelabs.github.io/DialectOS/assets/og-image.png">
+<meta property="og:url" content="https://kyanitelabs.github.io/DialectOS">
 <meta property="og:type" content="website">
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="DialectOS — Spanish Dialect Translation Server">
 <meta name="twitter:description" content="25 Spanish variants. MCP-native. Quality gates. Structure-preserving translation.">
-<meta name="twitter:image" content="https://pastorsimon1798.github.io/DialectOS/assets/og-image.png">
+<meta name="twitter:image" content="https://kyanitelabs.github.io/DialectOS/assets/og-image.png">
 
 <!-- Canonical -->
-<link rel="canonical" href="https://pastorsimon1798.github.io/DialectOS/">
+<link rel="canonical" href="https://kyanitelabs.github.io/DialectOS/">
 
 <!-- Schema.org JSON-LD -->
 <script type="application/ld+json">
@@ -117,8 +117,8 @@ Add to `docs/index.html` `<head>`:
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Any",
   "softwareVersion": "0.1.1",
-  "license": "https://github.com/Pastorsimon1798/DialectOS/blob/main/LICENSE",
-  "codeRepository": "https://github.com/Pastorsimon1798/DialectOS",
+  "license": "https://github.com/KyaniteLabs/DialectOS/blob/main/LICENSE",
+  "codeRepository": "https://github.com/KyaniteLabs/DialectOS",
   "programmingLanguage": ["TypeScript", "JavaScript"],
   "featureList": [
     "25 Spanish regional dialects",
@@ -147,16 +147,16 @@ Create `docs/robots.txt`:
 ```
 User-agent: *
 Allow: /
-Sitemap: https://pastorsimon1798.github.io/DialectOS/sitemap.xml
+Sitemap: https://kyanitelabs.github.io/DialectOS/sitemap.xml
 ```
 
 Create `docs/sitemap.xml`:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://pastorsimon1798.github.io/DialectOS/</loc><priority>1.0</priority></url>
-  <url><loc>https://github.com/Pastorsimon1798/DialectOS</loc><priority>0.9</priority></url>
-  <url><loc>https://github.com/Pastorsimon1798/DialectOS#readme</loc><priority>0.8</priority></url>
+  <url><loc>https://kyanitelabs.github.io/DialectOS/</loc><priority>1.0</priority></url>
+  <url><loc>https://github.com/KyaniteLabs/DialectOS</loc><priority>0.9</priority></url>
+  <url><loc>https://github.com/KyaniteLabs/DialectOS#readme</loc><priority>0.8</priority></url>
 </urlset>
 ```
 
@@ -203,7 +203,7 @@ DialectOS exposes 17 translation tools through MCP.
 
 **Add a "Built with DialectOS" badge**:
 ```markdown
-[![Translated with DialectOS](https://img.shields.io/badge/translated%20with-DialectOS-d89b2b)](https://github.com/Pastorsimon1798/DialectOS)
+[![Translated with DialectOS](https://img.shields.io/badge/translated%20with-DialectOS-d89b2b)](https://github.com/KyaniteLabs/DialectOS)
 ```
 
 **Add comparison table** (LLMs LOVE these):
@@ -287,8 +287,8 @@ DialectOS exposes 17 translation tools through MCP.
   - genre: translation software (QXXX)
   - programming language: TypeScript (QXXX)
   - license: Business Source License 1.1 (QXXX)
-  - official website: https://github.com/Pastorsimon1798/DialectOS
-  - source code repository: https://github.com/Pastorsimon1798/DialectOS
+  - official website: https://github.com/KyaniteLabs/DialectOS
+  - source code repository: https://github.com/KyaniteLabs/DialectOS
   - developer: Simon Gonzalez
 
 **3. Create .llm file**
@@ -324,9 +324,9 @@ translation, glossary enforcement, and adversarial quality gates.
 BSL 1.1 (free for most use). Becomes Apache-2.0 on 2030-04-20.
 
 ## Links
-- Repository: https://github.com/Pastorsimon1798/DialectOS
-- Documentation: https://pastorsimon1798.github.io/DialectOS
-- Issues: https://github.com/Pastorsimon1798/DialectOS/issues
+- Repository: https://github.com/KyaniteLabs/DialectOS
+- Documentation: https://kyanitelabs.github.io/DialectOS
+- Issues: https://github.com/KyaniteLabs/DialectOS/issues
 ```
 
 **4. Get Listed in AI Tool Directories**

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Pastorsimon1798/DialectOS/action@v0.3.0
+      - uses: KyaniteLabs/DialectOS/action@v0.3.0
         with:
           dialect: es-MX
           fail-on-blocking: true
@@ -58,7 +58,7 @@ jobs:
         dialect: [es-ES, es-MX, es-AR, es-CO]
     steps:
       - uses: actions/checkout@v4
-      - uses: Pastorsimon1798/DialectOS/action@v0.3.0
+      - uses: KyaniteLabs/DialectOS/action@v0.3.0
         with:
           dialect: ${{ matrix.dialect }}
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,16 +6,16 @@
   <title>DialectOS — Spanish dialect translation with receipts</title>
   <meta name="description" content="A full-stack Spanish dialect translation demo with provider-backed inference, regional semantic prompts, and visible quality receipts.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230a0a0b'/%3E%3Cpath d='M16 43V20h14c11 0 18 6 18 15s-7 8-18 8H16z' fill='none' stroke='%23d89b2b' stroke-width='5' stroke-linejoin='round'/%3E%3Ccircle cx='31' cy='32' r='4' fill='%23fafafa'/%3E%3C/svg%3E">
-  <link rel="canonical" href="https://pastorsimon1798.github.io/DialectOS/">
+  <link rel="canonical" href="https://kyanitelabs.github.io/DialectOS/">
   <meta property="og:title" content="DialectOS — Spanish Dialect Translation Server (MCP + CLI)">
   <meta property="og:description" content="Translate across 25 Spanish regional variants with structure preservation, quality gates, and MCP native integration. 1034 tests. 17 MCP tools.">
-  <meta property="og:image" content="https://pastorsimon1798.github.io/DialectOS/assets/og-image.png">
-  <meta property="og:url" content="https://pastorsimon1798.github.io/DialectOS">
+  <meta property="og:image" content="https://kyanitelabs.github.io/DialectOS/assets/og-image.png">
+  <meta property="og:url" content="https://kyanitelabs.github.io/DialectOS">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="DialectOS — Spanish Dialect Translation Server">
   <meta name="twitter:description" content="25 Spanish variants. MCP-native. Quality gates. Structure-preserving translation.">
-  <meta name="twitter:image" content="https://pastorsimon1798.github.io/DialectOS/assets/og-image.png">
+  <meta name="twitter:image" content="https://kyanitelabs.github.io/DialectOS/assets/og-image.png">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Any",
     "softwareVersion": "0.3.0",
-    "license": "https://github.com/Pastorsimon1798/DialectOS/blob/main/LICENSE",
-    "codeRepository": "https://github.com/Pastorsimon1798/DialectOS",
+    "license": "https://github.com/KyaniteLabs/DialectOS/blob/main/LICENSE",
+    "codeRepository": "https://github.com/KyaniteLabs/DialectOS",
     "programmingLanguage": ["TypeScript", "JavaScript"],
     "featureList": [
       "25 Spanish regional dialects",
@@ -352,7 +352,7 @@
       <a href="#translate">Live demo</a>
       <a href="#stress-matrix">Stress matrix</a>
       <a href="docs/full-app-demo.md">Container guide</a>
-      <a class="nav-cta" href="https://github.com/Pastorsimon1798/DialectOS">GitHub</a>
+      <a class="nav-cta" href="https://github.com/KyaniteLabs/DialectOS">GitHub</a>
     </div>
   </nav>
 
@@ -491,7 +491,7 @@
 
   <footer class="shell">
     <div class="footer-inner">
-      <p><a href="https://github.com/Pastorsimon1798/DialectOS">DialectOS</a> — BSL 1.1, Apache-2.0 on 2030-04-20</p>
+      <p><a href="https://github.com/KyaniteLabs/DialectOS">DialectOS</a> — BSL 1.1, Apache-2.0 on 2030-04-20</p>
       <p class="mono">1034 tests · 17 MCP tools · 25 dialects</p>
     </div>
   </footer>

--- a/docs/launch-kit/awesome-list-prs/awesome-cli-apps.md
+++ b/docs/launch-kit/awesome-list-prs/awesome-cli-apps.md
@@ -1,7 +1,7 @@
 # PR Draft: Add DialectOS to awesome-cli-apps
 
 **Repo to submit to:** `agarrharr/awesome-cli-apps`
-**Your fork:** `Pastorsimon1798/awesome-cli-apps` (fork if needed)
+**Your fork:** `simongonzalezdc/awesome-cli-apps` (fork if needed)
 **Branch to create:** `add-dialectos`
 
 ---
@@ -15,7 +15,7 @@ Find the section for **Translation / Internationalization** or **Text** tools.
 Add this line alphabetically:
 
 ```markdown
-- [DialectOS](https://github.com/Pastorsimon1798/DialectOS) - Spanish dialect translation CLI with 25 regional variants, markdown preservation, and quality gates.
+- [DialectOS](https://github.com/KyaniteLabs/DialectOS) - Spanish dialect translation CLI with 25 regional variants, markdown preservation, and quality gates.
 ```
 
 ## Step 2: Commit and push

--- a/docs/launch-kit/awesome-list-prs/awesome-mcp-servers.md
+++ b/docs/launch-kit/awesome-list-prs/awesome-mcp-servers.md
@@ -1,21 +1,21 @@
 # PR Draft: Add DialectOS to awesome-mcp-servers
 
 **Repo to submit to:** `punkpeye/awesome-mcp-servers`
-**Your fork:** `Pastorsimon1798/awesome-mcp-servers`
+**Your fork:** `simongonzalezdc/awesome-mcp-servers`
 **Branch to create:** `add-dialectos`
 
 ---
 
 ## Step 1: Edit your fork
 
-In `Pastorsimon1798/awesome-mcp-servers`, edit `README.md`.
+In `simongonzalezdc/awesome-mcp-servers`, edit `README.md`.
 
 Find the section `[🌐 - Translation](#translation)` (or create it after `[🛠️ - Developer Tools](#developer-tools)`).
 
 Add this line alphabetically within that section:
 
 ```markdown
-- 📇 🏠 [DialectOS](https://github.com/Pastorsimon1798/DialectOS) - Spanish dialect translation server with 25 regional variants, structure preservation, and adversarial quality gates. Supports markdown, i18n locales, and gender-neutral language.
+- 📇 🏠 [DialectOS](https://github.com/KyaniteLabs/DialectOS) - Spanish dialect translation server with 25 regional variants, structure preservation, and adversarial quality gates. Supports markdown, i18n locales, and gender-neutral language.
 ```
 
 If no Translation section exists, add this section before `## Frameworks`:
@@ -23,7 +23,7 @@ If no Translation section exists, add this section before `## Frameworks`:
 ```markdown
 ### 🌐 Translation
 
-- 📇 🏠 [DialectOS](https://github.com/Pastorsimon1798/DialectOS) - Spanish dialect translation server with 25 regional variants, structure preservation, and adversarial quality gates. Supports markdown, i18n locales, and gender-neutral language.
+- 📇 🏠 [DialectOS](https://github.com/KyaniteLabs/DialectOS) - Spanish dialect translation server with 25 regional variants, structure preservation, and adversarial quality gates. Supports markdown, i18n locales, and gender-neutral language.
 ```
 
 Also add the Translation link to the table of contents:
@@ -42,13 +42,13 @@ git push origin add-dialectos
 
 ## Step 3: Create PR
 
-Go to: `https://github.com/punkpeye/awesome-mcp-servers/compare/main...Pastorsimon1798:awesome-mcp-servers:add-dialectos`
+Go to: `https://github.com/punkpeye/awesome-mcp-servers/compare/main...simongonzalezdc:awesome-mcp-servers:add-dialectos`
 
 **Title:** `Add DialectOS — MCP server for Spanish dialect translation`
 
 **Body:**
 ```
-Adds [DialectOS](https://github.com/Pastorsimon1798/DialectOS) to the Translation section.
+Adds [DialectOS](https://github.com/KyaniteLabs/DialectOS) to the Translation section.
 
 DialectOS is an open-source MCP server for Spanish regional dialect translation:
 - 25 Spanish dialects (es-MX, es-AR, es-CO, es-PR, etc.)

--- a/docs/launch-kit/awesome-list-prs/awesome-nlp.md
+++ b/docs/launch-kit/awesome-list-prs/awesome-nlp.md
@@ -1,7 +1,7 @@
 # PR Draft: Add DialectOS to awesome-nlp
 
 **Repo to submit to:** `keon/awesome-nlp`
-**Your fork:** `Pastorsimon1798/awesome-nlp` (fork if needed)
+**Your fork:** `simongonzalezdc/awesome-nlp` (fork if needed)
 **Branch to create:** `add-dialectos`
 
 ---
@@ -15,7 +15,7 @@ Find the section for **Translation** or **Multilingual NLP** tools.
 Add this line alphabetically:
 
 ```markdown
-- [DialectOS](https://github.com/Pastorsimon1798/DialectOS) - Spanish dialect translation server with 25 regional variants, MCP integration, structure-preserving markdown translation, and adversarial quality gates.
+- [DialectOS](https://github.com/KyaniteLabs/DialectOS) - Spanish dialect translation server with 25 regional variants, MCP integration, structure-preserving markdown translation, and adversarial quality gates.
 ```
 
 ## Step 2: Commit and push

--- a/docs/launch-kit/devto-articles/article-1-mcp-server.md
+++ b/docs/launch-kit/devto-articles/article-1-mcp-server.md
@@ -100,8 +100,8 @@ dialectos translate "Hello world" --dialect es-MX
 
 - **1034 tests** across 7 packages
 - **BSL 1.1** — free for most use, becomes Apache-2.0 in 2030
-- [GitHub](https://github.com/Pastorsimon1798/DialectOS)
-- [Live Demo](https://pastorsimon1798.github.io/DialectOS)
+- [GitHub](https://github.com/KyaniteLabs/DialectOS)
+- [Live Demo](https://kyanitelabs.github.io/DialectOS)
 
 ---
 

--- a/docs/launch-kit/devto-articles/article-2-25-dialects.md
+++ b/docs/launch-kit/devto-articles/article-2-25-dialects.md
@@ -73,7 +73,7 @@ DialectOS supports all of these:
 2. **Pick target markets** — Translate to the specific dialect, not "Spanish"
 3. **Use quality gates** — Check for semantic drift, negation drops, structure breaks
 
-[DialectOS](https://github.com/Pastorsimon1798/DialectOS) handles all of this as an MCP server and CLI tool. 25 dialects, structure preservation, adversarial quality gates, 1034 tests.
+[DialectOS](https://github.com/KyaniteLabs/DialectOS) handles all of this as an MCP server and CLI tool. 25 dialects, structure preservation, adversarial quality gates, 1034 tests.
 
 ---
 

--- a/docs/launch-kit/hacker-news/show-hn.md
+++ b/docs/launch-kit/hacker-news/show-hn.md
@@ -2,7 +2,7 @@
 
 **Title:** Show HN: DialectOS — MCP server for 25 Spanish dialects with quality gates
 
-**URL:** https://github.com/Pastorsimon1798/DialectOS
+**URL:** https://github.com/KyaniteLabs/DialectOS
 
 **Best time to post:** Tuesday or Thursday, 7-9 AM PT
 
@@ -34,6 +34,6 @@ A semantic backstop catches borderline scores. If "Do not click" becomes "Haz cl
 
 **Tech:** TypeScript monorepo, 7 packages, 1034 tests, pnpm workspace, stdio MCP.
 
-**Demo:** https://pastorsimon1798.github.io/DialectOS
+**Demo:** https://kyanitelabs.github.io/DialectOS
 
 Would love feedback on the architecture, the quality gate design, or any Spanish localization war stories.

--- a/docs/launch-kit/medium/article.md
+++ b/docs/launch-kit/medium/article.md
@@ -158,4 +158,4 @@ Your users will notice. And they'll thank you for it.
 
 *Simon Gonzalez is the builder of DialectOS, an open-source Spanish dialect translation server. 25 dialects, 1034 tests, and a mission to fix Spanish localization.*
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS

--- a/docs/launch-kit/outreach/newsletters.md
+++ b/docs/launch-kit/outreach/newsletters.md
@@ -25,8 +25,8 @@ It exposes 17 MCP (Model Context Protocol) tools so AI assistants like Claude ca
 - Works with OpenAI, Anthropic, or local LLMs
 - BSL 1.1 license
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
-**Demo:** https://pastorsimon1798.github.io/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
+**Demo:** https://kyanitelabs.github.io/DialectOS
 
 Would love to be featured in an upcoming issue. Happy to provide more details or a guest post.
 
@@ -57,7 +57,7 @@ It started from a real production issue: we shipped Spain Spanish translations t
 - Translation memory with SHA-256 keyed caching
 - 1034 tests across 7 packages
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Would be great to get coverage in Node Weekly.
 
@@ -88,7 +88,7 @@ MCP (Model Context Protocol) is exploding right now. We built what might be the 
 **Why it matters:**
 Most AI translation produces generic Spanish. But Mexican Spanish, Argentinian voseo, and Puerto Rican Spanish are fundamentally different. DialectOS adds dialect-aware prompts + quality validation.
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Interested in covering this?
 
@@ -116,7 +116,7 @@ I'd like to recommend DialectOS for your newsletter — it's an open-source Span
 - High test coverage (1034 tests)
 - Clean architecture (pnpm workspace, provider registry, circuit breaker)
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Would love to be considered.
 
@@ -147,7 +147,7 @@ We're building DialectOS — an open-source translation engine for Spanish regio
 
 It exposes 17 MCP tools, supports 25 dialects, and applies adversarial quality gates to catch semantic drift in AI translations.
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Would love to be featured.
 

--- a/docs/launch-kit/outreach/podcasts.md
+++ b/docs/launch-kit/outreach/podcasts.md
@@ -26,7 +26,7 @@ I'd love to come on the show to talk about DialectOS — an open-source Spanish 
 
 **About me:** Simon Gonzalez, builder of DialectOS. Previously [add relevant background].
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Available for recording any time. Would love to chat!
 
@@ -61,7 +61,7 @@ I'd like to pitch DialectOS for the show — it's an open-source translation eng
 - MCP and the future of AI tool integration
 - Testing strategies for translation software
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Would love to be considered.
 
@@ -97,7 +97,7 @@ DialectOS is a Spanish dialect translation system that applies adversarial quali
 **Why it matters for AI:**
 As more apps use LLMs for translation, quality validation becomes critical. We're building the testing infrastructure that generic translation APIs skip.
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Available any time. Would love to discuss!
 
@@ -126,7 +126,7 @@ I'd like to pitch DialectOS for an episode — it's an open-source Spanish diale
 - Quality gates for AI-generated content
 - Testing strategies for NLP applications
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Let me know if you're interested!
 
@@ -156,7 +156,7 @@ I'd love to do a deep dive on DialectOS — our open-source translation server's
 - Rate limiting + SSRF protection
 - Chaos harness for deterministic resilience testing
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Interested?
 

--- a/docs/launch-kit/product-hunt/launch-kit.md
+++ b/docs/launch-kit/product-hunt/launch-kit.md
@@ -14,8 +14,8 @@
 DialectOS is an open-source Spanish dialect translation server that runs as an MCP (Model Context Protocol) tool and CLI. It translates English and other languages into 25 regional Spanish variants while preserving markdown structure, enforcing glossary terms, and applying adversarial quality gates that catch semantic drift before it reaches users.
 
 **Topics:** Developer Tools, AI, Open Source, Translation
-**Website:** https://pastorsimon1798.github.io/DialectOS
-**GitHub:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://kyanitelabs.github.io/DialectOS
+**GitHub:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 

--- a/docs/launch-kit/reddit/r-LocalLLaMA.md
+++ b/docs/launch-kit/reddit/r-LocalLLaMA.md
@@ -42,6 +42,6 @@ This runs adversarial tests and writes:
 - Translation memory with SHA-256 cache
 - 1034 tests
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Has anyone else worked on dialect-aware prompting for local models? Curious about your approaches.

--- a/docs/launch-kit/reddit/r-javascript.md
+++ b/docs/launch-kit/reddit/r-javascript.md
@@ -50,6 +50,6 @@ npm install -g @dialectos/cli
 dialectos translate "Hello world" --dialect es-MX
 ```
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Feedback welcome! Especially on the MCP stdio implementation and the provider fallback chain.

--- a/docs/launch-kit/reddit/r-selfhosted.md
+++ b/docs/launch-kit/reddit/r-selfhosted.md
@@ -24,7 +24,7 @@ Generic Spanish fails 24 out of 25 countries.
 **Self-hosting setup:**
 
 ```bash
-git clone https://github.com/Pastorsimon1798/DialectOS.git
+git clone https://github.com/KyaniteLabs/DialectOS.git
 cd DialectOS
 pnpm install
 pnpm build
@@ -40,7 +40,7 @@ pnpm dialect:eval -- --live --provider=llm
 
 **License:** BSL 1.1 (free for most use, becomes Apache-2.0 in 2030).
 
-Demo: https://pastorsimon1798.github.io/DialectOS
-Repo: https://github.com/Pastorsimon1798/DialectOS
+Demo: https://kyanitelabs.github.io/DialectOS
+Repo: https://github.com/KyaniteLabs/DialectOS
 
 Would love feedback from the selfhosted community!

--- a/docs/launch-kit/reddit/r-translate.md
+++ b/docs/launch-kit/reddit/r-translate.md
@@ -35,6 +35,6 @@ We shipped Spain Spanish to Mexico. Users thought we were being rude. Generic Sp
 
 **Supported dialects:** es-ES, es-MX, es-AR, es-CO, es-CL, es-PE, es-VE, es-UY, es-PR, es-CU, es-DO, es-PA, es-CR, es-GT, es-HN, es-SV, es-NI, es-EC, es-BO, es-PY, es-GQ, es-US, es-PH, es-BZ, es-AD
 
-Repo: https://github.com/Pastorsimon1798/DialectOS
+Repo: https://github.com/KyaniteLabs/DialectOS
 
 What's the most confusing Spanish regional word you've encountered?

--- a/docs/launch-kit/stackoverflow/answer-1-spanish-translation-api.md
+++ b/docs/launch-kit/stackoverflow/answer-1-spanish-translation-api.md
@@ -12,7 +12,7 @@ If you need **dialect-aware Spanish translation** (not just generic "Spanish"), 
 - **DeepL** — ~5 Spanish variants (ES, MX, BR-PT, etc.)
 - **Azure Translator** — 1 Spanish option
 
-For **25 regional Spanish variants** with quality gates, consider **[DialectOS](https://github.com/Pastorsimon1798/DialectOS)** — an open-source MCP server and CLI:
+For **25 regional Spanish variants** with quality gates, consider **[DialectOS](https://github.com/KyaniteLabs/DialectOS)** — an open-source MCP server and CLI:
 
 ```bash
 npm install -g @dialectos/cli

--- a/docs/launch-kit/stackoverflow/answer-2-i18n-spanish-locales.md
+++ b/docs/launch-kit/stackoverflow/answer-2-i18n-spanish-locales.md
@@ -29,7 +29,7 @@ locales/
 
 **But how do you keep them in sync?**
 
-[DialectOS](https://github.com/Pastorsimon1798/DialectOS) has tools for this exact problem:
+[DialectOS](https://github.com/KyaniteLabs/DialectOS) has tools for this exact problem:
 
 ```bash
 # Detect missing keys across dialect files

--- a/docs/launch-kit/stackoverflow/answer-3-mcp-server-translation.md
+++ b/docs/launch-kit/stackoverflow/answer-3-mcp-server-translation.md
@@ -8,7 +8,7 @@
 
 If you're using Claude Desktop, Cursor, or any MCP client and want **native translation tools**, you need an MCP server that exposes translation capabilities.
 
-**[DialectOS](https://github.com/Pastorsimon1798/DialectOS)** is the first MCP server built specifically for Spanish dialect translation. It exposes 17 tools:
+**[DialectOS](https://github.com/KyaniteLabs/DialectOS)** is the first MCP server built specifically for Spanish dialect translation. It exposes 17 tools:
 
 ```json
 {

--- a/docs/launch-kit/stackoverflow/answer-4-markdown-translation-preservation.md
+++ b/docs/launch-kit/stackoverflow/answer-4-markdown-translation-preservation.md
@@ -15,7 +15,7 @@ Translating markdown docs is harder than plain text because you must preserve:
 
 **Most translation APIs destroy this.** They treat markdown as plain text.
 
-**[DialectOS](https://github.com/Pastorsimon1798/DialectOS)** has a dedicated `translate_markdown` tool that:
+**[DialectOS](https://github.com/KyaniteLabs/DialectOS)** has a dedicated `translate_markdown` tool that:
 
 1. Parses markdown into an AST
 2. Extracts only translatable text nodes

--- a/docs/launch-kit/stackoverflow/answer-5-gender-neutral-spanish.md
+++ b/docs/launch-kit/stackoverflow/answer-5-gender-neutral-spanish.md
@@ -16,7 +16,7 @@ Spanish is a heavily gendered language. Most translation tools default to mascul
 | latino | latine | U.S. Latinx communities |
 | amigos | amigues | Progressive |
 
-**[DialectOS](https://github.com/Pastorsimon1798/DialectOS)** has a dedicated `apply_gender_neutral` tool:
+**[DialectOS](https://github.com/KyaniteLabs/DialectOS)** has a dedicated `apply_gender_neutral` tool:
 
 ```bash
 dialectos i18n apply-gender-neutral ./locales/es-MX.json --style inclusive

--- a/docs/launch-kit/submissions/ai-tool-directories.md
+++ b/docs/launch-kit/submissions/ai-tool-directories.md
@@ -13,7 +13,7 @@
 DialectOS is an open-source translation engine built on the Model Context Protocol (MCP). It translates content to 25 Spanish regional variants while preserving markdown structure and applying adversarial quality gates. Works as an MCP server for Claude Desktop, Cursor, and other AI assistants.
 
 **Category:** Translation / Developer Tools
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 **Pricing:** Free (BSL 1.1)
 
 ---
@@ -29,7 +29,7 @@ Translate to 25 Spanish dialects with an MCP server. DialectOS preserves markdow
 
 **Category:** Translation / Writing
 **Use Case:** Localizing apps and docs for Latin American Spanish markets
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -43,7 +43,7 @@ Translate to 25 Spanish dialects with an MCP server. DialectOS preserves markdow
 Open-source Spanish dialect translation with MCP support. 25 regional variants, structure-preserving markdown translation, adversarial quality gates, and i18n locale tools.
 
 **Category:** AI Translation / Developer Tools
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -57,7 +57,7 @@ Open-source Spanish dialect translation with MCP support. 25 regional variants, 
 The first MCP server for Spanish dialects. Translate to 25 regional variants with quality gates, glossary enforcement, and markdown preservation. CLI and MCP server included.
 
 **Category:** Developer Tools / Translation
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -71,7 +71,7 @@ The first MCP server for Spanish dialects. Translate to 25 regional variants wit
 Spanish dialect translation server with 25 regional variants, MCP integration, and adversarial quality gates. Open source, 1034 tests.
 
 **Category:** Translation
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -86,7 +86,7 @@ Once you're listed in awesome-mcp-servers, Glama will auto-sync. But you can als
 
 MCP server for Spanish dialect translation. 25 variants, 17 tools, quality gates.
 
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -99,7 +99,7 @@ MCP server for Spanish dialect translation. 25 variants, 17 tools, quality gates
 
 Spanish dialect translation MCP server with 25 regional variants.
 
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 ---
 

--- a/docs/launch-kit/submissions/openai-product-discovery.md
+++ b/docs/launch-kit/submissions/openai-product-discovery.md
@@ -14,7 +14,7 @@ DialectOS is an open-source Spanish dialect translation server built on the Mode
 
 **Category:** Developer Tools
 
-**Website:** https://github.com/Pastorsimon1798/DialectOS
+**Website:** https://github.com/KyaniteLabs/DialectOS
 
 **Additional Details:**
 

--- a/docs/launch-kit/submissions/wikidata-entry.md
+++ b/docs/launch-kit/submissions/wikidata-entry.md
@@ -36,8 +36,8 @@
 | genre (P136) | translation software | Search for exact QID |
 | programming language (P277) | TypeScript (Q978185) | |
 | license (P275) | Business Source License 1.1 | May need to create this item |
-| official website (P856) | https://github.com/Pastorsimon1798/DialectOS | |
-| source code repository (P1324) | https://github.com/Pastorsimon1798/DialectOS | |
+| official website (P856) | https://github.com/KyaniteLabs/DialectOS | |
+| source code repository (P1324) | https://github.com/KyaniteLabs/DialectOS | |
 | developer (P178) | Simon Gonzalez | Create person item if needed |
 | software version (P348) | 0.1.1 | |
 | operating system (P306) | cross-platform (Q285308) | |

--- a/docs/launch-kit/twitter/thread.md
+++ b/docs/launch-kit/twitter/thread.md
@@ -81,7 +81,7 @@ Translate "Pick up the file" to Mexican Spanish:
 
 DialectOS applies dialect context + semantic gates.
 
-🔗 https://pastorsimon1798.github.io/DialectOS
+🔗 https://kyanitelabs.github.io/DialectOS
 
 ---
 
@@ -109,7 +109,7 @@ We test harder than we market.
 
 Star it if it helps your project ⭐
 
-🔗 https://github.com/Pastorsimon1798/DialectOS
+🔗 https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -122,7 +122,7 @@ Ship Mexican Spanish. Argentinian Spanish. Puerto Rican Spanish.
 
 Your users will notice.
 
-⭐ https://github.com/Pastorsimon1798/DialectOS
+⭐ https://github.com/KyaniteLabs/DialectOS
 
 ---
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://pastorsimon1798.github.io/DialectOS/sitemap.xml
+Sitemap: https://kyanitelabs.github.io/DialectOS/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://pastorsimon1798.github.io/DialectOS/</loc>
+    <loc>https://kyanitelabs.github.io/DialectOS/</loc>
     <priority>1.0</priority>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://github.com/Pastorsimon1798/DialectOS</loc>
+    <loc>https://github.com/KyaniteLabs/DialectOS</loc>
     <priority>0.9</priority>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>https://github.com/Pastorsimon1798/DialectOS#readme</loc>
+    <loc>https://github.com/KyaniteLabs/DialectOS#readme</loc>
     <priority>0.8</priority>
     <changefreq>weekly</changefreq>
   </url>

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -23,7 +23,7 @@ DialectOS is a Model Context Protocol server that understands 25 Spanish regiona
 
 **Tech stack:** TypeScript, pnpm monorepo, 1034 tests, Vitest
 
-**Repo:** https://github.com/Pastorsimon1798/DialectOS
+**Repo:** https://github.com/KyaniteLabs/DialectOS
 
 Would love feedback from anyone working on multilingual products!
 
@@ -71,7 +71,7 @@ Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
 
 If you're building multilingual products, give it a look.
 
-⭐ https://github.com/Pastorsimon1798/DialectOS
+⭐ https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -95,7 +95,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 
 **License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
 
-https://github.com/Pastorsimon1798/DialectOS
+https://github.com/KyaniteLabs/DialectOS
 
 ---
 
@@ -115,7 +115,7 @@ For teams building multilingual products, this means:
 
 Source available, BSL 1.1 licensed, 1034 tests passing.
 
-https://github.com/Pastorsimon1798/DialectOS
+https://github.com/KyaniteLabs/DialectOS
 
 #i18n #localization #mcp #ai #typescript #opensource
 
@@ -152,4 +152,4 @@ It runs as a Model Context Protocol server, making it the first translation infr
 
 The project includes security hardening (SSRF protection, circuit breakers, adversarial testing), quality gates (semantic drift detection, glossary enforcement), and a full CLI for CI/CD pipelines.
 
-https://github.com/Pastorsimon1798/DialectOS
+https://github.com/KyaniteLabs/DialectOS

--- a/packages/cli/src/__tests__/translate-api-docs.test.ts
+++ b/packages/cli/src/__tests__/translate-api-docs.test.ts
@@ -452,17 +452,17 @@ describe("translate-api-docs command", () => {
       mockReadFile.mockImplementation((filePath: string) => {
         if (filePath === tokenFile) {
           return Promise.resolve(JSON.stringify({
-            tokens: ["Kyanite Labs", "@pastorsimon1798"],
+            tokens: ["Kyanite Labs", "@simongonzalezdc"],
           }));
         }
-        return Promise.resolve("Kyanite Labs by @pastorsimon1798");
+        return Promise.resolve("Kyanite Labs by @simongonzalezdc");
       });
       mockParseMarkdown.mockReturnValue({
         sections: [
           {
             type: "paragraph",
-            content: "Kyanite Labs by @pastorsimon1798",
-            raw: "Kyanite Labs by @pastorsimon1798",
+            content: "Kyanite Labs by @simongonzalezdc",
+            raw: "Kyanite Labs by @simongonzalezdc",
             translatable: true,
           },
         ],
@@ -474,7 +474,7 @@ describe("translate-api-docs command", () => {
       (mockProvider.translate as any).mockImplementation(async (inputText: string) => ({
         translatedText: inputText
           .replace("Kyanite Labs", "Laboratorios Cianita")
-          .replace("@pastorsimon1798", "@pastoresimon1798"),
+          .replace("@simongonzalezdc", "@translated-handle"),
         detectedLanguage: "en",
         provider: "mymemory",
       }));
@@ -486,7 +486,7 @@ describe("translate-api-docs command", () => {
       );
 
       expect(mockWriteOutput).toHaveBeenCalledWith(expect.stringContaining("Kyanite Labs"));
-      expect(mockWriteOutput).toHaveBeenCalledWith(expect.stringContaining("@pastorsimon1798"));
+      expect(mockWriteOutput).toHaveBeenCalledWith(expect.stringContaining("@simongonzalezdc"));
     });
 
     it("should enforce strict glossary mappings in API doc translation", async () => {

--- a/packages/cli/src/__tests__/translate-readme.test.ts
+++ b/packages/cli/src/__tests__/translate-readme.test.ts
@@ -302,17 +302,17 @@ date: 2024-01-01
     });
 
     it("should preserve protected tokens when token file is provided", async () => {
-      const content = "# Kyanite Labs and @pastorsimon1798";
+      const content = "# Kyanite Labs and @simongonzalezdc";
       await fs.writeFile(inputFile, content);
       await fs.writeFile(tokensFile, JSON.stringify({
-        tokens: ["Kyanite Labs", "@pastorsimon1798"],
+        tokens: ["Kyanite Labs", "@simongonzalezdc"],
       }));
 
       const registry = new MockRegistry(
         new MockProvider((text) =>
           text
             .replace("Kyanite Labs", "Laboratorios Cianita")
-            .replace("@pastorsimon1798", "@pastoresimon1798")
+            .replace("@simongonzalezdc", "@translated-handle")
         )
       ) as ProviderRegistry;
 
@@ -326,9 +326,9 @@ date: 2024-01-01
 
       const result = await fs.readFile(outputFile, "utf-8");
       expect(result).toContain("Kyanite Labs");
-      expect(result).toContain("@pastorsimon1798");
+      expect(result).toContain("@simongonzalezdc");
       expect(result).not.toContain("Laboratorios Cianita");
-      expect(result).not.toContain("@pastoresimon1798");
+      expect(result).not.toContain("@translated-handle");
     });
 
     it("should enforce strict glossary mappings for domain terms", async () => {
@@ -362,13 +362,13 @@ date: 2024-01-01
     });
 
     it("should auto-protect identity tokens by default", async () => {
-      const content = "# Follow @pastorsimon1798 on kyanitelabs.tech";
+      const content = "# Follow @simongonzalezdc on kyanitelabs.tech";
       await fs.writeFile(inputFile, content);
 
       const registry = new MockRegistry(
         new MockProvider((text) =>
           text
-            .replace("@pastorsimon1798", "@pastoresimon1798")
+            .replace("@simongonzalezdc", "@translated-handle")
             .replace("kyanitelabs.tech", "kyanitelabs.es")
         )
       ) as ProviderRegistry;
@@ -376,9 +376,9 @@ date: 2024-01-01
       await executeCommand(registry, [inputFile, "--output", outputFile]);
 
       const result = await fs.readFile(outputFile, "utf-8");
-      expect(result).toContain("@pastorsimon1798");
+      expect(result).toContain("@simongonzalezdc");
       expect(result).toContain("kyanitelabs.tech");
-      expect(result).not.toContain("@pastoresimon1798");
+      expect(result).not.toContain("@translated-handle");
       expect(result).not.toContain("kyanitelabs.es");
     });
 

--- a/server/deploy/hostinger-vps/README.md
+++ b/server/deploy/hostinger-vps/README.md
@@ -35,7 +35,7 @@ SSH to the Hostinger VPS. Install Docker if not present (see Dclutter's README f
 
 ```bash
 # Clone the repo on the VPS
-git clone https://github.com/Pastorsimon1798/DialectOS.git
+git clone https://github.com/KyaniteLabs/DialectOS.git
 cd DialectOS/server/deploy/hostinger-vps
 
 # Configure
@@ -52,7 +52,7 @@ docker compose --env-file env.hostinger ps
 
 ## Connecting the GitHub Pages demo
 
-The landing page at `pastorsimon1798.github.io/DialectOS` automatically tries the VPS API
+The landing page at `kyanitelabs.github.io/DialectOS` automatically tries the VPS API
 when the local `/api/status` endpoint is unreachable. No extra configuration needed —
 the page falls back to client-side vocabulary adaptation if the VPS is down.
 


### PR DESCRIPTION
## Summary\n- replace stale personal namespace links across public docs, SEO metadata, launch-kit drafts, and generated discovery files\n- move canonical repo/action references to KyaniteLabs/DialectOS\n- update maintainer/fork/account references to simongonzalezdc and keep license licensor as the human author name\n- refresh token-protection fixtures to use the active handle\n\n## Verification\n- stale-handle rg scan returned no matches\n- pnpm install --frozen-lockfile\n- pnpm -r build\n- pnpm run check:generated\n- pnpm --filter @dialectos/cli exec vitest run src/__tests__/translate-readme.test.ts src/__tests__/translate-api-docs.test.ts\n\n## Note\nA full 
> @dialectos/cli@0.3.0 test /Users/simongonzalezdecruz/workspaces/kyanite-labs/DialectOS/.worktrees/post-rename-owner-cleanup/packages/cli
> vitest run


 RUN  v4.1.5 /Users/simongonzalezdecruz/workspaces/kyanite-labs/DialectOS/.worktrees/post-rename-owner-cleanup/packages/cli

Corpus statistics:  Entries: 0  Corrections: 0  Quality distribution:    High (≥80): 0    Medium (50-79): 0    Low (<50): 0  No dialect entries recorded.Corpus statistics:  Entries: 1  Corrections: 0  Quality distribution:    High (≥80): 1    Medium (50-79): 0    Low (<50): 0  By dialect:    es-MX: 1Exported all dialects corpus to /Users/simongonzalezdecruz/workspaces/kyanite-labs/DialectOS/.worktrees/post-rename-owner-cleanup/packages/cli/test-export.jsonlExported dialect es-MX corpus to /Users/simongonzalezdecruz/workspaces/kyanite-labs/DialectOS/.worktrees/post-rename-owner-cleanup/packages/cli/test-export-mx.jsonlGlossary diff: 1 added, 0 removed, 0 changed
Added:  + file: archivoGlossary diff: 0 added, 1 removed, 0 changed
Removed:  - file: archivoGlossary diff: 0 added, 0 removed, 1 changed
Changed:  ~ button: boton → botónGlossary diff: 0 added, 0 removed, 0 changedGlossary diff: 0 added, 0 removed, 0 changed
 Test Files  39 passed (39)
      Tests  566 passed | 1 skipped (567)
   Start at  11:19:59
   Duration  12.45s (transform 3.62s, setup 0ms, import 32.32s, tests 20.54s, environment 46ms) was attempted after install; it requires built sibling packages and includes timeout-heavy/full-suite failures outside this metadata change. After building the workspace, the changed CLI fixture tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->