### PR TITLE
docs: add KyaniteLabs cross-link footer (SEO/internal linking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Made with ❤️ by KyaniteLabs and contributors.
 
 ## Part of KyaniteLabs
 
-Open-source tools by [KyaniteLabs](https://kyanitelabs.tech). Related projects:
+More from [KyaniteLabs](https://kyanitelabs.tech). Related projects:
 
 - **[mcp-video](https://github.com/KyaniteLabs/mcp-video)** — guardrailed video-editing MCP server for AI agents
 - **[Epoch](https://github.com/KyaniteLabs/Epoch)** — time-estimation MCP server (PERT) for AI agents

--- a/README.md
+++ b/README.md
@@ -488,3 +488,15 @@ Made with ❤️ by KyaniteLabs and contributors.
 **Star ⭐ this repo if it helps your project!**
 
 </div>
+
+---
+
+## Part of KyaniteLabs
+
+Open-source tools by [KyaniteLabs](https://kyanitelabs.tech). Related projects:
+
+- **[mcp-video](https://github.com/KyaniteLabs/mcp-video)** — guardrailed video-editing MCP server for AI agents
+- **[Epoch](https://github.com/KyaniteLabs/Epoch)** — time-estimation MCP server (PERT) for AI agents
+- **[checkyourself](https://github.com/KyaniteLabs/checkyourself)** — local-first production-readiness checks for AI-built code
+
+→ More at **[kyanitelabs.tech](https://kyanitelabs.tech)**


### PR DESCRIPTION
## Why
Internal linking strengthens SEO/GEO authority flow between KyaniteLabs projects and surfaces related open-source tools to readers. Additive and low-maintenance.

## What changed
- Added a consistent **Part of KyaniteLabs** footer to `README.md` linking to 3 related projects + kyanitelabs.tech.
- Docs only — no code, dependencies, or behavior change.

## Verification
- Footer diff rendered; all links resolve to valid repos and the live site.
- License-accurate wording (neutral "More from KyaniteLabs", since some repos are BSL/source-available, not open-source).
- CI green.

## Maintainer checklist
- [x] Docs-only change
- [x] No code/behavior change
- [x] Links + license wording verified