### PR TITLE
fix(types): prevent false-positive lexical substitution of ambiguous slang terms

### DIFF
--- a/packages/providers/src/__tests__/lexical-substitution.test.ts
+++ b/packages/providers/src/__tests__/lexical-substitution.test.ts
@@ -74,4 +74,25 @@ describe("applyLexicalSubstitution", () => {
     expect(result).toContain("zumo");
     expect(result).not.toContain("jugo");
   });
+
+  it("does not swap ambiguous slang terms with common non-slang meanings", () => {
+    // "botón" = button (UI) but also es-UY slang for "cop". Must NOT swap to "tomba".
+    expect(applyLexicalSubstitution("Haga clic en el botón para continuar.", "es-CO"))
+      .toContain("botón");
+
+    // "agente" = agent (generic) but also es-EC variant for "cop". Must NOT swap.
+    expect(applyLexicalSubstitution("El agente secreto fue descubierto.", "es-CO"))
+      .toContain("agente");
+
+    // "cuero" = leather but also es-DO slang for "money" and "cop". Must NOT swap.
+    expect(applyLexicalSubstitution("El cuero del zapato está dañado.", "es-CO"))
+      .toContain("cuero");
+  });
+
+  it("still swaps unambiguous slang terms correctly", () => {
+    // "paco" (es-CL cop slang) is unambiguous — should still swap
+    const result = applyLexicalSubstitution("El paco está en la esquina.", "es-CO");
+    expect(result).toContain("tomba");
+    expect(result).not.toContain("paco");
+  });
 });

--- a/packages/types/src/dialectal-dictionary.json
+++ b/packages/types/src/dialectal-dictionary.json
@@ -44897,7 +44897,8 @@
       "es-UY": {
         "term": "botón",
         "frequency": 1,
-        "register": "informal"
+        "register": "informal",
+        "ambiguous": true
       },
       "es-PY": {
         "term": "mbae",
@@ -44942,7 +44943,8 @@
       "es-EC": {
         "term": "agente",
         "frequency": 1,
-        "register": "universal"
+        "register": "universal",
+        "ambiguous": true
       },
       "es-BO": {
         "term": "choco",
@@ -44952,7 +44954,8 @@
       "es-DO": {
         "term": "cuero",
         "frequency": 1,
-        "register": "informal"
+        "register": "informal",
+        "ambiguous": true
       },
       "es-PR": {
         "term": "policía",
@@ -46001,7 +46004,8 @@
       "es-DO": {
         "term": "cuero",
         "frequency": 2,
-        "register": "informal"
+        "register": "informal",
+        "ambiguous": true
       },
       "es-PR": {
         "term": "chavos",

--- a/packages/types/src/dialectal-dictionary.ts
+++ b/packages/types/src/dialectal-dictionary.ts
@@ -19,6 +19,10 @@ export interface Variant {
   frequency: 1 | 2 | 3;
   register: "formal" | "informal" | "universal";
   notes?: string;
+  /** When true, this variant has a common non-slang meaning and should not
+   *  be used as an avoid-term for lexical substitution. Prevents false
+   *  positives like "botón" (button) being swapped to "tomba" (cop slang). */
+  ambiguous?: boolean;
 }
 
 export interface DictionaryEntry {

--- a/packages/types/src/dialectal-vocabulary.ts
+++ b/packages/types/src/dialectal-vocabulary.ts
@@ -73,7 +73,13 @@ export function getVocabularyForDialect(dialect: SpanishDialect): VocabularySwap
     const variant = resolveVariant(entry, dialect);
     if (!variant) continue;
     const allTerms = getAllTerms(entry);
-    const avoidTerms = allTerms.filter(t => t !== variant.term);
+    // Build avoid-terms, excluding ambiguous variants that have common
+    // non-slang meanings (e.g. "botón" = button, not just es-UY cop slang).
+    const ambiguousTerms = new Set<string>();
+    for (const v of Object.values(entry.variants ?? {})) {
+      if (v?.ambiguous) ambiguousTerms.add(v.term);
+    }
+    const avoidTerms = allTerms.filter(t => t !== variant.term && !ambiguousTerms.has(t));
     swaps.push({
       concept: entry.concept,
       englishGloss: entry.englishGloss,


### PR DESCRIPTION
## Summary
- Fix lexical substitution engine swapping common words ("botón", "agente", "cuero") to slang equivalents when they appeared as regional variants in the `cop_informal` and `money_slang` dictionary concepts
- Add `ambiguous` flag to the `Variant` interface so dictionary entries can mark variants that have common non-slang meanings and should be excluded from avoid-term generation
- Mark 4 variant entries as ambiguous: `botón` (es-UY/cop), `agente` (es-EC/cop), `cuero` (es-DO/cop), `cuero` (es-DO/money)
- Add 3 regression tests for the false-positive cases

## Root cause
The `cop_informal` concept lists "botón" as the es-UY slang for "police officer". For es-CO, this became an avoid-term, causing the engine to swap "el botón" (button, UI) → "la tomba" (cop slang). The LLM translation was correct — the corruption happened in post-processing.

## Test plan
- [x] All 569 existing tests pass
- [x] 3 new regression tests cover botón, agente, cuero false positives
- [x] Verified real slang (paco, yuta) still gets substituted correctly
- [x] E2E test: "Click the button to grab your report." → "Haga clic en el botón para obtener su informe." (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->