### PR TITLE
fix(providers): add missing regex capture group in article gender contractions

### DIFF
--- a/packages/providers/src/lexical-substitution.ts
+++ b/packages/providers/src/lexical-substitution.ts
@@ -150,20 +150,20 @@ function fixArticleGender(text: string, oldNoun: string, newNoun: string): strin
 
   if (newGender === "m") {
     text = text.replace(
-      new RegExp(`(^|[^\\p{L}\\p{N}])de\\s+la\\s+${nounLower}([^\\p{L}\\p{N}]|$)`, "giu"),
+      new RegExp(`(^|[^\\p{L}\\p{N}])de\\s+la\\s+(${nounLower})([^\\p{L}\\p{N}]|$)`, "giu"),
       "$1del $2$3"
     );
     text = text.replace(
-      new RegExp(`(^|[^\\p{L}\\p{N}])a\\s+la\\s+${nounLower}([^\\p{L}\\p{N}]|$)`, "giu"),
+      new RegExp(`(^|[^\\p{L}\\p{N}])a\\s+la\\s+(${nounLower})([^\\p{L}\\p{N}]|$)`, "giu"),
       "$1al $2$3"
     );
   } else {
     text = text.replace(
-      new RegExp(`(^|[^\\p{L}\\p{N}])del\\s+${nounLower}([^\\p{L}\\p{N}]|$)`, "giu"),
+      new RegExp(`(^|[^\\p{L}\\p{N}])del\\s+(${nounLower})([^\\p{L}\\p{N}]|$)`, "giu"),
       "$1de la $2$3"
     );
     text = text.replace(
-      new RegExp(`(^|[^\\p{L}\\p{N}])al\\s+${nounLower}([^\\p{L}\\p{N}]|$)`, "giu"),
+      new RegExp(`(^|[^\\p{L}\\p{N}])al\\s+(${nounLower})([^\\p{L}\\p{N}]|$)`, "giu"),
       "$1a la $2$3"
     );
   }


### PR DESCRIPTION
## Summary
- Fix 4 regex replacement patterns in `fixArticleGender()` that referenced `$3` but only defined 2 capture groups
- The noun between the article and word boundary was not captured, causing either a literal `$3` in output text or the noun being dropped entirely
- Wrap the noun pattern `(${nounLower})` in a capture group so all 3 backreferences resolve correctly: `$1`=boundary, `$2`=noun, `$3`=trailing boundary

## Bug Impact
When the dialect output pipeline performed article gender contractions (e.g., "de la botón" → "del botón"), the noun was lost from the output. For example, translating "Click the button to grab your report" to es-PR produced `Dale a la $3para agarrar tu reporte` — the `$3` was a literal regex backreference that leaked into the translation output.

## Test plan
- [x] All 569 existing tests pass (39 test files, 0 failures)
- [x] Verified es-PR translation no longer emits `$3` literal
- [x] Verified noun is preserved in article gender contractions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->