### PR TITLE
Update docs for GitHub release distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,11 @@ pnpm dialect:report -- --input=audits/release-candidate-2026-04-22/model-matrix.
 ### CLI install
 
 ```bash
-# Local development (packages are not published yet)
+# Install the v0.3.0 CLI tarball from the GitHub Release
+pnpm add -g https://github.com/KyaniteLabs/DialectOS/releases/download/v0.3.0/dialectos-cli-0.3.0.tgz
+
+# Or use a local source checkout
+pnpm install --frozen-lockfile
 pnpm build
 
 # Translate to Mexican Spanish
@@ -401,14 +405,14 @@ Yes. DialectOS is an MCP server, so Claude Desktop, Cursor, Windsurf, and other 
 clients can use its 17 translation tools natively.
 
 **Is DialectOS free?**
-It is source-available under BSL 1.1. Most non-production use is free. It becomes Apache-2.0 on 2030-04-20. See [LICENSE](LICENSE) for details.
+Yes. DialectOS v0.3.0 is released under Apache-2.0. See [LICENSE](LICENSE) for details.
 
 **What is MCP?**
 Model Context Protocol is an open standard that lets AI assistants use external tools.
 DialectOS exposes 17 translation tools through MCP so AI agents can translate natively.
 
 **Can I use DialectOS for commercial projects?**
-Commercial/production use requires a commercial license or explicit Additional Use Grant until the Change Date. See [LICENSE](LICENSE) for details.
+Yes. Apache-2.0 allows commercial use, modification, and redistribution subject to the license terms. See [LICENSE](LICENSE) for details.
 
 **How accurate is the translation?**
 DialectOS applies 4 quality gates (token integrity, glossary fidelity, structure integrity,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -33,9 +33,11 @@ done
 docker compose config
 ```
 
-## npm Publish Order
+## Package Distribution
 
-Publish in dependency order:
+The default v0.3.0 distribution path is GitHub Release tarballs plus `SHA256SUMS.txt`.
+
+Attach package tarballs in dependency order:
 
 1. `@dialectos/types`
 2. `@dialectos/security`
@@ -50,7 +52,19 @@ Publish in dependency order:
 After tagging and verifying CI passes, create a GitHub Release from the tag.
 The release notes are auto-generated from PR labels per `.github/release.yml`.
 
-## Rollback / Unpublish Policy
+## Optional npm Publish Order
+
+If npm publishing is explicitly enabled later, publish in dependency order with `pnpm publish` so workspace dependencies are rewritten correctly:
+
+1. `@dialectos/types`
+2. `@dialectos/security`
+3. `@dialectos/locale-utils`
+4. `@dialectos/markdown-parser`
+5. `@dialectos/providers`
+6. `@dialectos/cli`
+7. `@dialectos/mcp`
+
+## npm Rollback / Unpublish Policy
 
 - Within 72 hours of publish: `npm unpublish <package>@<version>`
 - After 72 hours: publish a patch version with the fix; do not unpublish

--- a/docs/SEO-AI-SEO-MASTERPLAN.md
+++ b/docs/SEO-AI-SEO-MASTERPLAN.md
@@ -17,7 +17,7 @@
 | 1 | **Only 1 star** | Social proof death spiral. People don't star what looks abandoned. | Hard — needs launch |
 | 2 | **Only 10/20 GitHub topics** | Missing `nlp`, `llm`, `ai`, `machine-translation`, `vscode-extension`, `es-mx`, `es-ar`, `gender-neutral`, `formality`, `chatgpt`, `claude`, `anthropic`, `openai`, `langchain`, `awesome` | Invisible in topic search | 5 min |
 | 3 | **No custom social preview image** | Default GitHub OG image is ugly. When shared on Twitter/LinkedIn/Slack, looks amateur. | Low shareability | 30 min |
-| 4 | **CITATION.cff says MIT license** | Actual repo license is BSL-1.1. Academic confusion + legal mismatch. | Credibility hit | 2 min |
+| 4 | **CITATION.cff license metadata must match** | Actual repo license is Apache-2.0. Academic confusion + legal mismatch hurts credibility. | Credibility hit | 2 min |
 | 5 | **CITATION.cff says "20 variants"** | README says 25. Inconsistency signals sloppiness to LLMs. | Trust erosion | 2 min |
 | 6 | **No Open Graph / Twitter Card tags** on docs/index.html | Sharing the demo URL produces a blank card. | Zero social virality | 10 min |
 | 7 | **No schema.org structured data** | Google doesn't know this is a SoftwareApplication. LLMs can't extract entity type. | Unindexable by AI | 20 min |
