### PR TITLE
Add guarded npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,19 @@
-name: Release Dry Run
+name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish packages to npm
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  dry-run:
+  release:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -46,11 +52,46 @@ jobs:
           done
 
       - name: Publish dry-run
+        if: ${{ !inputs.publish }}
         run: |
-          for pkg in packages/*; do
-            [ -f "$pkg/package.json" ] || continue
-            echo "::group::npm publish --dry-run for $pkg"
-            (cd "$pkg" && npm publish --dry-run)
+          packages=(
+            packages/types
+            packages/security
+            packages/locale-utils
+            packages/markdown-parser
+            packages/providers
+            packages/cli
+            packages/mcp
+          )
+          for pkg in "${packages[@]}"; do
+            echo "::group::pnpm publish --dry-run for $pkg"
+            (cd "$pkg" && pnpm publish --dry-run --access public --no-git-checks)
+            echo "::endgroup::"
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish packages
+        if: ${{ inputs.publish }}
+        run: |
+          packages=(
+            packages/types
+            packages/security
+            packages/locale-utils
+            packages/markdown-parser
+            packages/providers
+            packages/cli
+            packages/mcp
+          )
+          for pkg in "${packages[@]}"; do
+            name="$(node -p "require('./$pkg/package.json').name")"
+            version="$(node -p "require('./$pkg/package.json').version")"
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version already exists on npm; skipping"
+              continue
+            fi
+            echo "::group::pnpm publish for $pkg"
+            (cd "$pkg" && pnpm publish --access public --no-git-checks)
             echo "::endgroup::"
           done
         env:

--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -7,7 +7,7 @@ const workflow = readFileSync('.github/workflows/release.yml', 'utf8');
 test('release workflow is workflow_dispatch only', () => {
   assert.match(workflow, /workflow_dispatch/);
   assert.doesNotMatch(workflow, /push:\s*\n\s*tags:/);
-  assert.doesNotMatch(workflow, /npm publish(?!\s+--dry-run)/);
+  assert.doesNotMatch(workflow, /\bnpm publish\b/);
 });
 
 test('release workflow includes verification steps', () => {
@@ -21,5 +21,17 @@ test('release workflow includes package smoke', () => {
 });
 
 test('release workflow includes dry-run publish', () => {
-  assert.match(workflow, /npm publish --dry-run/);
+  assert.match(workflow, /default:\s*false/);
+  assert.match(workflow, /pnpm publish --dry-run/);
+});
+
+test('release workflow gates real publish behind explicit input', () => {
+  assert.match(workflow, /type:\s*boolean/);
+  assert.match(workflow, /if:\s*\$\{\{\s*inputs\.publish\s*\}\}/);
+  assert.match(workflow, /pnpm publish --access public --no-git-checks/);
+});
+
+test('release workflow skips versions already published to npm', () => {
+  assert.match(workflow, /npm view "\$name@\$version" version/);
+  assert.match(workflow, /already exists on npm; skipping/);
 });


### PR DESCRIPTION
## Summary
- convert the release workflow from dry-run-only to a manual guarded release workflow
- keep dry-run as the default workflow_dispatch behavior
- add an explicit publish boolean input for real npm publishing
- publish packages in dependency order with pnpm publish so workspace dependencies are rewritten correctly

## Verification
- node --test scripts/__tests__/release-workflow.test.mjs
- local ordered pnpm publish --dry-run --access public --no-git-checks passed for all seven packages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783044200&installation_id=130430723&pr_number=162&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F162&signature=b2358add2917ff6d01ab416c71eee942466668b70caaa33df57d139376e3561a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->