### PR TITLE
Improve MCP tool metadata for Glama scoring

### DIFF
--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -32,6 +32,7 @@ import type { ProviderRegistry } from "@dialectos/providers";
 import { ToolResult } from "../lib/types.js";
 import type { BaseToolOptions } from "../lib/types.js";
 import { createProviderRegistry } from "@dialectos/providers";
+import { registerScoredTool } from "./metadata.js";
 
 // Re-export for backward compatibility
 export { createProviderRegistry };
@@ -485,56 +486,100 @@ export function registerDocsTools(
   // Create rate limiter if not provided
   const rateLimiter = options.rateLimiter || new RateLimiter(60, 60000);
 
-  // Register translate_markdown tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_markdown",
-    "Translate a markdown file while preserving structure (code blocks, links, etc.)",
     {
-      filePath: z.string().describe("Path to the markdown file to translate"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
-      formal: z.boolean().optional().describe("Use formal tone (for languages that distinguish formal/informal)"),
-      informal: z.boolean().optional().describe("Use informal tone (for languages that distinguish formal/informal)"),
+      title: "Translate Markdown file",
+      description:
+        "Read a Markdown file, translate translatable prose into a Spanish dialect, and return reconstructed Markdown while preserving code blocks, links, and non-translatable sections. Reads the file only; it does not overwrite the source file.",
+      inputSchema: {
+        filePath: z.string().min(1).describe("Path to the Markdown file to read and translate."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code. Defaults to es-ES when omitted; examples include es-MX, es-AR, and es-CO."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+        formal: z.boolean().optional().describe("Request formal Spanish register. Do not set both formal and informal."),
+        informal: z.boolean().optional().describe("Request informal Spanish register. Do not set both informal and formal."),
+      },
+      annotations: {
+        title: "Translate Markdown file",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (params) => {
       return handleTranslateMarkdown(params as TranslateMarkdownParams, registry, rateLimiter);
     }
   );
 
-  // Register extract_translatable tool
-  server.tool(
+  registerScoredTool(
+    server,
     "extract_translatable",
-    "Extract translatable text from a markdown file (excludes code blocks, HTML)",
     {
-      filePath: z.string().describe("Path to the markdown file to analyze"),
+      title: "Extract translatable Markdown text",
+      description:
+        "Read a Markdown file and return only the prose sections considered safe to translate, excluding code blocks and other protected structure. This is a read-only analysis tool and does not call a translation provider.",
+      inputSchema: {
+        filePath: z.string().min(1).describe("Path to the Markdown file to inspect for translatable sections."),
+      },
+      annotations: {
+        title: "Extract translatable Markdown text",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       return handleExtractTranslatable(params as ExtractTranslatableParams, registry, rateLimiter);
     }
   );
 
-  // Register translate_api_docs tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_api_docs",
-    "Translate API documentation markdown with optimized handling for tables and lists",
     {
-      filePath: z.string().describe("Path to the API documentation markdown file"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
+      title: "Translate API documentation",
+      description:
+        "Read API documentation Markdown and translate prose into a Spanish dialect with documentation context for tables, lists, endpoints, and technical terms. Returns translated Markdown and errors; it does not modify the file.",
+      inputSchema: {
+        filePath: z.string().min(1).describe("Path to the API documentation Markdown file to read and translate."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code. Defaults to es-ES when omitted."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+      },
+      annotations: {
+        title: "Translate API documentation",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (params) => {
       return handleTranslateApiDocs(params as TranslateApiDocsParams, registry, rateLimiter);
     }
   );
 
-  // Register create_bilingual_doc tool
-  server.tool(
+  registerScoredTool(
+    server,
     "create_bilingual_doc",
-    "Create a side-by-side bilingual document with original and translated sections",
     {
-      filePath: z.string().describe("Path to the markdown file to translate"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
+      title: "Create bilingual Markdown document",
+      description:
+        "Read a Markdown file and return a bilingual document that pairs original sections with Spanish translations. The result is returned as Markdown text; the source file is read only and not overwritten.",
+      inputSchema: {
+        filePath: z.string().min(1).describe("Path to the Markdown file to read and convert into a bilingual document."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code for translated sections. Defaults to es-ES when omitted."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+      },
+      annotations: {
+        title: "Create bilingual Markdown document",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (params) => {
       return handleCreateBilingualDoc(params as CreateBilingualDocParams, registry, rateLimiter);

--- a/packages/mcp/src/tools/i18n.ts
+++ b/packages/mcp/src/tools/i18n.ts
@@ -43,6 +43,7 @@ import {
 import { ToolResult } from "../lib/types.js";
 import { createProviderRegistry } from "@dialectos/providers";
 import type { TranslateOptions } from "@dialectos/types";
+import { registerScoredTool } from "./metadata.js";
 
 // ============================================================================
 // Types
@@ -839,12 +840,24 @@ export function registerI18nTools(
   const rateLimiter = options.rateLimiter || new RateLimiter(60, 60000);
 
   // Register detect_missing_keys tool
-  server.tool(
+  registerScoredTool(
+    server,
     "detect_missing_keys",
-    "Compare two locale files and report missing keys",
     {
-      basePath: z.string().describe("Path to the base locale file"),
-      targetPath: z.string().describe("Path to the target locale file"),
+      title: "Detect missing locale keys",
+      description:
+        "Compare a base JSON locale file against a target JSON locale file and return keys present in the base but absent from the target. Reads both files only; it does not translate, create, or modify locale files.",
+      inputSchema: {
+        basePath: z.string().min(1).describe("Absolute or workspace-relative path to the complete base JSON locale file, such as locales/en.json."),
+        targetPath: z.string().min(1).describe("Absolute or workspace-relative path to the target JSON locale file to audit, such as locales/es-MX.json."),
+      },
+      annotations: {
+        title: "Detect missing locale keys",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       return handleDetectMissingKeys(params as DetectMissingKeysParams, registry, rateLimiter);
@@ -852,14 +865,26 @@ export function registerI18nTools(
   );
 
   // Register translate_missing_keys tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_missing_keys",
-    "Translate missing keys from base locale to target locale",
     {
-      basePath: z.string().describe("Path to the base locale file"),
-      targetPath: z.string().describe("Path to the target locale file"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
+      title: "Translate missing locale keys",
+      description:
+        "Fill a target JSON locale file with translated values for keys that exist in the base locale but are missing from the target. Reads both files and writes the updated target file; existing target keys are preserved.",
+      inputSchema: {
+        basePath: z.string().min(1).describe("Path to the source JSON locale file that contains the canonical key set and source-language values."),
+        targetPath: z.string().min(1).describe("Path to the JSON locale file to update with translated missing keys. This file may be modified in place."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code. Defaults to es-ES when omitted; examples include es-MX, es-AR, and es-CO."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+      },
+      annotations: {
+        title: "Translate missing locale keys",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (params) => {
       return handleTranslateMissingKeys(params as TranslateMissingKeysParams, registry, rateLimiter);
@@ -867,16 +892,28 @@ export function registerI18nTools(
   );
 
   // Register batch_translate_locales tool
-  server.tool(
+  registerScoredTool(
+    server,
     "batch_translate_locales",
-    "Translate base locale to multiple target dialects",
     {
-      directory: z.string().describe("Directory containing locale files"),
-      baseLocale: z.string().optional().describe("Base locale name (e.g., en, es-ES)"),
-      targets: z.array(z.string().refine((v) => ALL_SPANISH_DIALECTS.includes(v as SpanishDialect), {
-        message: "Invalid Spanish dialect code",
-      })).describe("Array of target Spanish dialect codes"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
+      title: "Batch translate locale files",
+      description:
+        "Create or update multiple Spanish JSON locale files from one base locale file in a directory. For each target dialect it writes <dialect>.json, preserves existing translated keys, translates only missing keys, and returns per-target errors without deleting files.",
+      inputSchema: {
+        directory: z.string().min(1).describe("Directory containing locale JSON files. The base file is read from this directory and target files are written here."),
+        baseLocale: z.string().min(1).optional().describe("Base locale filename without .json. Defaults to en, so the default source file is en.json."),
+        targets: z.array(z.string().refine((v) => ALL_SPANISH_DIALECTS.includes(v as SpanishDialect), {
+          message: "Invalid Spanish dialect code",
+        })).min(1).max(MAX_ARRAY_LENGTH).describe("One or more target Spanish dialect codes to generate or update, such as es-MX, es-AR, or es-CO."),
+        provider: providerNameSchema.optional().describe("Translation provider to use for all targets. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+      },
+      annotations: {
+        title: "Batch translate locale files",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (params) => {
       return handleBatchTranslateLocales(params as BatchTranslateLocalesParams, registry, rateLimiter);
@@ -884,15 +921,27 @@ export function registerI18nTools(
   );
 
   // Register manage_dialect_variants tool
-  server.tool(
+  registerScoredTool(
+    server,
     "manage_dialect_variants",
-    "Create dialect-specific variants of a locale file",
     {
-      sourcePath: z.string().describe("Path to the source locale file"),
-      variant: z.string().refine((v) => ALL_SPANISH_DIALECTS.includes(v as SpanishDialect), {
-        message: "Invalid Spanish dialect variant",
-      }).describe("Target dialect variant (e.g., es-MX, es-AR, es-CO)"),
-      outputPath: z.string().optional().describe("Output path (optional, defaults to source path)"),
+      title: "Create dialect locale variant",
+      description:
+        "Apply deterministic regional vocabulary substitutions to a JSON locale file for a specific Spanish dialect. Writes the adapted locale to outputPath when provided; otherwise overwrites sourcePath.",
+      inputSchema: {
+        sourcePath: z.string().min(1).describe("Path to the source JSON locale file whose string values should be adapted."),
+        variant: z.string().refine((v) => ALL_SPANISH_DIALECTS.includes(v as SpanishDialect), {
+          message: "Invalid Spanish dialect variant",
+        }).describe("Target Spanish dialect variant for regional vocabulary adaptation, such as es-MX, es-AR, or es-CO."),
+        outputPath: z.string().min(1).optional().describe("Destination JSON file. Omit to update the source file in place."),
+      },
+      annotations: {
+        title: "Create dialect locale variant",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       return handleManageDialectVariants(params as ManageDialectVariantsParams, registry, rateLimiter);
@@ -900,12 +949,24 @@ export function registerI18nTools(
   );
 
   // Register check_formality tool
-  server.tool(
+  registerScoredTool(
+    server,
     "check_formality",
-    "Check locale file for formality consistency",
     {
-      localePath: z.string().describe("Path to the locale file to check"),
-      register: z.enum(["formal", "informal"]).optional().describe("Register to check for (formal or informal)"),
+      title: "Check locale formality",
+      description:
+        "Audit a JSON locale file for Spanish register consistency by flagging informal tú/vos patterns in formal copy or usted patterns in informal copy. Reads the locale file and returns issue objects; it does not rewrite text.",
+      inputSchema: {
+        localePath: z.string().min(1).describe("Path to the JSON locale file to inspect for formality issues."),
+        register: z.enum(["formal", "informal"]).optional().describe("Expected register for the locale copy. Defaults to formal when omitted."),
+      },
+      annotations: {
+        title: "Check locale formality",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       return handleCheckFormality(params as CheckFormalityParams, registry, rateLimiter);
@@ -913,12 +974,24 @@ export function registerI18nTools(
   );
 
   // Register apply_gender_neutral tool
-  server.tool(
+  registerScoredTool(
+    server,
     "apply_gender_neutral",
-    "Apply gender-neutral language strategies to a locale file",
     {
-      localePath: z.string().describe("Path to the locale file to adapt"),
-      strategy: z.enum(["latine", "elles", "x", "descriptive"]).optional().describe("Gender-neutral strategy (latine, elles, x, descriptive)"),
+      title: "Apply gender-neutral locale language",
+      description:
+        "Rewrite a JSON locale file using one gender-neutral Spanish strategy. This modifies the locale file in place and returns a count of changed entries; it does not call a translation provider.",
+      inputSchema: {
+        localePath: z.string().min(1).describe("Path to the JSON locale file to adapt in place."),
+        strategy: z.enum(["latine", "elles", "x", "descriptive"]).optional().describe("Gender-neutral strategy. Defaults to latine; options are latine, elles, x, and descriptive."),
+      },
+      annotations: {
+        title: "Apply gender-neutral locale language",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       return handleApplyGenderNeutral(params as ApplyGenderNeutralParams, registry, rateLimiter);

--- a/packages/mcp/src/tools/metadata.ts
+++ b/packages/mcp/src/tools/metadata.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
+
+type ToolHandler = (params: any) => unknown;
+
+type ToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+type ScoredToolConfig = {
+  title: string;
+  description: string;
+  inputSchema: z.ZodRawShape;
+  annotations: ToolAnnotations;
+};
+
+type RegisterableServer = McpServer & {
+  registerTool?: (name: string, config: ScoredToolConfig, handler: ToolHandler) => void;
+  tool?: (
+    name: string,
+    description: string,
+    inputSchema: z.ZodRawShape,
+    handler: ToolHandler
+  ) => void;
+};
+
+export function registerScoredTool(
+  server: McpServer,
+  name: string,
+  config: ScoredToolConfig,
+  handler: ToolHandler
+): void {
+  const registerable = server as RegisterableServer;
+
+  if (typeof registerable.registerTool === "function") {
+    registerable.registerTool(name, config, handler);
+    return;
+  }
+
+  registerable.tool?.(name, config.description, config.inputSchema, handler);
+}

--- a/packages/mcp/src/tools/translator.ts
+++ b/packages/mcp/src/tools/translator.ts
@@ -26,6 +26,7 @@ import {
   handleResearchRegionalTerm,
   handleListDialects,
 } from "./translator-handlers.js";
+import { registerScoredTool } from "./metadata.js";
 import type {
   TranslateTextParams,
   DetectDialectParams,
@@ -65,97 +66,160 @@ export function registerTranslatorTools(
   // Create rate limiter if not provided
   const rateLimiter = options.rateLimiter || new RateLimiter(60, 60000);
 
-  // Register translate_text tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_text",
-    "Translate text to a Spanish dialect",
     {
-      text: z.string().describe("Text to translate"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
-      formal: z.boolean().optional().describe("Use formal tone"),
-      informal: z.boolean().optional().describe("Use informal tone"),
+      title: "Translate text to Spanish dialect",
+      description:
+        "Translate a short text string from English into one Spanish regional dialect and return the translated text plus provider metadata. This does not read or write files; it may call the selected translation provider.",
+      inputSchema: {
+        text: z.string().min(1).describe("Source text to translate. Plain text only; for Markdown files use translate_markdown or translate_readme."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code. Defaults to es-ES when omitted; examples include es-MX, es-AR, and es-CO."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+        formal: z.boolean().optional().describe("Request formal Spanish register. Do not set both formal and informal."),
+        informal: z.boolean().optional().describe("Request informal Spanish register. Do not set both informal and formal."),
+      },
+      annotations: {
+        title: "Translate text to Spanish dialect",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
-    async (params) => {
-      return handleTranslateText(params as TranslateTextParams, registry, rateLimiter);
-    }
+    async (params) => handleTranslateText(params as TranslateTextParams, registry, rateLimiter)
   );
 
-  // Register detect_dialect tool
-  server.tool(
+  registerScoredTool(
+    server,
     "detect_dialect",
-    "Detect Spanish dialect from text using keyword matching, grammar analysis, and IDF-weighted scoring across 25 regional variants",
     {
-      text: z.string().describe("Text to analyze for dialect detection"),
+      title: "Detect Spanish dialect",
+      description:
+        "Analyze Spanish text and rank likely regional dialects using vocabulary, grammar, and weighted scoring across 25 variants. Returns the detected dialect, confidence signals, and evidence; it does not translate or modify text.",
+      inputSchema: {
+        text: z.string().min(1).describe("Spanish text to analyze for regional dialect signals."),
+      },
+      annotations: {
+        title: "Detect Spanish dialect",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
-    async (params) => {
-      return handleDetectDialect(params as DetectDialectParams, registry, rateLimiter);
-    }
+    async (params) => handleDetectDialect(params as DetectDialectParams, registry, rateLimiter)
   );
 
-  // Register translate_code_comment tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_code_comment",
-    "Extract and translate code comments (basic text extraction)",
     {
-      code: z.string().describe("Source code with comments to translate"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
+      title: "Translate code comments",
+      description:
+        "Translate English // and /* */ comments inside a code snippet into a Spanish dialect while leaving executable code unchanged. Returns a translated code string and comment-level error list; it does not write files.",
+      inputSchema: {
+        code: z.string().min(1).describe("Source code text containing comments to translate. The tool only rewrites comments detected in this string."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code for translated comments. Defaults to es-ES when omitted."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+      },
+      annotations: {
+        title: "Translate code comments",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
-    async (params) => {
-      return handleTranslateCodeComment(params as TranslateCodeCommentParams, registry, rateLimiter);
-    }
+    async (params) => handleTranslateCodeComment(params as TranslateCodeCommentParams, registry, rateLimiter)
   );
 
-  // Register translate_readme tool
-  server.tool(
+  registerScoredTool(
+    server,
     "translate_readme",
-    "Translate a README markdown file preserving structure",
     {
-      filePath: z.string().describe("Path to the README markdown file"),
-      dialect: dialectSchema.optional().describe("Spanish dialect code (e.g., es-ES, es-MX, es-AR)"),
-      provider: providerNameSchema.optional().describe("Translation provider name (llm, deepl, libre, mymemory)"),
-      formal: z.boolean().optional().describe("Use formal tone"),
-      informal: z.boolean().optional().describe("Use informal tone"),
+      title: "Translate README Markdown",
+      description:
+        "Read a README Markdown file, translate translatable prose into a Spanish dialect, and return translated Markdown with code blocks and structure preserved. Reads the file only; it does not overwrite the README.",
+      inputSchema: {
+        filePath: z.string().min(1).describe("Path to the README Markdown file to read and translate."),
+        dialect: dialectSchema.optional().describe("Target Spanish dialect code. Defaults to es-ES when omitted."),
+        provider: providerNameSchema.optional().describe("Translation provider to use. Omit for automatic provider selection; valid values include llm, deepl, libre, and mymemory."),
+        formal: z.boolean().optional().describe("Request formal Spanish register. Do not set both formal and informal."),
+        informal: z.boolean().optional().describe("Request informal Spanish register. Do not set both informal and formal."),
+      },
+      annotations: {
+        title: "Translate README Markdown",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
-    async (params) => {
-      return handleTranslateReadme(params as TranslateReadmeParams, registry, rateLimiter);
-    }
+    async (params) => handleTranslateReadme(params as TranslateReadmeParams, registry, rateLimiter)
   );
 
-  // Register search_glossary tool
-  server.tool(
+  registerScoredTool(
+    server,
     "search_glossary",
-    "Search the built-in glossary for technical and business terms",
     {
-      query: z.string().describe("Search query for glossary terms"),
+      title: "Search translation glossary",
+      description:
+        "Search DialectOS's built-in technical and business glossary for matching source terms and localized Spanish equivalents. Returns matching glossary records and count; it does not call external services or modify glossary data.",
+      inputSchema: {
+        query: z.string().min(1).describe("Term, phrase, or keyword to search in the built-in glossary."),
+      },
+      annotations: {
+        title: "Search translation glossary",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
-    async (params) => {
-      return handleSearchGlossary(params as SearchGlossaryParams, registry, rateLimiter);
-    }
+    async (params) => handleSearchGlossary(params as SearchGlossaryParams, registry, rateLimiter)
   );
 
-  // Register research_regional_term tool
-  server.tool(
+  registerScoredTool(
+    server,
     "research_regional_term",
-    "Research a regional term as a source-backed proposal; does not mutate runtime translation data",
     {
-      concept: z.string().describe("Concept or phrase to research, e.g. orange juice"),
-      dialects: z.string().describe("Comma-separated dialect codes, e.g. es-PR,es-MX"),
-      semanticField: z.string().optional().describe("Semantic field, e.g. food-drink"),
+      title: "Research regional Spanish term",
+      description:
+        "Generate a source-backed proposal for how a concept is expressed across selected Spanish dialects. Returns candidate terms, confidence, and sources; it does not mutate runtime translation data.",
+      inputSchema: {
+        concept: z.string().min(1).describe("Concept or phrase to research, such as orange juice or mobile app onboarding."),
+        dialects: z.string().min(1).describe("Comma-separated Spanish dialect codes to research, such as es-PR,es-MX."),
+        semanticField: z.string().min(1).optional().describe("Optional domain or semantic field that narrows the research context, such as food-drink, legal, or software-ui."),
+      },
+      annotations: {
+        title: "Research regional Spanish term",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
-    async (params) => {
-      return handleResearchRegionalTerm(params as ResearchRegionalTermParams, registry, rateLimiter);
-    }
+    async (params) => handleResearchRegionalTerm(params as ResearchRegionalTermParams, registry, rateLimiter)
   );
 
-  // Register list_dialects tool
-  server.tool(
+  registerScoredTool(
+    server,
     "list_dialects",
-    "List all 25 Spanish dialects with metadata",
-    {},
-    async (params) => {
-      return handleListDialects(params as ListDialectsParams, registry, rateLimiter);
-    }
+    {
+      title: "List supported Spanish dialects",
+      description:
+        "Return all 25 Spanish dialect codes supported by DialectOS with names and short descriptions. This is a read-only catalog lookup and does not require a translation provider.",
+      inputSchema: {},
+      annotations: {
+        title: "List supported Spanish dialects",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (params) => handleListDialects(params as ListDialectsParams, registry, rateLimiter)
   );
 }


### PR DESCRIPTION
## Summary
- add a small MCP metadata registration helper
- enrich DialectOS MCP tool descriptions, parameter semantics, and annotations
- preserve the legacy FastMCP-style test registration path

## Verification
- pnpm -r build
- pnpm --filter @dialectos/mcp test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783138219&installation_id=130430723&pr_number=168&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F168&signature=bc35f5abb4809225255cb59d430ae8f88f17bba8ec2485a7438706d3209c1559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->