### PR TITLE
Fix release dry-run tarball smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,15 @@ jobs:
         continue-on-error: true
 
       - name: Verify packages install from tarballs
-        run: node scripts/tarball-smoke.mjs
+        run: |
+          mkdir -p /tmp/dialectos-release-dry-run
+          for pkg in packages/*; do
+            [ -f "$pkg/package.json" ] || continue
+            echo "::group::tarball smoke for $pkg"
+            tarball="$(cd "$pkg" && pnpm pack --pack-destination /tmp/dialectos-release-dry-run | tail -n 1)"
+            node scripts/tarball-smoke.mjs "$tarball"
+            echo "::endgroup::"
+          done
 
       - name: Publish dry-run
         run: |


### PR DESCRIPTION
## Summary
- pack each publishable workspace package before tarball smoke verification
- use pnpm pack so workspace dependencies are rewritten in packed tarballs
- pass the generated tarball path to scripts/tarball-smoke.mjs

## Verification
- local pnpm pack + tarball smoke loop passed for all seven @dialectos packages

This unblocks the Release Dry Run workflow before the actual npm publish step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783043556&installation_id=130430723&pr_number=160&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F160&signature=17131aa4a7e6bbfcc89ee63efbf94f3ef9c0a1062af28b5b0b5e338aee47acdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->