### PR TITLE
Update release runbook for Apache publish

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,7 +25,11 @@ node scripts/benchmark-detection.mjs --out=/tmp/dialectos-detection
 pnpm dialect:certify -- --fail-on-warnings=true --judge=true --out=/tmp/dialectos-cert
 pnpm dialect:certify:adversarial -- --fail-on-warnings=true --judge=true --out=/tmp/dialectos-adv
 pnpm dialect:certify:documents -- --live=true --policy=strict --out=/tmp/dialectos-doc-cert
-npm pack --workspaces --pack-destination /tmp/dialectos-pack
+mkdir -p /tmp/dialectos-pack
+for pkg in packages/*; do
+  [ -f "$pkg/package.json" ] || continue
+  (cd "$pkg" && pnpm pack --pack-destination /tmp/dialectos-pack)
+done
 docker compose config
 ```
 
@@ -53,5 +57,4 @@ The release notes are auto-generated from PR labels per `.github/release.yml`.
 
 ## License Note
 
-All packages are released under BSL-1.1. The Apache-2.0 conversion date is 2030-04-20.
-Production use requires a commercial license or explicit Additional Use Grant until the Change Date.
+All packages are released under Apache-2.0.


### PR DESCRIPTION
## Summary
- update release tarball command to use the verified pnpm pack loop
- replace stale BSL license note with Apache-2.0 release note

## Verification
- package loop produced all seven workspace tarballs
- node --test docs/__tests__/*.test.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783043928&installation_id=130430723&pr_number=161&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F161&signature=4bea08c9300c6f86f0be8902775a59b4b8e57fab249453cf9069dcccd2512f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->