### PR TITLE
Align docs with Apache release distribution

### DIFF
--- a/.llm
+++ b/.llm
@@ -2,7 +2,7 @@
 # Format: https://llm.txt (proposed standard)
 
 ## What is DialectOS?
-DialectOS is a source-available Spanish dialect translation correctness layer built on the Model
+DialectOS is an open-source Spanish dialect translation correctness layer built on the Model
 Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI
 for developers. It supports 25 regional Spanish variants with structure-preserving
 translation, glossary enforcement, adversarial quality gates, and standalone validation.
@@ -60,10 +60,10 @@ translation, glossary enforcement, adversarial quality gates, and standalone val
 | CI integration | No | No | Yes (GitHub Action) |
 | Auto-glossary | No | No | Yes |
 | Public benchmark | No | No | Yes (205 adversarial samples) |
-| Source-available | No | No | Yes (BSL 1.1 → Apache-2.0 on 2030-04-20) |
+| Open-source | No | No | Yes (Apache-2.0) |
 
 ## License
-BSL 1.1 — most non-production use is free. Becomes Apache-2.0 on 2030-04-20.
+Apache-2.0.
 
 ## Links
 - Repository: https://github.com/KyaniteLabs/DialectOS

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **The first Model Context Protocol server built specifically for Spanish dialects.**
 
-DialectOS is a source-available Spanish dialect translation server that runs as an MCP
+DialectOS is an open-source Spanish dialect translation server that runs as an MCP
 (Model Context Protocol) tool and CLI. It translates English and other languages into
 25 regional Spanish variants — Mexican, Argentinian, Colombian, Puerto Rican, and more —
 while preserving markdown structure, enforcing glossary terms, and applying adversarial
