### PR TITLE
docs: fix public install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,38 @@ Spanish is not one language — it's **25 regional variants** with different voc
 
 ## 🚀 Quick Start
 
-> **Note:** DialectOS packages are not yet published to npm. Setup requires cloning the repo and building from source (~2–5 minutes first time).
+> **Install note:** DialectOS v0.3.0 is distributed through GitHub Release tarballs, not the npm registry. Use the released MCP/CLI tarballs for agent and command-line installs; clone the repo only for local development or the browser demo.
+
+### MCP setup
+
+Add the released MCP server to Claude Desktop, Cursor, or any MCP client:
+
+```json
+{
+  "mcpServers": {
+    "dialectos": {
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "https://github.com/KyaniteLabs/DialectOS/releases/download/v0.3.0/dialectos-mcp-0.3.0.tgz"
+      ],
+      "env": {
+        "LLM_API_URL": "https://your-llm-gateway/v1/chat/completions",
+        "LLM_MODEL": "your-dialect-capable-model",
+        "LLM_API_KEY": "your-key-if-required",
+        "LLM_API_FORMAT": "openai",
+        "ALLOWED_LOCALE_DIRS": "/path/to/locales"
+      }
+    }
+  }
+}
+```
+
+For local development from a source checkout, run `pnpm build` and point your MCP client at `packages/mcp/dist/index.js`.
 
 ### Full-app browser demo
+
+The browser demo requires a source checkout.
 
 The browser demo is no longer a fake/static rule replacer. It calls a local
 DialectOS backend, and that backend calls the configured provider stack.
@@ -115,29 +144,6 @@ Open `http://127.0.0.1:8080`.
 
 For the beginner container walkthrough, see
 [`docs/full-app-demo.md`](docs/full-app-demo.md).
-
-### Local MCP setup
-
-After `pnpm build`, add to your Claude Desktop, Cursor, or any MCP client:
-
-```json
-{
-  "mcpServers": {
-    "dialectos": {
-      "command": "node",
-      "args": ["packages/mcp/dist/index.js"],
-      "comment": "Local development setup — see README for clone and build instructions.",
-      "env": {
-        "LLM_API_URL": "https://your-llm-gateway/v1/chat/completions",
-        "LLM_MODEL": "your-dialect-capable-model",
-        "LLM_API_KEY": "your-key-if-required",
-        "LLM_API_FORMAT": "openai",
-        "ALLOWED_LOCALE_DIRS": "/path/to/locales"
-      }
-    }
-  }
-}
-```
 
 ### Recommended certified models
 

--- a/docs/__tests__/public-claims.test.mjs
+++ b/docs/__tests__/public-claims.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 
 const files = ['README.md', 'SECURITY.md', '.llm', 'ROADMAP.md'];
 const contents = Object.fromEntries(files.map((file) => [file, readFileSync(file, 'utf8')]));
