### PR TITLE
fix(demo): resolve crash on startup and serve missing static files

### DIFF
--- a/scripts/demo-server.mjs
+++ b/scripts/demo-server.mjs
@@ -51,6 +51,9 @@ const PUBLIC_STATIC_FILES = new Map([
   ["/dialectos-engine.js", "docs/dialectos-engine.js"],
   ["/assets/dialectos-logo.svg", "docs/assets/dialectos-logo.svg"],
   ["/CNAME", "docs/CNAME"],
+  ["/robots.txt", "docs/robots.txt"],
+  ["/sitemap.xml", "docs/sitemap.xml"],
+  ["/llms.txt", "llms.txt"],
 ]);
 
 // Additional safe paths that can be served dynamically from docs/
@@ -240,10 +243,10 @@ async function serveStatic(req, res, rootDir) {
 
 async function loadDefaultServices(rootDir) {
   const serviceUrl = pathToFileURL(path.join(rootDir, "packages/cli/dist/lib/web-demo-service.js")).href;
-  const factoryUrl = pathToFileURL(path.join(rootDir, "packages/cli/dist/lib/provider-factory.js")).href;
+  const factoryUrl = pathToFileURL(path.join(rootDir, "packages/providers/dist/factory.js")).href;
   const service = await import(serviceUrl);
   const factory = await import(factoryUrl);
-  const registry = factory.createProviderRegistry(true);
+  const registry = factory.createProviderRegistry(undefined, true);
   return {
     status: () => service.getWebDemoProviderStatus(registry),
     translate: (request) => service.translateForWebDemo(request, registry),


### PR DESCRIPTION
## Summary
- Fix demo server crash caused by importing non-existent `packages/cli/dist/lib/provider-factory.js` — corrected to `packages/providers/dist/factory.js` with proper call signature
- Add `/robots.txt`, `/sitemap.xml`, and `/llms.txt` to the static file whitelist so smoke-pages passes

## Test plan
- [x] Full test suite passes (1,377 tests, 0 failures)
- [x] Demo server starts and serves all endpoints (200 for landing, status, static files; 503 for translate without provider)
- [x] `node scripts/smoke-pages.mjs` passes all 4 pages
- [x] Launch gate passes (`node scripts/launch-gate.mjs --no-docker`)
- [x] All 18 demo contract tests pass
- [x] Git workspace clean — orphaned worktree removed, 11 stale branches deleted, 17 stale remote refs pruned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->