### PR TITLE
chore: add Dockerfile for Glama listing checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Minimal image so MCP directories (e.g. Glama) can start the server and run
+# introspection checks. Installs the published package and launches the stdio server.
+FROM node:22-slim
+RUN npm install -g @espanol/mcp
+ENTRYPOINT ["espanol-mcp"]


### PR DESCRIPTION
Adds a minimal Dockerfile that installs the published package (`@espanol/mcp`) and starts the stdio MCP server via its `espanol-mcp` bin, so Glama can run its start + introspection check (required for the punkpeye listing).

Note: not built locally (the dev Docker daemon wasn't available); the image is standard (node:22-slim + global install of the published package + entrypoint to the confirmed bin). Glama runs the authoritative build/introspection check on submission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783010463&installation_id=130430723&pr_number=157&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F157&signature=3427e3c3304a8b7139c665216234c7b43ee6d75470066845a1ef5c7389df6152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->