@@ -37,7 +37,7 @@
 | 16 | **No tutorial blog posts** | No "How to translate your Next.js app to Mexican Spanish with DialectOS" content. | Zero organic search traffic | 4 hrs |
 | 17 | **No Dev.to / Medium presence** | These domains rank insanely well on Google. DialectOS has zero content there. | Zero content marketing | 4 hrs |
 | 18 | **No Stack Overflow answers** | When people ask "How to translate Spanish dialects programmatically?" — you're not there. | Zero intent-based discovery | 2 hrs |
-| 19 | **Release v0.1.1 has no release notes** | The release page is empty. People checking project activity see nothing. | Looks dead | 15 min |
+| 19 | **Release v0.3.0 needs launch-quality notes** | The release page is the main package distribution surface. Thin notes waste credibility. | Looks weak | 15 min |
 | 20 | **No GitHub Wiki** | Could host extended docs, API reference, dialect guides. Another indexable surface. | Wasted SEO real estate | 2 hrs |
 
 ### 🟢 AI SEO / LLMO — THE FUTURE (Fix This Month)
@@ -63,7 +63,7 @@
 
 ```bash
 # 1. Fix CITATION.cff
-# Change: license: MIT → license: BSL-1.1
+# Change: license: MIT → license: Apache-2.0
 # Change: "20 regional variants" → "25 regional variants"
 
 # 2. Fix FUNDING.yml — remove placeholder comment, add real options
@@ -84,8 +84,8 @@ topics_to_add = [
 # Must include: DialectOS logo, tagline, key metrics (25 dialects, 17 MCP tools)
 # Upload: Repo Settings → General → Social preview
 
-# 6. Write release notes for v0.1.1
-# Go to Releases → Edit v0.1.1 → Add changelog
+# 6. Keep release notes current for v0.3.0
+# Go to Releases → Edit v0.3.0 → Add launch notes and asset links
 ```
 
 ### PHASE 1: GitHub Pages SEO (This Week, ~4 hours)
@@ -118,7 +118,7 @@ Add to `docs/index.html` `<head>`:
   "description": "The first Model Context Protocol server built specifically for Spanish dialects. Translate across 25 regional variants with structure preservation and quality gates.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Any",
-  "softwareVersion": "0.1.1",
+  "softwareVersion": "0.3.0",
   "license": "https://github.com/KyaniteLabs/DialectOS/blob/main/LICENSE",
   "codeRepository": "https://github.com/KyaniteLabs/DialectOS",
   "programmingLanguage": ["TypeScript", "JavaScript"],
@@ -288,7 +288,7 @@ DialectOS exposes 17 translation tools through MCP.
   - instance of: software (Q7397)
   - genre: translation software (QXXX)
   - programming language: TypeScript (QXXX)
-  - license: Business Source License 1.1 (QXXX)
+  - license: Apache License 2.0 (Q13785927)
   - official website: https://github.com/KyaniteLabs/DialectOS
   - source code repository: https://github.com/KyaniteLabs/DialectOS
   - developer: Simon Gonzalez
@@ -448,7 +448,7 @@ The $500 Spanish Launch Certification is a brilliant dual-purpose tool:
 - [ ] Add 10 more GitHub topics
 - [ ] Enable GitHub Discussions
 - [ ] Create custom social preview image
-- [ ] Write release notes for v0.1.1
+- [ ] Keep release notes current for v0.3.0
 - [ ] Add OG/Twitter Card tags to docs/index.html
 - [ ] Add schema.org JSON-LD to docs/index.html
 - [ ] Create docs/robots.txt and docs/sitemap.xml
@@ -576,7 +576,7 @@ Print this. Do it in order. Don't skip steps.
 - [ ] Add 10 GitHub topics
 - [ ] Enable GitHub Discussions
 - [ ] Create and upload custom social preview image
