### PR TITLE
Fix Glama MCP startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@
 # introspection checks. Installs the published package and launches the stdio server.
 FROM node:22-slim
 RUN npm install -g @espanol/mcp
-ENTRYPOINT ["espanol-mcp"]
+ENTRYPOINT ["node", "/usr/local/lib/node_modules/@espanol/mcp/dist/index.js"]

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,7 +11,8 @@
  * - Bilingual document creation (create_bilingual_doc)
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerDocsTools } from "./tools/docs.js";
@@ -76,8 +77,22 @@ async function main(): Promise<void> {
   // No need to log anything as stdout/stderr are used for the protocol
 }
 
+function isCurrentFileEntrypoint(): boolean {
+  const entrypoint = process.argv[1];
+
+  if (!entrypoint) {
+    return false;
+  }
+
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(entrypoint)).href;
+  } catch {
+    return import.meta.url === pathToFileURL(entrypoint).href;
+  }
+}
+
 // Start the server if this file is run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isCurrentFileEntrypoint()) {
   main().catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     console.error(JSON.stringify({ level: "fatal", error: "MCP_STARTUP_FAILED", message }));


### PR DESCRIPTION
## Summary\n- start the Glama Docker image through the package's real dist entrypoint instead of the npm bin symlink\n- make the MCP package entrypoint guard symlink-safe for future package releases\n\n## Verification\n- pnpm --filter @dialectos/mcp build\n- pnpm --filter @dialectos/mcp test\n- MCP client handshake against node packages/mcp/dist/index.js returned 17 tools

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783128460&installation_id=130430723&pr_number=167&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F167&signature=b6ca4a8653fd6701ae6583b3a2010ac6b7f43618106c26c80347fb176e267a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->