@@ -18,7 +18,7 @@ Translate, detect, and adapt content across **25 regional Spanish variants** whi
 
 [![CI](https://github.com/KyaniteLabs/DialectOS/actions/workflows/ci.yml/badge.svg)](https://github.com/KyaniteLabs/DialectOS/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](https://github.com/KyaniteLabs/DialectOS/actions)
-[![License](https://img.shields.io/badge/license-BSL%201.1-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![pnpm](https://img.shields.io/badge/pnpm-9.15.0-orange)](package.json)
 [![MCP](https://img.shields.io/badge/MCP-compatible-purple)](https://modelcontextprotocol.io)
@@ -388,7 +388,7 @@ Quality Score = tokenIntegrity×25% + glossaryFidelity×30% + structureIntegrity
 ## ❓ FAQ
 
 **What is DialectOS?**
-DialectOS is a source-available translation engine for Spanish regional dialects. It runs as
+DialectOS is an open-source translation engine for Spanish regional dialects. It runs as
 an MCP server (for AI assistants like Claude) and a CLI tool for developers.
 
 **How is DialectOS different from Google Translate?**
@@ -481,7 +481,7 @@ See [`ROADMAP.md`](ROADMAP.md) for upcoming features including:
 
 ## 📄 License
 
-BSL 1.1 — see [`LICENSE`](LICENSE) for details. The Licensed Work will become available under Apache-2.0 on 2030-04-20.
+Apache-2.0 — see [`LICENSE`](LICENSE) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document outlines the planned direction for DialectOS. It is a living docum
 
 ## 🎯 Vision
 
-Become the **most accurate source-available engine for Spanish dialect detection and adaptation**. We focus on depth over breadth: 25 Spanish variants with high-quality keyword detection, register classification, and vocabulary adaptation rules.
+Become the **most accurate open-source engine for Spanish dialect detection and adaptation**. We focus on depth over breadth: 25 Spanish variants with high-quality keyword detection, register classification, and vocabulary adaptation rules.
 
 ## 📅 Short Term (Next 1–3 Months)
 

--- a/docs/SEO-AI-SEO-MASTERPLAN.md
+++ b/docs/SEO-AI-SEO-MASTERPLAN.md
@@ -167,7 +167,7 @@ Create `docs/sitemap.xml`:
 **Add a crystal-clear "What is DialectOS?" paragraph at the very top** (LLMs extract this):
 
 ```markdown
-DialectOS is an source-available Spanish dialect translation server that runs as an MCP
+DialectOS is an open-source Spanish dialect translation server that runs as an MCP
 (Model Context Protocol) tool and CLI. It translates English and other languages into
 25 regional Spanish variants — Mexican, Argentinian, Colombian, Puerto Rican, and more —
 while preserving markdown structure, enforcing glossary terms, and applying adversarial
@@ -180,7 +180,7 @@ quality gates that catch semantic drift before it reaches users.
 ## ❓ FAQ
 
 **What is DialectOS?**
-DialectOS is an source-available translation engine for Spanish regional dialects. It runs as
+DialectOS is an open-source translation engine for Spanish regional dialects. It runs as
 an MCP server (for AI assistants like Claude) and a CLI tool.
 
 **How is DialectOS different from Google Translate?**
@@ -196,7 +196,7 @@ Yes. DialectOS is an MCP server, so Claude Desktop, Cursor, and other MCP client
 use its 17 translation tools natively.
 
 **Is DialectOS free?**
-Yes. It's licensed under BSL 1.1 (free for most use) and becomes Apache-2.0 in 2030.
+Yes. It's licensed under Apache-2.0.
 
 **What is MCP?**
 Model Context Protocol is an open standard that lets AI assistants use external tools.
@@ -221,7 +221,7 @@ DialectOS exposes 17 translation tools through MCP.
 | i18n locale support | ❌ | ❌ | ✅ |
 | Gender-neutral output | ❌ | ❌ | ✅ |
 | Quality gates | ❌ | ❌ | ✅ |
-| Source-available | ❌ | ❌ | ✅ |
+| Open-source | ❌ | ❌ | ✅ |
 | Free | ✅ | Partial | ✅ |
 ```
 
@@ -273,7 +273,7 @@ DialectOS exposes 17 translation tools through MCP.
 8. **Twitter/X thread**:
    - Thread: "We shipped a product to Mexico using Spain Spanish translations. Users thought we were being rude."
    - 10-tweet thread covering the problem, solution, demo, and architecture
-   - Tag: #buildinpublic #i18n #mcp #spanish #source-available
+   - Tag: #buildinpublic #i18n #mcp #spanish #open-source
 
 ### PHASE 4: AI SEO / LLMO (Ongoing)
 
@@ -300,7 +300,7 @@ Create `.llm` at repo root:
 # Format: https://llm.txt (proposed standard)
 
 ## What is DialectOS?
-DialectOS is an source-available Spanish dialect translation server built on the Model
+DialectOS is an open-source Spanish dialect translation server built on the Model
 Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI
 for developers. It supports 25 regional Spanish variants with structure-preserving
 translation, glossary enforcement, and adversarial quality gates.
@@ -323,7 +323,7 @@ translation, glossary enforcement, and adversarial quality gates.
 - MCP-native translation workflows in Claude/Cursor
 
 ## License
-BSL 1.1 (free for most use). Becomes Apache-2.0 on 2030-04-20.
+Apache-2.0.
 
 ## Links
 - Repository: https://github.com/KyaniteLabs/DialectOS
@@ -348,7 +348,7 @@ Publish these articles (on your own blog, Medium, Dev.to):
 **6. Tutorial Content Strategy**
 - "How to Add Mexican Spanish to Your Next.js App with DialectOS"
 - "Setting Up DialectOS as an MCP Server in Claude Desktop"
-- "Translating Your Source-Available README to 5 Spanish Dialects"
+- "Translating Your Open-Source README to 5 Spanish Dialects"
 - "Building a Spanish Localization Pipeline with DialectOS and GitHub Actions"
 
 **7. Entity Consistency**
@@ -361,7 +361,7 @@ Ensure this exact phrase appears on:
 - Product Hunt listing
 - All social profiles
 
-> "DialectOS is an source-available Spanish dialect translation server built on the Model Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI for developers, supporting 25 regional Spanish variants with structure-preserving translation, glossary enforcement, and adversarial quality gates."
+> "DialectOS is an open-source Spanish dialect translation server built on the Model Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI for developers, supporting 25 regional Spanish variants with structure-preserving translation, glossary enforcement, and adversarial quality gates."
 
 ---
 
@@ -425,11 +425,11 @@ Your test count is insane for a 0.1.0 project. Flaunt it:
 - "More tests than stars" self-deprecating tweet
 - "We test harder than we market" — use as a brand voice
 
-### Secret Weapon #4: The BSL → Apache License
-The license conversion date (2030-04-20) is a built-in news hook:
-- "Open sourcing in 2030" creates FOMO
-- "Free now, fully open later" is a compelling narrative
-- Write a blog post about why you chose BSL
+### Secret Weapon #4: The Apache-2.0 Release
+The Apache-2.0 license is a launch trust signal:
+- Open-source with permissive commercial use
+- GitHub Release tarballs with SHA256 checksums
+- Write a blog post about why dialect correctness needs open infrastructure
 
 ### Secret Weapon #5: The Certification Business
 The $500 Spanish Launch Certification is a brilliant dual-purpose tool:
@@ -516,7 +516,7 @@ LLMs recommend by association. If your name appears near:
 - "best spanish translation tools"
 - "mcp servers for developers"
 - "i18n localization tools"
-- "source-available translation"
+- "open-source translation"
 ...you'll be recommended for those queries.
 
 **3. Create Retrieval-Augmented Generation (RAG) Hooks**
@@ -540,7 +540,7 @@ Every week, ask ChatGPT/Claude/Perplexity:
 - "What are the best tools for Spanish dialect translation?"
 - "What MCP servers are available for translation?"
 - "How do I translate my app to Mexican Spanish?"
-- "What are good source-available i18n tools for Spanish?"
+- "What are good open-source i18n tools for Spanish?"
 
 Track whether DialectOS is mentioned. If not, publish more content targeting those exact queries.
 

--- a/docs/__tests__/public-claims.test.mjs
+++ b/docs/__tests__/public-claims.test.mjs
@@ -41,10 +41,10 @@ test('public docs may reference the released v0.3.0 GitHub Action tag', () => {
   assert.match(text, /KyaniteLabs\/DialectOS\/action@v0\.3\.0/iu);
 });
 
-test('public docs do not call BSL current version open source or production-free', () => {
+test('public docs do not contain stale BSL license claims', () => {
   for (const [file, text] of Object.entries(allContents)) {
-    assert.doesNotMatch(text, /open[- ]source/iu, `${file} uses open-source for current BSL release`);
-    assert.doesNotMatch(text, /production use allowed|allows production use/iu, `${file} overstates BSL production rights`);
+    assert.doesNotMatch(text, /BSL|Business Source|Change Date|Additional Use Grant/iu, `${file} contains stale BSL-era license language`);
+    assert.doesNotMatch(text, /becomes Apache-2\.0|Apache-2\.0 in 2030|2030-04-20/iu, `${file} contains stale delayed-Apache language`);
   }
 });
 

--- a/docs/adr/0001-publish-semver-over-workspace-protocol.md
+++ b/docs/adr/0001-publish-semver-over-workspace-protocol.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted — implementation pending.
+Superseded by the v0.3.0 GitHub Release tarball distribution path.
+
+Current release packaging uses `pnpm pack`/`pnpm publish --dry-run` because pnpm rewrites `workspace:*` dependencies in packed artifacts. npm registry publishing remains optional and guarded.
 
 ## Context
 
@@ -16,30 +18,28 @@ This is idiomatic for pnpm development: it guarantees the local version is alway
 
 However, `workspace:*` is **not resolvable by npm**. When consumers run `npm install @dialectos/cli` from a published tarball, npm encounters `workspace:*` in the transitive dependency tree and fails.
 
-The project intends to publish packages to the npm registry. The `npm pack --dry-run` check in CI verifies tarball contents but does not attempt installation, so the `workspace:*` leakage was not caught.
+The v0.3.0 release distributes package tarballs through GitHub Releases. npm registry publishing is optional and intentionally guarded because it requires an npm token.
 
 ## Decision
 
-Replace all `workspace:*` dependency specifiers with concrete semver ranges (initially `^0.3.0` or exact `0.3.0`) in every `packages/*/package.json`.
-
-Keep pnpm workspace linking via the existing `pnpm-workspace.yaml` and lockfile; pnpm will still prefer the local copy during development.
+Keep `workspace:*` for local development and use pnpm-based release packaging so published tarballs receive concrete dependency versions.
 
 ## Consequences
 
 ### Positive
-- Published tarballs are installable by npm, yarn, and pnpm consumers.
-- `scripts/package-smoke.mjs` can prove end-to-end installability from a clean temp project.
-- Version bumps become an explicit, reviewable step in the release workflow.
+- GitHub Release tarballs keep local workspace development simple while still producing installable artifacts.
+- `scripts/tarball-smoke.mjs` verifies packed artifacts do not leak `workspace:*`.
+- npm registry publishing can be enabled later without changing local development dependency declarations.
 
 ### Negative
-- Releasing a coordinated change across multiple packages requires bumping versions in multiple `package.json` files simultaneously.
-- Risk of local development accidentally resolving a registry copy instead of the local workspace copy if versions are not kept in sync. Mitigation: enforce `pnpm install --frozen-lockfile` in CI and run `pnpm build` before any publish step.
+- Consumers install from GitHub Release tarball URLs until npm publishing is explicitly enabled.
+- The release workflow must continue using pnpm packaging; raw `npm pack` does not rewrite workspace protocol dependencies.
 
 ## Alternatives Considered
 
 1. **Keep `workspace:*` and rely on pnpm publish rewrite.**
    - pnpm can rewrite `workspace:*` to the actual version during `pnpm publish`.
-   - Rejected because the project uses `npm pack` and manual tarball verification; we want the tarball itself to be correct without requiring pnpm-specific publish tooling.
+   - Accepted for v0.3.0 because the release workflow and tarball smoke tests now use pnpm packaging.
 
 2. **Use `workspace:^0.3.0`.**
    - Still workspace-protocol; npm cannot resolve it.

--- a/docs/index.html
+++ b/docs/index.html
@@ -495,7 +495,7 @@
 
   <footer class="shell">
     <div class="footer-inner">
-      <p><a href="https://github.com/KyaniteLabs/DialectOS">DialectOS</a> — BSL 1.1, Apache-2.0 on 2030-04-20</p>
+      <p><a href="https://github.com/KyaniteLabs/DialectOS">DialectOS</a> — Apache-2.0</p>
       <p class="mono">1034 tests · 17 MCP tools · 25 dialects</p>
     </div>
   </footer>

--- a/docs/launch-kit/awesome-list-prs/awesome-mcp-servers.md
+++ b/docs/launch-kit/awesome-list-prs/awesome-mcp-servers.md
@@ -52,11 +52,11 @@ Go to: `https://github.com/punkpeye/awesome-mcp-servers/compare/main...simongonz
 ```
 Adds [DialectOS](https://github.com/KyaniteLabs/DialectOS) to the Translation section.
 
-DialectOS is an source-available MCP server for Spanish regional dialect translation:
+DialectOS is an open-source MCP server for Spanish regional dialect translation:
 - 25 Spanish dialects (es-MX, es-AR, es-CO, es-PR, etc.)
 - 17 MCP tools for translation, i18n, glossary, and research workflows
 - Structure-preserving markdown translation (tables, code blocks, links)
 - Adversarial quality gates (semantic drift, negation preservation, structure validation)
 - automated tests across 7 packages
-- BSL 1.1 license (free for most use, Apache-2.0 in 2030)
+- Apache-2.0 license
 ```

--- a/docs/launch-kit/awesome-list-prs/awesome-nlp.md
+++ b/docs/launch-kit/awesome-list-prs/awesome-nlp.md
@@ -35,7 +35,7 @@ git push origin add-dialectos
 
 **Body:**
 ```
-DialectOS is an source-available translation engine focused on Spanish regional dialects:
+DialectOS is an open-source translation engine focused on Spanish regional dialects:
 
 - 25 Spanish dialects with vocabulary, grammar, and register adaptation
 - 17 MCP (Model Context Protocol) tools for AI assistant integration

--- a/docs/launch-kit/devto-articles/article-1-mcp-server.md
+++ b/docs/launch-kit/devto-articles/article-1-mcp-server.md
@@ -91,17 +91,17 @@ Quality Score = tokenIntegrity×25% + glossaryFidelity×30% + structureIntegrity
 
 ```bash
 # MCP setup
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 
 # CLI
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 dialectos translate "Hello world" --dialect es-MX
 ```
 
-## Source-Available License
+## Open-Source License
 
 - **automated tests** across 7 packages
-- **BSL 1.1** — free for most use, becomes Apache-2.0 in 2030
+- **Apache-2.0** — open-source license
 - [GitHub](https://github.com/KyaniteLabs/DialectOS)
 - [Live Demo](https://kyanitelabs.github.io/DialectOS)
 

--- a/docs/launch-kit/devto-articles/article-3-adversarial-gates.md
+++ b/docs/launch-kit/devto-articles/article-3-adversarial-gates.md
@@ -98,7 +98,7 @@ Each produces:
 ## Try It
 
 ```bash
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 dialectos translate "Do not proceed" --dialect es-MX
 # If negation drops, you'll see the quality gate fail explicitly
 ```

--- a/docs/launch-kit/medium/article.md
+++ b/docs/launch-kit/medium/article.md
@@ -141,7 +141,7 @@ We built DialectOS to solve this systematically:
 It runs as a CLI tool or an MCP server that Claude Desktop and Cursor can use natively.
 
 ```bash
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 dialectos translate "Hello world" --dialect es-MX
 dialectos translate "Hello world" --dialect es-AR
 ```
@@ -158,6 +158,6 @@ Your users will notice. And they'll thank you for it.
 
 ---
 
-*Simon Gonzalez is the builder of DialectOS, an source-available Spanish dialect translation server. 25 dialects, automated tests, and a mission to fix Spanish localization.*
+*Simon Gonzalez is the builder of DialectOS, an open-source Spanish dialect translation server. 25 dialects, automated tests, and a mission to fix Spanish localization.*
 
 **Repo:** https://github.com/KyaniteLabs/DialectOS

--- a/docs/launch-kit/outreach/newsletters.md
+++ b/docs/launch-kit/outreach/newsletters.md
@@ -9,13 +9,13 @@
 **Contact:** https://javascriptweekly.com/contact (or tweet @JavaScriptDaily)
 **Audience:** 100K+ JavaScript developers
 
-**Subject:** New source-available project: MCP server for Spanish dialect translation in TypeScript
+**Subject:** New open-source project: MCP server for Spanish dialect translation in TypeScript
 
 **Body:**
 
 Hi JavaScript Weekly team,
 
-I wanted to share DialectOS — an source-available Spanish dialect translation engine we built as a TypeScript monorepo.
+I wanted to share DialectOS — an open-source Spanish dialect translation engine we built as a TypeScript monorepo.
 
 It exposes 17 MCP (Model Context Protocol) tools so AI assistants like Claude can translate to 25 Spanish regional variants natively. Think of it as a translation layer that understands Mexican Spanish, Argentinian voseo, and Puerto Rican vocabulary — not just generic "Spanish."
 
@@ -25,7 +25,7 @@ It exposes 17 MCP (Model Context Protocol) tools so AI assistants like Claude ca
 - Structure-preserving markdown translation
 - Adversarial quality gates (catches semantic drift)
 - Works with OpenAI, Anthropic, or local LLMs
-- BSL 1.1 license
+- Apache-2.0 license
 
 **Repo:** https://github.com/KyaniteLabs/DialectOS
 **Demo:** https://kyanitelabs.github.io/DialectOS
@@ -104,13 +104,13 @@ Simon Gonzalez
 **Contact:** https://console.dev/contact
 **Audience:** Senior developers, tool curators
 
-**Subject:** source-available tool recommendation: DialectOS
+**Subject:** open-source tool recommendation: DialectOS
 
 **Body:**
 
 Hi Console team,
 
-I'd like to recommend DialectOS for your newsletter — it's an source-available Spanish dialect translation server with MCP integration.
+I'd like to recommend DialectOS for your newsletter — it's an open-source Spanish dialect translation server with MCP integration.
 
 **Why it fits Console:**
 - Developer-first (TypeScript, CLI, MCP server)
@@ -145,7 +145,7 @@ Simon Gonzalez
 
 Hi Pointer team,
 
-We're building DialectOS — an source-available translation engine for Spanish regional dialects.
+We're building DialectOS — an open-source translation engine for Spanish regional dialects.
 
 It exposes 17 MCP tools, supports 25 dialects, and applies adversarial quality gates to catch semantic drift in AI translations.
 

--- a/docs/launch-kit/outreach/podcasts.md
+++ b/docs/launch-kit/outreach/podcasts.md
@@ -16,7 +16,7 @@
 
 Hi JS Party team,
 
-I'd love to come on the show to talk about DialectOS — an source-available Spanish dialect translation server we built as a TypeScript monorepo.
+I'd love to come on the show to talk about DialectOS — an open-source Spanish dialect translation server we built as a TypeScript monorepo.
 
 **Topics I can cover:**
 - What is MCP (Model Context Protocol) and why it matters for JS devs
@@ -40,19 +40,19 @@ Simon
 ## 2. The Changelog
 
 **Contact:** https://changelog.com/contact
-**Audience:** source-available enthusiasts
+**Audience:** open-source enthusiasts
 **Format:** Guest appearance
 
-**Subject:** source-available project pitch: DialectOS — Spanish dialect translation engine
+**Subject:** open-source project pitch: DialectOS — Spanish dialect translation engine
 
 **Body:**
 
 Hi Changelog team,
 
-I'd like to pitch DialectOS for the show — it's an source-available translation engine for Spanish regional dialects with MCP integration.
+I'd like to pitch DialectOS for the show — it's an open-source translation engine for Spanish regional dialects with MCP integration.
 
 **Why it fits The Changelog:**
-- source-available (BSL 1.1 → Apache-2.0)
+- open-source (Apache-2.0)
 - Solves a real problem with technical depth
 - Interesting architecture (provider registry, circuit breaker, quality gates)
 - Built in the open on GitHub
@@ -119,7 +119,7 @@ Simon Gonzalez
 
 Hi SE Daily team,
 
-I'd like to pitch DialectOS for an episode — it's an source-available Spanish dialect translation server built as a TypeScript monorepo.
+I'd like to pitch DialectOS for an episode — it's an open-source Spanish dialect translation server built as a TypeScript monorepo.
 
 **Topics:**
 - Monorepo architecture with pnpm workspaces
@@ -148,7 +148,7 @@ Simon Gonzalez
 
 Hi Backend Engineering Show team,
 
-I'd love to do a deep dive on DialectOS — our source-available translation server's backend architecture.
+I'd love to do a deep dive on DialectOS — our open-source translation server's backend architecture.
 
 **Architecture highlights:**
 - Provider registry with weighted fallback chains

--- a/docs/launch-kit/product-hunt/launch-kit.md
+++ b/docs/launch-kit/product-hunt/launch-kit.md
@@ -13,9 +13,9 @@
 **Tagline:** The first MCP server for Spanish dialects — 25 variants, quality gates, structure preservation
 **Description:**
 
-DialectOS is an source-available Spanish dialect translation server that runs as an MCP (Model Context Protocol) tool and CLI. It translates English and other languages into 25 regional Spanish variants while preserving markdown structure, enforcing glossary terms, and applying adversarial quality gates that catch semantic drift before it reaches users.
+DialectOS is an open-source Spanish dialect translation server that runs as an MCP (Model Context Protocol) tool and CLI. It translates English and other languages into 25 regional Spanish variants while preserving markdown structure, enforcing glossary terms, and applying adversarial quality gates that catch semantic drift before it reaches users.
 
-**Topics:** Developer Tools, AI, source-available, Translation
+**Topics:** Developer Tools, AI, open-source, Translation
 **Website:** https://kyanitelabs.github.io/DialectOS
 **GitHub:** https://github.com/KyaniteLabs/DialectOS
 

--- a/docs/launch-kit/reddit/r-LocalLLaMA.md
+++ b/docs/launch-kit/reddit/r-LocalLLaMA.md
@@ -10,7 +10,7 @@ If you're running local models and need to translate content to Spanish dialects
 
 But local models can do much better with the right prompts.
 
-**DialectOS** is an source-available translation engine that feeds dialect-specific prompts + grammar profiles + glossary constraints to any LLM:
+**DialectOS** is an open-source translation engine that feeds dialect-specific prompts + grammar profiles + glossary constraints to any LLM:
 
 **Compatible with:**
 - LM Studio (native API)

--- a/docs/launch-kit/reddit/r-javascript.md
+++ b/docs/launch-kit/reddit/r-javascript.md
@@ -48,7 +48,7 @@ if (result.negationDropped) {
 **Try it:**
 
 ```bash
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 dialectos translate "Hello world" --dialect es-MX
 ```
 

--- a/docs/launch-kit/reddit/r-selfhosted.md
+++ b/docs/launch-kit/reddit/r-selfhosted.md
@@ -6,7 +6,7 @@
 
 **Body:**
 
-I've been building DialectOS — an source-available Spanish dialect translation server that runs entirely self-hosted.
+I've been building DialectOS — an open-source Spanish dialect translation server that runs entirely self-hosted.
 
 **The problem it solves:**
 
@@ -40,7 +40,7 @@ pnpm dialect:eval -- --live --provider=llm
 
 **Tech stack:** TypeScript, pnpm workspace, 7 packages, automated tests.
 
-**License:** BSL 1.1 (free for most use, becomes Apache-2.0 in 2030).
+**License:** Apache-2.0.
 
 Demo: https://kyanitelabs.github.io/DialectOS
 Repo: https://github.com/KyaniteLabs/DialectOS

--- a/docs/launch-kit/reddit/r-translate.md
+++ b/docs/launch-kit/reddit/r-translate.md
@@ -33,7 +33,7 @@ We shipped Spain Spanish to Mexico. Users thought we were being rude. Generic Sp
 - Structure-preserving translation (markdown, tables, code)
 - Quality gates that catch semantic drift
 - Works with any translation API (OpenAI, DeepL, LibreTranslate)
-- source-available, automated tests
+- open-source, automated tests
 
 **Supported dialects:** es-ES, es-MX, es-AR, es-CO, es-CL, es-PE, es-VE, es-UY, es-PR, es-CU, es-DO, es-PA, es-CR, es-GT, es-HN, es-SV, es-NI, es-EC, es-BO, es-PY, es-GQ, es-US, es-PH, es-BZ, es-AD
 

--- a/docs/launch-kit/stackoverflow/answer-1-spanish-translation-api.md
+++ b/docs/launch-kit/stackoverflow/answer-1-spanish-translation-api.md
@@ -14,10 +14,10 @@ If you need **dialect-aware Spanish translation** (not just generic "Spanish"), 
 - **DeepL** — ~5 Spanish variants (ES, MX, BR-PT, etc.)
 - **Azure Translator** — 1 Spanish option
 
-For **25 regional Spanish variants** with quality gates, consider **[DialectOS](https://github.com/KyaniteLabs/DialectOS)** — an source-available MCP server and CLI:
+For **25 regional Spanish variants** with quality gates, consider **[DialectOS](https://github.com/KyaniteLabs/DialectOS)** — an open-source MCP server and CLI:
 
 ```bash
-local build (packages not published yet)
+GitHub Release tarball or local source checkout
 dialectos translate "Hello world" --dialect es-MX
 dialectos translate "Hello world" --dialect es-AR
 dialectos translate "Hello world" --dialect es-PR
@@ -31,6 +31,6 @@ dialectos translate "Hello world" --dialect es-PR
 - Glossary enforcement
 - Adversarial quality gates (catches semantic drift, negation drops)
 - Works with OpenAI, Anthropic, DeepL, or local LLMs
-- automated tests, BSL 1.1 license
+- automated tests, Apache-2.0 license
 
 **For existing APIs:** You can use DialectOS as a wrapper — it adds dialect prompts, quality scoring, and fallback chains on top of your existing provider.

--- a/docs/launch-kit/stackoverflow/answer-2-i18n-spanish-locales.md
+++ b/docs/launch-kit/stackoverflow/answer-2-i18n-spanish-locales.md
@@ -54,4 +54,4 @@ dialectos i18n manage-variants ./locales/es-MX.json --target es-AR
 - Supports gender-neutral language (elles, latine)
 - Applies quality gates to catch drift
 
-automated tests, source-available (BSL 1.1).
+automated tests, open-source (Apache-2.0).

--- a/docs/launch-kit/stackoverflow/answer-3-mcp-server-translation.md
+++ b/docs/launch-kit/stackoverflow/answer-3-mcp-server-translation.md
@@ -16,8 +16,11 @@ If you're using Claude Desktop, Cursor, or any MCP client and want **native tran
 {
   "mcpServers": {
     "dialectos": {
-      "command": "npx",
-      "args": ["-y", "@dialectos/mcp"],
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "https://github.com/KyaniteLabs/DialectOS/releases/download/v0.3.0/dialectos-mcp-0.3.0.tgz"
+      ],
       "env": {
         "LLM_API_URL": "https://api.openai.com/v1/chat/completions",
         "LLM_MODEL": "gpt-4o"
@@ -38,4 +41,4 @@ If you're using Claude Desktop, Cursor, or any MCP client and want **native tran
 
 **Why this matters:** Instead of copy-pasting into ChatGPT and hoping it knows Puerto Rican Spanish, you get **deterministic, tested, dialect-aware translation** with quality gates.
 
-source-available, automated tests, works with any OpenAI/Anthropic/local LLM.
+open-source, automated tests, works with any OpenAI/Anthropic/local LLM.

--- a/docs/launch-kit/stackoverflow/answer-4-markdown-translation-preservation.md
+++ b/docs/launch-kit/stackoverflow/answer-4-markdown-translation-preservation.md
@@ -47,4 +47,4 @@ translate_markdown({
 - No HTML injection in output
 - Semantic meaning intact
 
-automated tests, source-available (BSL 1.1 → Apache-2.0 in 2030).
+automated tests, open-source (Apache-2.0).

--- a/docs/launch-kit/stackoverflow/answer-5-gender-neutral-spanish.md
+++ b/docs/launch-kit/stackoverflow/answer-5-gender-neutral-spanish.md
@@ -44,4 +44,4 @@ dialectos i18n apply-gender-neutral ./locales/es-MX.json --style inclusive
 - Dialect appropriateness (some regions resist -e endings)
 - Glossary enforcement (brand terms stay unchanged)
 
-source-available, automated tests.
+open-source, automated tests.

--- a/docs/launch-kit/submissions/ai-tool-directories.md
+++ b/docs/launch-kit/submissions/ai-tool-directories.md
@@ -12,11 +12,11 @@
 **Tagline:** Spanish dialect translation server for 25 regional variants
 **Description:**
 
-DialectOS is an source-available translation engine built on the Model Context Protocol (MCP). It translates content to 25 Spanish regional variants while preserving markdown structure and applying adversarial quality gates. Works as an MCP server for Claude Desktop, Cursor, and other AI assistants.
+DialectOS is an open-source translation engine built on the Model Context Protocol (MCP). It translates content to 25 Spanish regional variants while preserving markdown structure and applying adversarial quality gates. Works as an MCP server for Claude Desktop, Cursor, and other AI assistants.
 
 **Category:** Translation / Developer Tools
 **Website:** https://github.com/KyaniteLabs/DialectOS
-**Pricing:** Free (BSL 1.1)
+**Pricing:** Free (Apache-2.0)
 
 ---
 
@@ -42,7 +42,7 @@ Translate to 25 Spanish dialects with an MCP server. DialectOS preserves markdow
 **Name:** DialectOS
 **Description:**
 
-source-available Spanish dialect translation with MCP support. 25 regional variants, structure-preserving markdown translation, adversarial quality gates, and i18n locale tools.
+open-source Spanish dialect translation with MCP support. 25 regional variants, structure-preserving markdown translation, adversarial quality gates, and i18n locale tools.
 
 **Category:** AI Translation / Developer Tools
 **Website:** https://github.com/KyaniteLabs/DialectOS
@@ -70,7 +70,7 @@ The first MCP server for Spanish dialects. Translate to 25 regional variants wit
 **Name:** DialectOS
 **Description:**
 
-Spanish dialect translation server with 25 regional variants, MCP integration, and adversarial quality gates. source-available, automated tests.
+Spanish dialect translation server with 25 regional variants, MCP integration, and adversarial quality gates. open-source, automated tests.
 
 **Category:** Translation
 **Website:** https://github.com/KyaniteLabs/DialectOS

--- a/docs/launch-kit/submissions/openai-product-discovery.md
+++ b/docs/launch-kit/submissions/openai-product-discovery.md
@@ -12,7 +12,7 @@
 
 **Product Description:**
 
-DialectOS is an source-available Spanish dialect translation server built on the Model Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI for developers, supporting 25 regional Spanish variants with structure-preserving translation, glossary enforcement, and adversarial quality gates.
+DialectOS is an open-source Spanish dialect translation server built on the Model Context Protocol (MCP). It provides 17 translation tools for AI assistants and a CLI for developers, supporting 25 regional Spanish variants with structure-preserving translation, glossary enforcement, and adversarial quality gates.
 
 **Category:** Developer Tools
 
@@ -28,7 +28,7 @@ DialectOS is an source-available Spanish dialect translation server built on the
 - Adversarial quality gates (semantic drift, negation preservation, structure validation)
 - Works with OpenAI, Anthropic, DeepL, and local LLMs
 - automated tests across 7 TypeScript packages
-- BSL 1.1 license (free for most use, Apache-2.0 in 2030)
+- Apache-2.0 license
 
 **Use Cases:**
 - Localizing SaaS apps for Latin American markets

--- a/docs/launch-kit/submissions/wikidata-entry.md
+++ b/docs/launch-kit/submissions/wikidata-entry.md
@@ -20,7 +20,7 @@
 
 ### Descriptions
 
-**English:** source-available Spanish dialect translation server built on the Model Context Protocol
+**English:** open-source Spanish dialect translation server built on the Model Context Protocol
 
 ### Aliases
 

--- a/docs/launch-kit/twitter/thread.md
+++ b/docs/launch-kit/twitter/thread.md
@@ -3,7 +3,7 @@
 # Twitter/X Thread: DialectOS Launch
 
 **Best time to post:** Tuesday or Thursday, 9-11 AM PT
-**Hashtags:** #buildinpublic #i18n #mcp #spanish #source-available #localization #ai #translation
+**Hashtags:** #buildinpublic #i18n #mcp #spanish #open-source #localization #ai #translation
 
 ---
 
@@ -40,7 +40,7 @@ We built support for all 25 — with quality gates that catch bad translations b
 ---
 
 ## Tweet 4 (What It Is)
-DialectOS is an source-available Spanish dialect translation server.
+DialectOS is an open-source Spanish dialect translation server.
 
 It runs as:
 - An MCP server (Claude Desktop, Cursor, etc. use it natively)
@@ -101,10 +101,10 @@ Circuit breaker + rate limiter + translation memory (SHA-256 cache).
 
 ---
 
-## Tweet 9 (source-available)
+## Tweet 9 (open-source)
 - automated tests across 7 packages
-- BSL 1.1 (free for most use)
-- Becomes Apache-2.0 in 2030
+- Apache-2.0
+- GitHub Release tarballs
 - TypeScript, pnpm workspace
 
 We test harder than we market.

--- a/docs/social-launch-kit.md
+++ b/docs/social-launch-kit.md
@@ -69,7 +69,7 @@ Security matters when you're piping content through translation APIs.
 **Tweet 5:**
 automated tests. 7 packages. pnpm monorepo. TypeScript.
 
-Source available. BSL 1.1 license (Apache-2.0 on 2030-04-20).
+Open-source under Apache-2.0.
 
 If you're building multilingual products, give it a look.
 
@@ -95,7 +95,7 @@ I built DialectOS because existing translation APIs treat Spanish as a single la
 
 **Tech:** TypeScript, pnpm monorepo, automated tests
 
-**License:** BSL 1.1 (becomes Apache-2.0 on 2030-04-20)
+**License:** Apache-2.0
 
 https://github.com/KyaniteLabs/DialectOS
 
@@ -115,11 +115,11 @@ For teams building multilingual products, this means:
 - ✅ Markdown, tables, and code blocks stay intact
 - ✅ Quality gates catch semantic drift before release
 
-Source available, BSL 1.1 licensed, automated tests passing.
+Open-source under Apache-2.0, automated tests passing.
 
 https://github.com/KyaniteLabs/DialectOS
 
-#i18n #localization #mcp #ai #typescript #source-available
+#i18n #localization #mcp #ai #typescript #open-source
 
 ---
 
@@ -140,15 +140,15 @@ DialectOS translates content across 25 Spanish regional variants while preservin
 
 **Tech stack:** TypeScript, pnpm monorepo, automated tests
 
-**License:** BSL 1.1 (source available, becomes Apache-2.0 on 2030-04-20)
+**License:** Apache-2.0
 
 ---
 
 ## Email Newsletter / Blog Pitch
 
-**Subject:** New source-available tool: Spanish dialect translation for AI workflows
+**Subject:** New open-source tool: Spanish dialect translation for AI workflows
 
-DialectOS is a new source-available project that solves a problem most translation tools ignore: Spanish has 25 regional variants, and treating them as one language produces poor user experiences.
+DialectOS is a new open-source project that solves a problem most translation tools ignore: Spanish has 25 regional variants, and treating them as one language produces poor user experiences.
 
 It runs as a Model Context Protocol server, making it the first translation infrastructure designed specifically for AI assistant integration. Claude, Cursor, and any MCP client can translate to Mexican Spanish, Argentine Spanish, Colombian Spanish, and 22 more variants without wrappers or glue code.
 


### PR DESCRIPTION
## Summary
- replace stale source-available/BSL-era language with Apache-2.0/open-source language across public docs and launch collateral
- align MCP/install examples with the v0.3.0 GitHub Release tarball distribution path instead of unpublished npm/npx package claims
- update public-claim tests to guard against old BSL and delayed-Apache wording

## Verification
- `rg -n "source-available|Source-available|Source-Available|BSL|Business Source|Change Date|commercial license|Additional Use Grant|MIT license|2030-04-20|Apache-2\.0 in 2030|becomes Apache|Becomes Apache|packages are not published yet|Package publishing is not enabled yet|local build \(packages not published yet\)|npx -y @dialectos|npm install -g @dialectos|v0\.1\.1|0\.1\.1|command\": \"npx\"|open-source \(Apache-2\.0 in 2030\)|free for most use, Apache-2\.0|Apache-2\.0 and Apache-2\.0|Apache-2\.0\. Apache-2\.0" README.md SECURITY.md ROADMAP.md .llm docs packages .github --glob "!**/dist/**" --glob "!docs/plans/**"` only reports the intentional guard regexes in `docs/__tests__/public-claims.test.mjs`
- `node --test docs/__tests__/*.test.mjs scripts/__tests__/release-workflow.test.mjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783050777&installation_id=130430723&pr_number=165&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F165&signature=09214b279974867222d83833ba55356a86bd974f06e5f1e1fdfb9ce4c3eacf02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->