-- [ ] Write release notes for v0.1.1
+- [ ] Keep release notes current for v0.3.0
 
 ### This Week
 - [ ] Add OG tags to docs/index.html

--- a/docs/__tests__/public-claims.test.mjs
+++ b/docs/__tests__/public-claims.test.mjs
@@ -29,12 +29,16 @@ for (const file of collateralFiles) {
   }
 }
 
-test('public docs do not claim unpublished packages or unreleased actions', () => {
+test('public docs do not claim unpublished npm packages', () => {
   for (const [file, text] of Object.entries(allContents)) {
     assert.doesNotMatch(text, /npm install -g @dialectos\/cli/iu, `${file} advertises unpublished CLI package`);
     assert.doesNotMatch(text, /npx -y @dialectos\/mcp/iu, `${file} advertises unpublished MCP package`);
-    assert.doesNotMatch(text, /KyaniteLabs\/DialectOS\/action@v0\.3\.0/iu, `${file} advertises unreleased action`);
   }
+});
+
+test('public docs may reference the released v0.3.0 GitHub Action tag', () => {
+  const text = readFileSync('docs/github-action.md', 'utf8');
+  assert.match(text, /KyaniteLabs\/DialectOS\/action@v0\.3\.0/iu);
 });
 
 test('public docs do not call BSL current version open source or production-free', () => {

--- a/docs/launch-kit/submissions/wikidata-entry.md
+++ b/docs/launch-kit/submissions/wikidata-entry.md
@@ -37,11 +37,11 @@
 | instance of (P31) | software (Q7397) | |
 | genre (P136) | translation software | Search for exact QID |
 | programming language (P277) | TypeScript (Q978185) | |
-| license (P275) | Business Source License 1.1 | May need to create this item |
+| license (P275) | Apache License 2.0 (Q13785927) | |
 | official website (P856) | https://github.com/KyaniteLabs/DialectOS | |
 | source code repository (P1324) | https://github.com/KyaniteLabs/DialectOS | |
 | developer (P178) | Simon Gonzalez | Create person item if needed |
-| software version (P348) | 0.1.1 | |
+| software version (P348) | 0.3.0 | |
 | operating system (P306) | cross-platform (Q285308) | |
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,11 +2,15 @@
 
 CLI commands for Spanish dialect translation workflows.
 
-> Package publishing is not enabled yet. For local development, clone the repository and use `pnpm`.
+> v0.3.0 is distributed through GitHub Release tarballs, not the npm registry.
 
-## Installation (development)
+## Installation
 
 ```bash
+# Install the released CLI tarball
+pnpm add -g https://github.com/KyaniteLabs/DialectOS/releases/download/v0.3.0/dialectos-cli-0.3.0.tgz
+
+# Or use a local source checkout
 pnpm install
 pnpm build
 ```

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,6 +2,8 @@
 
 Model Context Protocol server providing 17 tools for Spanish dialect translation across 25 regional variants.
 
+> v0.3.0 is distributed through GitHub Release tarballs, not the npm registry.
+
 ## Usage
 
 Add to your MCP client configuration:
@@ -10,8 +12,11 @@ Add to your MCP client configuration:
 {
   "mcpServers": {
     "dialectos": {
-      "command": "npx",
-      "args": ["-y", "@dialectos/mcp"],
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "https://github.com/KyaniteLabs/DialectOS/releases/download/v0.3.0/dialectos-mcp-0.3.0.tgz"
+      ],
       "env": {
         "DEEPL_AUTH_KEY": "your-key",
         "ALLOWED_LOCALE_DIRS": "/path/to/locales"


### PR DESCRIPTION
## Summary
- document GitHub Release tarballs as the v0.3.0 package distribution path
- remove stale npm registry and BSL-era public docs language
- allow docs to reference the now-released v0.3.0 GitHub Action tag
- refresh release/SEO/Wikidata collateral to Apache-2.0 and v0.3.0

## Verification
- node --test docs/__tests__/*.test.mjs scripts/__tests__/release-workflow.test.mjs
- stale-claim scan for npm registry install, unreleased action, BSL, Change Date, and v0.1.1 references

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783049211&installation_id=130430723&pr_number=164&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F164&signature=6cf386fb5bcf20db7533176b74ab4590b419ec2250126a797257c75949010f92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->