+const cliReadme = readFileSync('packages/cli/README.md', 'utf8');
 
 function walk(dir) {
   return readdirSync(dir).flatMap((name) => {
@@ -39,6 +40,22 @@ test('public docs do not claim unpublished npm packages', () => {
 test('public docs may reference the released v0.3.0 GitHub Action tag', () => {
   const text = readFileSync('docs/github-action.md', 'utf8');
   assert.match(text, /KyaniteLabs\/DialectOS\/action@v0\.3\.0/iu);
+});
+
+test('public install docs point users to release tarballs before source checkout', () => {
+  const rootLlms = readFileSync('llms.txt', 'utf8');
+  const docsLlms = readFileSync('docs/llms.txt', 'utf8');
+
+  assert.doesNotMatch(contents['README.md'], /Setup requires cloning the repo and building from source/iu);
+  assert.match(contents['README.md'], /GitHub Release tarballs/iu);
+  assert.match(contents['README.md'], /dialectos-mcp-0\.3\.0\.tgz/iu);
+  assert.match(rootLlms, /GitHub Release tarballs/iu);
+  assert.match(docsLlms, /GitHub Release tarballs/iu);
+});
+
+test('CLI README command examples use the installed dialectos binary', () => {
+  assert.doesNotMatch(cliReadme, /^node packages\/cli\/dist\/index\.js/mu);
+  assert.match(cliReadme, /\bdialectos translate "Hello world" --dialect es-MX\b/u);
 });
 
 test('public docs do not contain stale BSL license claims', () => {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,6 +4,8 @@
 
 DialectOS helps AI agents and localization teams translate, validate, and certify Spanish content across regional dialects while preserving structure, glossary terms, placeholders, and locale files.
 
+Distribution: v0.3.0 MCP and CLI installs use GitHub Release tarballs; npm registry packages are not published yet.
+
 ## Use cases
 - Spanish dialect translation for AI agents
 - i18n locale validation

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,8 @@
 
 DialectOS helps AI agents and localization teams translate, validate, and certify Spanish content across regional dialects while preserving structure, glossary terms, placeholders, and locale files.
 
+Distribution: v0.3.0 MCP and CLI installs use GitHub Release tarballs; npm registry packages are not published yet.
+
 ## Use cases
 - Spanish dialect translation for AI agents
 - i18n locale validation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,64 +17,66 @@ pnpm build
 
 ## Commands
 
+The examples below use the installed `dialectos` binary. For a source checkout, run `pnpm build` first and replace `dialectos` with `node packages/cli/dist/index.js`.
+
 ### Translation
 
 ```bash
 # Translate text to a specific dialect
-node packages/cli/dist/index.js translate "Hello world" --dialect es-MX
+dialectos translate "Hello world" --dialect es-MX
 
 # Translate with formal / informal register
-node packages/cli/dist/index.js translate "Hello world" --dialect es-MX --formal
-node packages/cli/dist/index.js translate "Hello world" --dialect es-AR --informal
+dialectos translate "Hello world" --dialect es-MX --formal
+dialectos translate "Hello world" --dialect es-AR --informal
 
 # Translate a README preserving structure
-node packages/cli/dist/index.js translate-readme README.md --dialect es-AR --output README.ar.md
+dialectos translate-readme README.md --dialect es-AR --output README.ar.md
 
 # Translate API documentation
-node packages/cli/dist/index.js translate-api-docs api.md --dialect es-CO --output api.co.md
+dialectos translate-api-docs api.md --dialect es-CO --output api.co.md
 ```
 
 ### i18n
 
 ```bash
 # Detect missing keys between locale files
-node packages/cli/dist/index.js i18n detect-missing ./locales/en.json ./locales/es.json
+dialectos i18n detect-missing ./locales/en.json ./locales/es.json
 
 # Translate missing keys
-node packages/cli/dist/index.js i18n translate-keys ./locales/en.json ./locales/es.json --dialect es-MX
+dialectos i18n translate-keys ./locales/en.json ./locales/es.json --dialect es-MX
 
 # Batch translate to multiple dialects
-node packages/cli/dist/index.js i18n batch-translate ./locales --base en --targets es-MX,es-AR,es-CO
+dialectos i18n batch-translate ./locales --base en --targets es-MX,es-AR,es-CO
 
 # Create dialect-specific variant from es-ES base
-node packages/cli/dist/index.js i18n manage-variants ./locales/es-ES.json --variant es-MX
+dialectos i18n manage-variants ./locales/es-ES.json --variant es-MX
 
 # Check formality consistency
-node packages/cli/dist/index.js i18n check-formality ./locales/es.json --register formal
+dialectos i18n check-formality ./locales/es.json --register formal
 
 # Apply gender-neutral language
-node packages/cli/dist/index.js i18n apply-gender-neutral ./locales/es.json --strategy latine
+dialectos i18n apply-gender-neutral ./locales/es.json --strategy latine
 ```
 
 ### Dialects
 
 ```bash
 # List all supported dialects
-node packages/cli/dist/index.js dialects list
+dialectos dialects list
 
 # Detect dialect from text
-node packages/cli/dist/index.js dialects detect "Che boludo, qué onda?"
-node packages/cli/dist/index.js dialects detect "Estimado señor, le saludo cordialmente" --register formal
+dialectos dialects detect "Che boludo, qué onda?"
+dialectos dialects detect "Estimado señor, le saludo cordialmente" --register formal
 ```
 
 ### Glossary
 
 ```bash
 # Search glossary terms
-node packages/cli/dist/index.js glossary search "API"
+dialectos glossary search "API"
 
 # Get detailed term info
-node packages/cli/dist/index.js glossary get --category programming
+dialectos glossary get --category programming
 ```
 
 ## Policy Profiles
@@ -83,11 +85,11 @@ Choose a preset for safety/reliability tradeoffs:
 
 ```bash
 # Strict: fail on any error, enforce all validations
-node packages/cli/dist/index.js translate-readme README.md --policy strict --dialect es-ES
+dialectos translate-readme README.md --policy strict --dialect es-ES
 
 # Balanced (default): allow partial output, warn on issues
-node packages/cli/dist/index.js translate-readme README.md --policy balanced --dialect es-MX
+dialectos translate-readme README.md --policy balanced --dialect es-MX
 
 # Permissive: maximize throughput, skip validations
-node packages/cli/dist/index.js translate-readme README.md --policy permissive --dialect es-AR
+dialectos translate-readme README.md --policy permissive --dialect es-AR
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ pnpm build
 
 ## Commands
 
-The examples below use the installed `dialectos` binary. For a source checkout, run `pnpm build` first and replace `dialectos` with `node packages/cli/dist/index.js`.
+The examples below use the installed `dialectos` binary. For a source checkout, run `pnpm build` first and replace `dialectos` with `node packages/cli/dist/cli.js`.
 
 ### Translation
 


### PR DESCRIPTION
## Summary
- make the top-level Quick Start lead with the released MCP tarball config instead of source-only setup
- mark the browser demo as a source-checkout workflow
- update CLI package examples to use the installed `dialectos` binary
- add regression coverage so public docs keep pointing users to release tarballs first

## Verification
- `node --test docs/__tests__/public-claims.test.mjs`
- `node --test docs/__tests__/*.test.mjs scripts/__tests__/*.test.mjs`
- verified GitHub release `v0.3.0` includes `dialectos-mcp-0.3.0.tgz` and `dialectos-cli-0.3.0.tgz`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/DialectOS/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783191679&installation_id=130430723&pr_number=169&repository=KyaniteLabs%2FDialectOS&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2FDialectOS%2Fpull%2F169&signature=bff627494c4bb62d7fe8d1f256c07842b19863fa95b4f8a56c3ed632739039aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->